### PR TITLE
japanese relative times

### DIFF
--- a/src/locale/ja.js
+++ b/src/locale/ja.js
@@ -4,7 +4,22 @@ const locale = {
   name: 'ja',
   weekdays: '日曜日_月曜日_火曜日_水曜日_木曜日_金曜日_土曜日'.split('_'),
   months: '1月_2月_3月_4月_5月_6月_7月_8月_9月_10月_11月_12月'.split('_'),
-  ordinal: n => `${n}日`
+  ordinal: n => `${n}日`,
+  relativeTime: {
+    future: '%s後',
+    past: '%s前',
+    s: '数秒',
+    m: '1分',
+    mm: '%d分',
+    h: '1時間',
+    hh: '%d時間',
+    d: '1日',
+    dd: '%d日',
+    M: '1ヶ月',
+    MM: '%dヶ月',
+    y: '1年',
+    yy: '%d年'
+  }
 }
 
 dayjs.locale(locale, null, true)


### PR DESCRIPTION
Added japanese relative times.

```javascript
relativeTime: {
  future: '%s後',
  past: '%s前',
  s: '数秒',
  m: '1分',
  mm: '%d分',
  h: '1時間',
  hh: '%d時間',
  d: '1日',
  dd: '%d日',
  M: '1ヶ月',
  MM: '%dヶ月',
  y: '1年',
  yy: '%d年'
}
```