### PR TITLE
fix 'locale' method name in index.d.ts typings file

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -89,5 +89,5 @@ declare namespace dayjs {
 
   export function extend(plugin: PluginFunc, option?: ConfigType): Dayjs
 
-  export function local(arg1: any, arg2?: any): void
+  export function locale(arg1: any, arg2?: any): void
 }


### PR DESCRIPTION
There is an error in the typings file with the 'locale' method of the namespace 'dayjs'
This pull request solves the problem of the name