### PR TITLE
Do not build and test with Node.js 6 any more

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@ cache:
 node_js:
   - '10'
   - '8'
-  - '6'
 install:
   - npm install -g codecov
   - npm install


### PR DESCRIPTION
Build scripts depend on JavaScript features available in Node.js 8 and newer.