### PR TITLE
Introduce an UTC mode simpler than #168

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -93,6 +93,8 @@ declare namespace dayjs {
     utcOffset(): number
   }
 
+  export function utc(config?: ConfigType, option?: OptionType): Dayjs
+
   export type PluginFunc = (option: ConfigType, d1: Dayjs, d2: Dayjs) => void
 
   export function extend(plugin: PluginFunc, option?: ConfigType): Dayjs

--- a/index.d.ts
+++ b/index.d.ts
@@ -5,7 +5,7 @@ declare function dayjs (config?: dayjs.ConfigType, option?: dayjs.OptionType): d
 declare namespace dayjs {
   export type ConfigType = string | number | Date | Dayjs
 
-  export type OptionType = { locale: string }
+  export type OptionType = { locale: string, utc: boolean }
 
   export type UnitType = 'millisecond' | 'second' | 'minute' | 'hour' | 'day' | 'week' | 'month' | 'quarter' | 'year' | 'date'
   
@@ -83,6 +83,14 @@ declare namespace dayjs {
     isLeapYear(): boolean
 
     locale(arg1: any, arg2?: any): Dayjs
+
+    utc(): Dayjs
+
+    local(): Dayjs
+
+    isUTC(): boolean
+
+    utcOffset(): number
   }
 
   export type PluginFunc = (option: ConfigType, d1: Dayjs, d2: Dayjs) => void

--- a/src/index.js
+++ b/src/index.js
@@ -29,7 +29,11 @@ const parseLocale = (preset, object, isLocal) => {
 
 const dayjs = (date, c) => {
   if (isDayjs(date)) {
-    return date.clone()
+    if (c) {
+      date = date.toDate()
+    } else {
+      return date.clone()
+    }
   }
   const cfg = c || {}
   cfg.date = date

--- a/src/index.js
+++ b/src/index.js
@@ -501,6 +501,11 @@ class Dayjs {
   }
 }
 
+dayjs.utc = (date, c) => {
+  const cfg = { ...c, utc: true }
+  return dayjs(date, cfg)
+}
+
 dayjs.extend = (plugin, option) => {
   plugin(option, Dayjs, dayjs)
   return dayjs

--- a/test/display.test.js
+++ b/test/display.test.js
@@ -114,6 +114,11 @@ it('Format Escaping characters', () => {
   expect(dayjs().format(string)).toBe(moment().format(string))
 })
 
+it('Formats an UTC instance to UTC time zone', () => {
+  const instance = dayjs('2018-09-06T19:34:28Z', { utc: true })
+  expect(instance.format()).toEqual('2018-09-06T19:34:28+00:00')
+})
+
 describe('Difference', () => {
   it('empty -> default milliseconds', () => {
     const dateString = '20110101'

--- a/test/get-set.test.js
+++ b/test/get-set.test.js
@@ -42,6 +42,38 @@ it('Millisecond', () => {
   expect(dayjs().millisecond()).toBe(moment().millisecond())
 })
 
+it('UTC Year', () => {
+  expect(dayjs().utc().year()).toBe(moment().utc().year())
+})
+
+it('UTC Month', () => {
+  expect(dayjs().utc().month()).toBe(moment().utc().month())
+})
+
+it('UTC Day of Week', () => {
+  expect(dayjs().utc().day()).toBe(moment().utc().day())
+})
+
+it('UTC Date', () => {
+  expect(dayjs().utc().date()).toBe(moment().utc().date())
+})
+
+it('UTC Hour', () => {
+  expect(dayjs().utc().hour()).toBe(moment().utc().hour())
+})
+
+it('UTC Minute', () => {
+  expect(dayjs().utc().minute()).toBe(moment().utc().minute())
+})
+
+it('UTC Second', () => {
+  expect(dayjs().utc().second()).toBe(moment().utc().second())
+})
+
+it('UTC Millisecond', () => {
+  expect(dayjs().utc().millisecond()).toBe(moment().utc().millisecond())
+})
+
 it('Set Day', () => {
   expect(dayjs().set('date', 30).valueOf()).toBe(moment().set('date', 30).valueOf())
 })
@@ -72,6 +104,38 @@ it('Set Second', () => {
 
 it('Set Millisecond', () => {
   expect(dayjs().set('millisecond', 999).valueOf()).toBe(moment().set('millisecond', 999).valueOf())
+})
+
+it('Set UTC Day', () => {
+  expect(dayjs().utc().set('date', 30).valueOf()).toBe(moment().utc().set('date', 30).valueOf())
+})
+
+it('Set UTC Day of Week', () => {
+  expect(dayjs().utc().set('day', 0).valueOf()).toBe(moment().utc().set('day', 0).valueOf())
+})
+
+it('Set UTC Month', () => {
+  expect(dayjs().utc().set('month', 11).valueOf()).toBe(moment().utc().set('month', 11).valueOf())
+})
+
+it('Set UTC Year', () => {
+  expect(dayjs().utc().set('year', 2008).valueOf()).toBe(moment().utc().set('year', 2008).valueOf())
+})
+
+it('Set UTC Hour', () => {
+  expect(dayjs().utc().set('hour', 6).valueOf()).toBe(moment().utc().set('hour', 6).valueOf())
+})
+
+it('Set UTC Minute', () => {
+  expect(dayjs().utc().set('minute', 59).valueOf()).toBe(moment().utc().set('minute', 59).valueOf())
+})
+
+it('Set UTC Second', () => {
+  expect(dayjs().utc().set('second', 59).valueOf()).toBe(moment().utc().set('second', 59).valueOf())
+})
+
+it('Set UTC Millisecond', () => {
+  expect(dayjs().utc().set('millisecond', 999).valueOf()).toBe(moment().utc().set('millisecond', 999).valueOf())
 })
 
 it('Set Unknown String', () => {

--- a/test/index.d.test.ts
+++ b/test/index.d.test.ts
@@ -71,3 +71,11 @@ dayjs().isSame(dayjs())
 dayjs().isAfter(dayjs())
 
 dayjs('2000-01-01').isLeapYear()
+
+dayjs().utc()
+
+dayjs().local()
+
+dayjs().isUTC()
+
+dayjs().utcOffset()

--- a/test/manipulate.test.js
+++ b/test/manipulate.test.js
@@ -20,6 +20,14 @@ describe('StartOf EndOf', () => {
     })
   })
 
+  it('StartOf EndOf Year ... in UTC mode', () => {
+    const testArr = ['year', 'month', 'day', 'date', 'week', 'hour', 'minute', 'second']
+    testArr.forEach((d) => {
+      expect(dayjs().utc().startOf(d).valueOf()).toBe(moment().utc().startOf(d).valueOf())
+      expect(dayjs().utc().endOf(d).valueOf()).toBe(moment().utc().endOf(d).valueOf())
+    })
+  })
+
   it('StartOf EndOf Other -> no change', () => {
     expect(dayjs().startOf('otherString').valueOf()).toBe(moment().startOf('otherString').valueOf())
     expect(dayjs().endOf('otherString').valueOf()).toBe(moment().endOf('otherString').valueOf())

--- a/test/parse.test.js
+++ b/test/parse.test.js
@@ -65,6 +65,20 @@ it('Number 0', () => {
   expect(dayjs(0).valueOf()).toBe(moment(0).valueOf())
 })
 
+it('Recognizes the UTC flag in constructor options', () => {
+  const instance = dayjs('2018-09-06', { utc: true })
+  expect(instance.$u).toBeTruthy()
+  expect(instance.hour()).toEqual(0)
+  expect(instance.minute()).toEqual(0)
+})
+
+it('Does not apply the UTC mode by default', () => {
+  const instance = dayjs('2018-09-06 19:34:28.657', {})
+  expect(instance.$u).toBeFalsy()
+  expect(instance.hour()).toEqual(19)
+  expect(instance.minute()).toEqual(34)
+})
+
 it('Clone not affect each other', () => {
   const base = dayjs(20170101)
   const year = base.year()

--- a/test/parse.test.js
+++ b/test/parse.test.js
@@ -79,6 +79,22 @@ it('Does not apply the UTC mode by default', () => {
   expect(instance.minute()).toEqual(34)
 })
 
+it('Creates an UTC instance from another instance', () => {
+  const source = dayjs('2018-09-06')
+  const instance = dayjs(source, { utc: true })
+  expect(instance.$u).toBeTruthy()
+  expect(instance.hour()).toEqual(source.toDate().getUTCHours())
+  expect(instance.minute()).toEqual(source.toDate().getUTCMinutes())
+})
+
+it('Creating a new instance from another instance retains the UTC mode', () => {
+  const source = dayjs('2018-09-06', { utc: true })
+  const instance = dayjs(source)
+  expect(instance.$u).toBeTruthy()
+  expect(instance.hour()).toEqual(source.hour())
+  expect(instance.minute()).toEqual(source.minute())
+})
+
 it('Clone not affect each other', () => {
   const base = dayjs(20170101)
   const year = base.year()
@@ -92,4 +108,10 @@ it('Clone with same value', () => {
   const newBase = base.set('year', year + 1)
   const another = newBase.clone()
   expect(newBase.toString()).toBe(another.toString())
+})
+
+it('Clone retains the UTC mode', () => {
+  const instance = dayjs('2018-09-06', { utc: true })
+  const another = instance.clone()
+  expect(another.$u).toBeTruthy()
 })

--- a/test/utc/isUTC.test.js
+++ b/test/utc/isUTC.test.js
@@ -1,0 +1,20 @@
+import MockDate from 'mockdate'
+import dayjs from '../../src'
+
+beforeEach(() => {
+  MockDate.set(new Date())
+})
+
+afterEach(() => {
+  MockDate.reset()
+})
+
+it('Returns false by default', () => {
+  const instance = dayjs()
+  expect(instance.isUTC()).toBeFalsy()
+})
+
+it('Returns true for UTC instances', () => {
+  const instance = dayjs(undefined, { utc: true })
+  expect(instance.isUTC()).toBeTruthy()
+})

--- a/test/utc/local.test.js
+++ b/test/utc/local.test.js
@@ -1,0 +1,23 @@
+import MockDate from 'mockdate'
+import dayjs from '../../src'
+
+beforeEach(() => {
+  MockDate.set(new Date())
+})
+
+afterEach(() => {
+  MockDate.reset()
+})
+
+it('Returns a new instance', () => {
+  const instance = dayjs('2018-09-06T19:34:28.657Z')
+  const local = instance.local()
+  expect(local).not.toBe(instance)
+})
+
+it('Returns a local instance', () => {
+  const instance = dayjs('2018-09-06 19:34:28.657').local()
+  expect(instance.$u).toBeFalsy()
+  expect(instance.hour()).toEqual(19)
+  expect(instance.minute()).toEqual(34)
+})

--- a/test/utc/utc.test.js
+++ b/test/utc/utc.test.js
@@ -21,3 +21,10 @@ it('Returns an UTC instance', () => {
   expect(instance.hour()).toEqual(19)
   expect(instance.minute()).toEqual(34)
 })
+
+it('Static method creates an UTC instance', () => {
+  const instance = dayjs.utc('2018-09-06T19:34:28.657Z')
+  expect(instance.$u).toBeTruthy()
+  expect(instance.hour()).toEqual(19)
+  expect(instance.minute()).toEqual(34)
+})

--- a/test/utc/utc.test.js
+++ b/test/utc/utc.test.js
@@ -1,0 +1,23 @@
+import MockDate from 'mockdate'
+import dayjs from '../../src'
+
+beforeEach(() => {
+  MockDate.set(new Date())
+})
+
+afterEach(() => {
+  MockDate.reset()
+})
+
+it('Returns a new instance', () => {
+  const instance = dayjs('2018-09-06T19:34:28.657Z')
+  const utc = instance.utc()
+  expect(utc).not.toBe(instance)
+})
+
+it('Returns an UTC instance', () => {
+  const instance = dayjs('2018-09-06T19:34:28.657Z').utc()
+  expect(instance.$u).toBeTruthy()
+  expect(instance.hour()).toEqual(19)
+  expect(instance.minute()).toEqual(34)
+})

--- a/test/utc/utcOffset.test.js
+++ b/test/utc/utcOffset.test.js
@@ -1,0 +1,21 @@
+import MockDate from 'mockdate'
+import dayjs from '../../src'
+
+beforeEach(() => {
+  MockDate.set(new Date())
+})
+
+afterEach(() => {
+  MockDate.reset()
+})
+
+it('Returns the UTC offset for local instances', () => {
+  const instance = dayjs('2018-09-06T19:34:28.657Z')
+  const date = instance.toDate()
+  expect(instance.utcOffset()).toEqual(date.getTimezoneOffset())
+})
+
+it('Returns zero for UTC instances', () => {
+  const instance = dayjs(undefined, { utc: true })
+  expect(instance.utcOffset()).toEqual(0)
+})


### PR DESCRIPTION
The "UTC mode" means, that he constructor assumes the UTC date in the input string and the instance methods return and accept date parts (year, month etc.) in UTC.

## Additions

* Constructor accepts a boolean flag to enable the UTC mode: `{ utc: true }`.
* Method `utc()` returns a clone of the instance in the UTC mode.
* Method `local()` returns a clone of the instance in the non-UTC (local) mode.
* Method `isUTC()` checks, if the instance is in the UTC mode.
* Method `utcOffset()` returns the time zone offset to UTC consistently with `Date.prototype.getTimezoneOffset()`

##  Differences to the "normal" (local) dayjs mode

* Assume UTC as the time zone of the string passed to the constructor - for example, "2018-10-28" will be parsed as "2018-10-28T00:00:00Z". *But only if the time zone is omitted.* If you end the string tith a TZ offset - "2018-10-28T00:00:00+02:00", it will be retained and the whole date will be converted to UTC, when iniitalizing the datejs object.
* Methods returning the date parts like `year()`, `month()` etc. return UTC parts using `Date.propertotype.getUTC*()` methods.
* Methods manipulating the date - `set()`, `add()` etc. - work with the UTC values of the date parts, as the getters mentioned above.
* The `format()` method uses the UTC getters too and always formats the time zone as "+00:00".
* The `utcOffset()` method always returns zero.

If a Day.js instance is constructed without the time part, it will appear, as if the instance runs in a "date-only" mode, where no conversion from UTC to the local time takes place, like the `Date` instance would do it. It can be used for attributes, where the time does not make sense and only the date should be maintained. If only the date applies, it should not be affected by time zone changes.