### PR TITLE
Modify the isBetween api description in zh-cn/API-reference.md、Plugin.md

### DIFF
--- a/docs/zh-cn/API-reference.md
+++ b/docs/zh-cn/API-reference.md
@@ -375,6 +375,6 @@ dayjs.isDayjs(new Date()); // false
 
 ### 是否之间
 
-`.isBetween` 返回一个时间是否介于两个时间之间
+`.isBetween` 返回一个日期是否介于两个日期之间
 
 plugin [`IsBetween`](./Plugin.md#isbetween)

--- a/docs/zh-cn/Plugin.md
+++ b/docs/zh-cn/Plugin.md
@@ -156,7 +156,7 @@ dayjs('06/27/2018').week() // 26
 ```
 
 ### IsBetween
- - IsBetween 增加了 `.isBetween()` API 返回一个 `boolean` 来展示一个时间是否介于两个时间之间.
+ - IsBetween 增加了 `.isBetween()` API 返回一个 `boolean` 来展示一个日期是否介于两个日期之间.
 
 ```javascript
 import isBetween from 'dayjs/plugin/isBetween'


### PR DESCRIPTION
here is the .isbetween api [example code ](https://github.com/iamkun/dayjs/blob/master/docs/zh-cn/Plugin.md#isbetween) in the doc
```js
import isBetween from 'dayjs/plugin/isBetween'
dayjs.extend(isBetween)
dayjs('2010-10-20').isBetween('2010-10-19', dayjs('2010-10-25')); // true
```
.isBetweens API seems that it will  returns a boolean indicating if a **date** is between **two other dates**.
but in the [zh-cn/API-reference.md](zh-cn/API-reference.md)  and[ zn-ch/Plugin.md](https://github.com/iamkun/dayjs/blob/master/docs/zh-cn/Plugin.md#isbetween) both description say 一个**时间**是否介于**两个时间**之间.
The example code above `isBetween('2010-10-19', dayjs('2010-10-25'))` is putting **date format** as a parameter in stead of **time format**.
So people may get a little confused that this api want to check either time or date.
In my suggestion that  **time** is relate to **时间** and **date** is relate to **日期** so i modify the description for the .isBetween.