### PR TITLE
fixed `toObject` return type

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -70,7 +70,7 @@ declare namespace dayjs {
   
     toISOString(): string
   
-    toObject(): Object
+    toObject(): DayjsObject
   
     toString(): string
   


### PR DESCRIPTION
Just noticed that `toObject` return type was too generic