### PR TITLE
replace gzip-size with size-limit

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,15 +7,19 @@
   "scripts": {
     "test": "jest",
     "lint": "./node_modules/.bin/eslint src/* test/* build/*",
-    "build": "BABEL_ENV=build node build",
+    "build": "BABEL_ENV=build node build && npm run size",
     "sauce": "npx karma start karma.sauce.conf.js",
     "test:sauce": "npm run sauce -- 0 && npm run sauce -- 1 && npm run sauce -- 2  && npm run sauce -- 3",
-    "gzip-size": "gzip-size dayjs.min.js",
+    "size": "size-limit",
     "postpublish": "npm run test:sauce"
   },
   "pre-commit": [
     "lint"
   ],
+  "size-limit": [{
+    "limit": "2.5 KB",
+    "path": "dayjs.min.js"
+  }],
   "jest": {
     "roots": [
       "test"
@@ -60,7 +64,6 @@
     "eslint-config-airbnb-base": "^12.1.0",
     "eslint-plugin-import": "^2.10.0",
     "eslint-plugin-jest": "^21.15.0",
-    "gzip-size-cli": "^2.1.0",
     "jasmine-core": "^2.99.1",
     "jest": "^22.4.3",
     "karma": "^2.0.2",
@@ -72,6 +75,7 @@
     "rollup": "^0.57.1",
     "rollup-plugin-babel": "^4.0.0-beta.4",
     "rollup-plugin-uglify": "^3.0.0",
+    "size-limit": "^0.18.0",
     "typescript": "^2.8.3"
   }
 }


### PR DESCRIPTION
[size-limit](https://github.com/ai/size-limit) work better with ci than `gzip-size`, and perfect for tiny module to control package size.