### PR TITLE
fix bug: advencedFormat plugin

### DIFF
--- a/src/plugin/advancedFormat.js
+++ b/src/plugin/advancedFormat.js
@@ -4,7 +4,7 @@ export default (o, c, d) => { // locale needed later
   const proto = c.prototype
   const oldFormat = proto.format
   // eslint-disable-next-line no-nested-ternary
-  d.en.ordinal = number => `${number}[${number === 1 ? 'st' : number === 2 ? 'nd' : number === 3 ? 'rd' : 'th'}]`
+  d.en.ordinal = number => `${number}[${number % 10 === 1 ? 'st' : number % 10 === 2 ? 'nd' : number % 10 === 3 ? 'rd' : 'th'}]`
   // extend en locale here
   proto.format = function (formatStr, localeObject) {
     const locale = localeObject || this.$locale()

--- a/src/plugin/advancedFormat.js
+++ b/src/plugin/advancedFormat.js
@@ -4,7 +4,13 @@ export default (o, c, d) => { // locale needed later
   const proto = c.prototype
   const oldFormat = proto.format
   // eslint-disable-next-line no-nested-ternary
-  d.en.ordinal = number => `${number}[${number % 10 === 1 ? 'st' : number % 10 === 2 ? 'nd' : number % 10 === 3 ? 'rd' : 'th'}]`
+  d.en.ordinal = number => {
+    let suffix = 'th';
+    if (![11, 12].includes(number)) {
+      suffix = ['st', 'nd', 'rd'][number % 10 - 1] || suffix;
+    }
+    return `${number}[${suffix}]`;
+  }
   // extend en locale here
   proto.format = function (formatStr, localeObject) {
     const locale = localeObject || this.$locale()

--- a/src/plugin/advancedFormat.js
+++ b/src/plugin/advancedFormat.js
@@ -4,12 +4,12 @@ export default (o, c, d) => { // locale needed later
   const proto = c.prototype
   const oldFormat = proto.format
   // eslint-disable-next-line no-nested-ternary
-  d.en.ordinal = number => {
-    let suffix = 'th';
+  d.en.ordinal = (number) => {
+    let suffix = 'th'
     if (![11, 12].includes(number)) {
-      suffix = ['st', 'nd', 'rd'][number % 10 - 1] || suffix;
+      suffix = ['st', 'nd', 'rd'][(number % 10) - 1] || suffix
     }
-    return `${number}[${suffix}]`;
+    return `${number}[${suffix}]`
   }
   // extend en locale here
   proto.format = function (formatStr, localeObject) {

--- a/test/plugin/advancedFormat.test.js
+++ b/test/plugin/advancedFormat.test.js
@@ -36,6 +36,10 @@ it('Format Day of Month Do 1 - 31', () => {
   expect(dayjs(d).format('Do')).toBe(moment(d).format('Do'))
   d = '2018-05-04 00:00:00.000'
   expect(dayjs(d).format('Do')).toBe(moment(d).format('Do'))
+  d = '2018-05-11'
+  expect(dayjs(d).format('Do')).toBe(moment(d).format('Do'))
+  d = '2018-05-22'
+  expect(dayjs(d).format('Do')).toBe(moment(d).format('Do'))
 })
 
 it('Format Hour k kk 24-hour 1 - 24', () => {


### PR DESCRIPTION
**When I run `npm run test`**：
![image](https://user-images.githubusercontent.com/15937065/40282683-a565958c-5ca5-11e8-9ca4-182ff04623c3.png)


The two letters of  an ordinal number after the number are usually **the last two letters in the word denoting that number**. So it's a bug, and I fixed it.

After fixed:
![image](https://user-images.githubusercontent.com/15937065/40282741-4b3a9962-5ca6-11e8-8015-893c0440ba52.png)


