### PR TITLE
Add benchmarks for basic scenarios

### DIFF
--- a/bench/add.bench.js
+++ b/bench/add.bench.js
@@ -1,13 +1,38 @@
 const { createSuite, runSuites } = require('./benchmark')
 
 const moment = require('moment')
+const datefnsAddSeconds = require('date-fns/add_seconds')
+const datefnsAddMinutes = require('date-fns/add_minutes')
+const datefnsAddHours = require('date-fns/add_hours')
+const datefnsAddDays = require('date-fns/add_days')
+const datefnsAddMonths = require('date-fns/add_months')
+const datefnsAddYears = require('date-fns/add_years')
 const dayjs = require('..')
 
 const momentDate = moment('2013-05-25')
 const dayjsDate = dayjs('2013-05-25')
 const date = new Date('2013-05-25')
 
-const units = ['second', 'minute', 'hour', 'date', 'month', 'year']
+const units = ['second', 'minute', 'hour', 'day', 'month', 'year']
+
+function addDateFnsUnit(input, value, unit) {
+  switch (unit) {
+    case 'second':
+      return datefnsAddSeconds(input, value)
+    case 'minute':
+      return datefnsAddMinutes(input, value)
+    case 'hour':
+      return datefnsAddHours(input, value)
+    case 'day':
+      return datefnsAddDays(input, value)
+    case 'month':
+      return datefnsAddMonths(input, value)
+    case 'year':
+      return datefnsAddYears(input, value)
+    default:
+      throw new Error(`Unrecognized unit: "${unit}".`)
+  }
+}
 
 function addDateUnit(input, value, unit) {
   const instance = new Date(input)
@@ -21,7 +46,7 @@ function addDateUnit(input, value, unit) {
     case 'hour':
       instance.setHours(instance.getHours() + value)
       break
-    case 'date':
+    case 'day':
       instance.setDate(instance.getDate() + value)
       break
     case 'month':
@@ -39,6 +64,7 @@ function addDateUnit(input, value, unit) {
 const suites = units.map((unit) => {
   const suite = createSuite(`add ${unit}`)
     .add('Moment.js', () => momentDate.add(8, unit))
+    .add('date-fns', () => addDateFnsUnit(date, 8, unit))
     .add('Day.js', () => dayjsDate.add(8, unit))
     .add('Date', () => addDateUnit(date, 8, unit))
   return suite

--- a/bench/add.bench.js
+++ b/bench/add.bench.js
@@ -1,0 +1,47 @@
+const { createSuite, runSuites } = require('./benchmark')
+
+const moment = require('moment')
+const dayjs = require('..')
+
+const momentDate = moment('2013-05-25')
+const dayjsDate = dayjs('2013-05-25')
+const date = new Date('2013-05-25')
+
+const units = ['second', 'minute', 'hour', 'date', 'month', 'year']
+
+function addDateUnit(input, value, unit) {
+  const instance = new Date(input)
+  switch (unit) {
+    case 'second':
+      instance.setSeconds(instance.getSeconds() + value)
+      break
+    case 'minute':
+      instance.setMinutes(instance.getMinutes() + value)
+      break
+    case 'hour':
+      instance.setHours(instance.getHours() + value)
+      break
+    case 'date':
+      instance.setDate(instance.getDate() + value)
+      break
+    case 'month':
+      instance.setMonth(instance.getMonth() + value)
+      break
+    case 'year':
+      instance.setFullYear(instance.getFullYear() + value)
+      break
+    default:
+      throw new Error(`Unrecognized unit: "${unit}".`)
+  }
+  return instance
+}
+
+const suites = units.map((unit) => {
+  const suite = createSuite(`add ${unit}`)
+    .add('Moment.js', () => momentDate.add(8, unit))
+    .add('Day.js', () => dayjsDate.add(8, unit))
+    .add('Date', () => addDateUnit(date, 8, unit))
+  return suite
+})
+
+runSuites(suites)

--- a/bench/benchmark.js
+++ b/bench/benchmark.js
@@ -1,0 +1,29 @@
+const { Suite } = require('benchmark')
+
+async function start() {
+  this.run({ async: true })
+  await this.promise
+}
+
+function createSuite(description) {
+  const suite = new Suite()
+  suite.start = start
+  let finish
+  suite.promise = new Promise(resolve => finish = resolve) // eslint-disable-line no-return-assign
+  return suite
+    .on('start', () => console.log(description)) // eslint-disable-line no-console
+    .on('cycle', ({ target }) => console.log(`  ${target}`)) // eslint-disable-line no-console
+    .on('complete', () => {
+      console.log(`The fastest one was ${suite.filter('fastest').map('name')}.`) // eslint-disable-line no-console
+      console.log() // eslint-disable-line no-console
+      finish()
+    })
+}
+
+async function runSuites(suites) {
+  for (let i = 0, { length } = suites; i < length; i += 1) {
+    await suites[i].start() // eslint-disable-line no-await-in-loop
+  }
+}
+
+module.exports = { createSuite, runSuites }

--- a/bench/clone.bench.js
+++ b/bench/clone.bench.js
@@ -1,0 +1,18 @@
+const { createSuite } = require('./benchmark')
+
+const moment = require('moment')
+const dayjs = require('..')
+
+const momentDate = moment('2013-05-25')
+const dayjsDate = dayjs('2013-05-25')
+const date = new Date('2013-05-25')
+
+function cloneDate(input) {
+  return new Date(input)
+}
+
+createSuite('clone')
+  .add('Moment.js', () => momentDate.clone())
+  .add('Day.js', () => dayjsDate.clone())
+  .add('Date', () => cloneDate(date))
+  .start()

--- a/bench/compare.bench.js
+++ b/bench/compare.bench.js
@@ -19,7 +19,7 @@ const scenarios = [
 
 const datefnsCompare = {
   isSame: datefnsIsSameSecond,
-  isafter: datefnsIsAfter,
+  isAfter: datefnsIsAfter,
   isBefore: datefnsIsBefore
 }
 

--- a/bench/compare.bench.js
+++ b/bench/compare.bench.js
@@ -1,6 +1,9 @@
 const { createSuite, runSuites } = require('./benchmark')
 
 const moment = require('moment')
+const datefnsIsBefore = require('date-fns/is_before')
+const datefnsIsAfter = require('date-fns/is_after')
+const datefnsIsSameSecond = require('date-fns/is_same_second')
 const dayjs = require('..')
 
 const momentDate = moment('2013-05-25')
@@ -13,6 +16,12 @@ const scenarios = [
   { input: '2013-05-25', label: 'the same' },
   { input: '2013-06-25', label: 'a newer' }
 ]
+
+const datefnsCompare = {
+  isSame: datefnsIsSameSecond,
+  isafter: datefnsIsAfter,
+  isBefore: datefnsIsBefore
+}
 
 const compareDate = {
   isSame(input) {
@@ -35,6 +44,7 @@ const suites = methods.reduce((result, method) => {
     const dateInput = new Date(input)
     const suite = createSuite(`${method} with ${label} date`)
       .add('Moment.js', () => momentDate[method](momentInput))
+      .add('date-fns', () => datefnsCompare[method](date, dateInput))
       .add('Day.js', () => dayjsDate[method](dayjsInput))
       .add('Date', () => compareDate[method](dateInput))
     return suite

--- a/bench/compare.bench.js
+++ b/bench/compare.bench.js
@@ -1,0 +1,45 @@
+const { createSuite, runSuites } = require('./benchmark')
+
+const moment = require('moment')
+const dayjs = require('..')
+
+const momentDate = moment('2013-05-25')
+const dayjsDate = dayjs('2013-05-25')
+const date = new Date('2013-05-25')
+
+const methods = ['isSame', 'isAfter', 'isBefore']
+const scenarios = [
+  { input: '2013-04-25', label: 'an older' },
+  { input: '2013-05-25', label: 'the same' },
+  { input: '2013-06-25', label: 'a newer' }
+]
+
+const compareDate = {
+  isSame(input) {
+    return date == input // eslint-disable-line eqeqeq
+  },
+
+  isAfter(input) {
+    return date < input
+  },
+
+  isBefore(input) {
+    return date > input
+  }
+}
+
+const suites = methods.reduce((result, method) => {
+  const subSuites = scenarios.map(({ input, label }) => {
+    const momentInput = moment(input)
+    const dayjsInput = dayjs(input)
+    const dateInput = new Date(input)
+    const suite = createSuite(`${method} with ${label} date`)
+      .add('Moment.js', () => momentDate[method](momentInput))
+      .add('Day.js', () => dayjsDate[method](dayjsInput))
+      .add('Date', () => compareDate[method](dateInput))
+    return suite
+  })
+  return result.concat(subSuites)
+}, [])
+
+runSuites(suites)

--- a/bench/diff.bench.js
+++ b/bench/diff.bench.js
@@ -1,0 +1,24 @@
+const { createSuite, runSuites } = require('./benchmark')
+
+const moment = require('moment')
+const dayjs = require('..')
+
+const momentDate = moment('2013-05-25')
+const dayjsDate = dayjs('2013-05-25')
+
+const scenarios = [
+  { input: '2013-04-25', label: 'an older' },
+  { input: '2013-05-25', label: 'the same' },
+  { input: '2013-06-25', label: 'a newer' }
+]
+
+const suites = scenarios.map(({ input, label }) => {
+  const momentInput = moment(input)
+  const dayjsInput = dayjs(input)
+  const suite = createSuite(`diff with ${label} date`)
+    .add('Moment.js', () => momentDate.diff(momentInput))
+    .add('Day.js', () => dayjsDate.diff(dayjsInput))
+  return suite
+})
+
+runSuites(suites)

--- a/bench/diff.bench.js
+++ b/bench/diff.bench.js
@@ -1,10 +1,12 @@
 const { createSuite, runSuites } = require('./benchmark')
 
 const moment = require('moment')
+const datefnsDiference = require('date-fns/difference_in_milliseconds')
 const dayjs = require('..')
 
 const momentDate = moment('2013-05-25')
 const dayjsDate = dayjs('2013-05-25')
+const date = new Date('2013-05-25')
 
 const scenarios = [
   { input: '2013-04-25', label: 'an older' },
@@ -15,8 +17,10 @@ const scenarios = [
 const suites = scenarios.map(({ input, label }) => {
   const momentInput = moment(input)
   const dayjsInput = dayjs(input)
+  const dateInput = new Date(input)
   const suite = createSuite(`diff with ${label} date`)
     .add('Moment.js', () => momentDate.diff(momentInput))
+    .add('date-fns', () => datefnsDiference(date, dateInput))
     .add('Day.js', () => dayjsDate.diff(dayjsInput))
   return suite
 })

--- a/bench/diff.bench.js
+++ b/bench/diff.bench.js
@@ -1,7 +1,7 @@
 const { createSuite, runSuites } = require('./benchmark')
 
 const moment = require('moment')
-const datefnsDiference = require('date-fns/difference_in_milliseconds')
+const datefnsDifferenceInMilliseconds = require('date-fns/difference_in_milliseconds')
 const dayjs = require('..')
 
 const momentDate = moment('2013-05-25')
@@ -20,7 +20,7 @@ const suites = scenarios.map(({ input, label }) => {
   const dateInput = new Date(input)
   const suite = createSuite(`diff with ${label} date`)
     .add('Moment.js', () => momentDate.diff(momentInput))
-    .add('date-fns', () => datefnsDiference(date, dateInput))
+    .add('date-fns', () => datefnsDifferenceInMilliseconds(date, dateInput))
     .add('Day.js', () => dayjsDate.diff(dayjsInput))
   return suite
 })

--- a/bench/endOf.bench.js
+++ b/bench/endOf.bench.js
@@ -1,0 +1,18 @@
+const { createSuite, runSuites } = require('./benchmark')
+
+const moment = require('moment')
+const dayjs = require('..')
+
+const momentDate = moment('2013-05-25')
+const dayjsDate = dayjs('2013-05-25')
+
+const units = ['second', 'minute', 'hour', 'date', 'day', 'week', 'month', 'year']
+
+const suites = units.map((unit) => {
+  const suite = createSuite(`endOf ${unit}`)
+  suite.add('Moment.js', () => momentDate.endOf(unit))
+  suite.add('Day.js', () => dayjsDate.endOf(unit))
+  return suite
+})
+
+runSuites(suites)

--- a/bench/endOf.bench.js
+++ b/bench/endOf.bench.js
@@ -1,16 +1,46 @@
 const { createSuite, runSuites } = require('./benchmark')
 
 const moment = require('moment')
+const datefnsEndOfSeconds = require('date-fns/end_of_second')
+const datefnsEndOfMinutes = require('date-fns/end_of_minute')
+const datefnsEndOfHours = require('date-fns/end_of_hour')
+const datefnsEndOfDays = require('date-fns/end_of_day')
+const datefnsEndOfWeek = require('date-fns/end_of_week')
+const datefnsEndOfMonths = require('date-fns/end_of_month')
+const datefnsEndOfYears = require('date-fns/end_of_year')
 const dayjs = require('..')
 
 const momentDate = moment('2013-05-25')
 const dayjsDate = dayjs('2013-05-25')
+const date = new Date('2013-05-25')
 
-const units = ['second', 'minute', 'hour', 'date', 'day', 'week', 'month', 'year']
+const units = ['second', 'minute', 'hour', 'day', 'week', 'month', 'year']
+
+function endOfDateFnsUnit(input, unit) {
+  switch (unit) {
+    case 'second':
+      return datefnsEndOfSeconds(input)
+    case 'minute':
+      return datefnsEndOfMinutes(input)
+    case 'hour':
+      return datefnsEndOfHours(input)
+    case 'day':
+      return datefnsEndOfDays(input)
+    case 'week':
+      return datefnsEndOfWeek(input)
+    case 'month':
+      return datefnsEndOfMonths(input)
+    case 'year':
+      return datefnsEndOfYears(input)
+    default:
+      throw new Error(`Unrecognized unit: "${unit}".`)
+  }
+}
 
 const suites = units.map((unit) => {
   const suite = createSuite(`endOf ${unit}`)
   suite.add('Moment.js', () => momentDate.endOf(unit))
+  suite.add('date-fns', () => endOfDateFnsUnit(date, unit))
   suite.add('Day.js', () => dayjsDate.endOf(unit))
   return suite
 })

--- a/bench/format.bench.js
+++ b/bench/format.bench.js
@@ -23,6 +23,6 @@ const customFormat = createSuite('use custom format')
   .add('Moment.js', () => momentDate.format(format))
   .add('date-fns', () => datefnsFormat(date, format))
   .add('Day.js', () => dayjsDate.format(format))
-  .add('Date', () => formatDate(input, format))
+  .add('Date', () => formatDate(date, format))
 
 runSuites([formatToISOString, customFormat])

--- a/bench/format.bench.js
+++ b/bench/format.bench.js
@@ -1,6 +1,7 @@
 const { createSuite, runSuites } = require('./benchmark')
 
 const moment = require('moment')
+const datefnsFormat = require('date-fns/format')
 const dayjs = require('..')
 
 const momentDate = moment('2018-09-15T12:58:07.123Z')
@@ -16,6 +17,7 @@ const formatToISOString = createSuite('format to ISO 8601')
 
 const customFormat = createSuite('use custom format')
   .add('Moment.js', () => momentDate.format(format))
+  .add('date-nfs', () => datefnsFormat(date, format))
   .add('Day.js', () => dayjsDate.format(format))
 
 runSuites([formatToISOString, customFormat])

--- a/bench/format.bench.js
+++ b/bench/format.bench.js
@@ -1,0 +1,21 @@
+const { createSuite, runSuites } = require('./benchmark')
+
+const moment = require('moment')
+const dayjs = require('..')
+
+const momentDate = moment('2018-09-15T12:58:07.123Z')
+const dayjsDate = dayjs('2018-09-15T12:58:07.123Z')
+const date = new Date('2018-09-15T12:58:07.123Z')
+
+const format = 'D.M.YYYY h:mm:ss.SSS A Z'
+
+const formatToISOString = createSuite('format to ISO 8601')
+  .add('Moment.js', () => momentDate.toISOString())
+  .add('Day.js', () => dayjsDate.toISOString())
+  .add('Date', () => date.toISOString())
+
+const customFormat = createSuite('use custom format')
+  .add('Moment.js', () => momentDate.format(format))
+  .add('Day.js', () => dayjsDate.format(format))
+
+runSuites([formatToISOString, customFormat])

--- a/bench/format.bench.js
+++ b/bench/format.bench.js
@@ -15,9 +15,14 @@ const formatToISOString = createSuite('format to ISO 8601')
   .add('Day.js', () => dayjsDate.toISOString())
   .add('Date', () => date.toISOString())
 
+function formatDate(input) {
+  return input.toLocaleString()
+}
+
 const customFormat = createSuite('use custom format')
   .add('Moment.js', () => momentDate.format(format))
-  .add('date-nfs', () => datefnsFormat(date, format))
+  .add('date-fns', () => datefnsFormat(date, format))
   .add('Day.js', () => dayjsDate.format(format))
+  .add('Date', () => formatDate(input, format))
 
 runSuites([formatToISOString, customFormat])

--- a/bench/index.js
+++ b/bench/index.js
@@ -1,0 +1,41 @@
+const { exec } = require('child_process')
+const { promisify } = require('util')
+let { readdir } = require('fs')
+
+const { stdout, stderr } = process
+readdir = promisify(readdir)
+
+async function listBenchmarks() {
+  const benchmarks = await readdir(__dirname)
+  return benchmarks.filter(suite => suite.lastIndexOf('.bench.js') > 0)
+}
+
+function runBenchmark(benchmark) {
+  return new Promise((resolve, reject) => {
+    const child = exec(`node "${benchmark}"`, {
+      shell: true,
+      cwd: __dirname
+    })
+    child.stdout.on('data', data => stdout.write(data))
+    child.stderr.on('data', data => stderr.write(data))
+    child.on('close', (code) => {
+      if (code) {
+        reject()
+      } else {
+        resolve()
+      }
+    })
+  })
+}
+
+(async function () {
+  try {
+    const suites = await listBenchmarks()
+    for (let i = 0, { length } = suites; i < length; i += 1) {
+      await runBenchmark(suites[i]) // eslint-disable-line no-await-in-loop
+    }
+  } catch (error) {
+    console.error(error) // eslint-disable-line no-console
+    process.exitCode = 1
+  }
+}())

--- a/bench/parse.bench.js
+++ b/bench/parse.bench.js
@@ -1,0 +1,23 @@
+const { createSuite, runSuites } = require('./benchmark')
+
+const moment = require('moment')
+const dayjs = require('..')
+
+const scenarios = [
+  { input: new Date(), label: 'Date' },
+  { input: new Date().valueOf(), label: 'timestamp' },
+  { input: '2018-09-15T12:58:07.123Z', label: 'string in ISO 8601' },
+  { input: '2018-09-15 14:58:07.123', label: 'string in the local time zone' }
+]
+
+function parseDate(input) {
+  return new Date(input)
+}
+
+const suites = scenarios.map(({ input, label }) =>
+  createSuite(`create from ${label}`)
+    .add('Moment.js', () => moment(input))
+    .add('Day.js', () => dayjs(input))
+    .add('Date', () => parseDate(input)))
+
+runSuites(suites)

--- a/bench/parse.bench.js
+++ b/bench/parse.bench.js
@@ -1,6 +1,7 @@
 const { createSuite, runSuites } = require('./benchmark')
 
 const moment = require('moment')
+const datefnsParse = require('date-fns/parse')
 const dayjs = require('..')
 
 const scenarios = [
@@ -17,6 +18,7 @@ function parseDate(input) {
 const suites = scenarios.map(({ input, label }) =>
   createSuite(`create from ${label}`)
     .add('Moment.js', () => moment(input))
+    .add('date-fns', () => datefnsParse(input))
     .add('Day.js', () => dayjs(input))
     .add('Date', () => parseDate(input)))
 

--- a/bench/startOf.bench.js
+++ b/bench/startOf.bench.js
@@ -1,16 +1,46 @@
 const { createSuite, runSuites } = require('./benchmark')
 
 const moment = require('moment')
+const datefnsStartOfSeconds = require('date-fns/start_of_second')
+const datefnsStartOfMinutes = require('date-fns/start_of_minute')
+const datefnsStartOfHours = require('date-fns/start_of_hour')
+const datefnsStartOfDays = require('date-fns/start_of_day')
+const datefnsStartOfWeek = require('date-fns/start_of_week')
+const datefnsStartOfMonths = require('date-fns/start_of_month')
+const datefnsStartOfYears = require('date-fns/start_of_year')
 const dayjs = require('..')
 
 const momentDate = moment('2013-05-25')
 const dayjsDate = dayjs('2013-05-25')
+const date = new Date('2013-05-25')
 
-const units = ['second', 'minute', 'hour', 'date', 'day', 'week', 'month', 'year']
+const units = ['second', 'minute', 'hour', 'day', 'week', 'month', 'year']
+
+function startOfDateFnsUnit(input, unit) {
+  switch (unit) {
+    case 'second':
+      return datefnsStartOfSeconds(input)
+    case 'minute':
+      return datefnsStartOfMinutes(input)
+    case 'hour':
+      return datefnsStartOfHours(input)
+    case 'day':
+      return datefnsStartOfDays(input)
+    case 'week':
+      return datefnsStartOfWeek(input)
+    case 'month':
+      return datefnsStartOfMonths(input)
+    case 'year':
+      return datefnsStartOfYears(input)
+    default:
+      throw new Error(`Unrecognized unit: "${unit}".`)
+  }
+}
 
 const suites = units.map((unit) => {
   const suite = createSuite(`startOf ${unit}`)
   suite.add('Moment.js', () => momentDate.startOf(unit))
+  suite.add('date-fns', () => startOfDateFnsUnit(date, unit))
   suite.add('Day.js', () => dayjsDate.startOf(unit))
   return suite
 })

--- a/bench/startOf.bench.js
+++ b/bench/startOf.bench.js
@@ -1,0 +1,18 @@
+const { createSuite, runSuites } = require('./benchmark')
+
+const moment = require('moment')
+const dayjs = require('..')
+
+const momentDate = moment('2013-05-25')
+const dayjsDate = dayjs('2013-05-25')
+
+const units = ['second', 'minute', 'hour', 'date', 'day', 'week', 'month', 'year']
+
+const suites = units.map((unit) => {
+  const suite = createSuite(`startOf ${unit}`)
+  suite.add('Moment.js', () => momentDate.startOf(unit))
+  suite.add('Day.js', () => dayjsDate.startOf(unit))
+  return suite
+})
+
+runSuites(suites)

--- a/package-lock.json
+++ b/package-lock.json
@@ -3300,6 +3300,12 @@
         "whatwg-url": "^6.4.0"
       }
     },
+    "date-fns": {
+      "version": "1.29.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-1.29.0.tgz",
+      "integrity": "sha512-lbTXWZ6M20cWH8N9S6afb0SBm6tMk+uUg6z3MqHPKE9atmsY3kJkTm8vKe93izJ2B2+q5MV990sM2CHgtAZaOw==",
+      "dev": true
+    },
     "date-format": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/date-format/-/date-format-1.2.0.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1971,6 +1971,16 @@
         "tweetnacl": "^0.14.3"
       }
     },
+    "benchmark": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/benchmark/-/benchmark-2.1.4.tgz",
+      "integrity": "sha1-CfPeMckWQl1JjMLuVloOvzwqVik=",
+      "dev": true,
+      "requires": {
+        "lodash": "^4.17.4",
+        "platform": "^1.3.3"
+      }
+    },
     "better-assert": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/better-assert/-/better-assert-1.0.2.tgz",
@@ -9493,6 +9503,12 @@
       "requires": {
         "find-up": "^2.1.0"
       }
+    },
+    "platform": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/platform/-/platform-1.3.5.tgz",
+      "integrity": "sha512-TuvHS8AOIZNAlE77WUDiR4rySV/VMptyMfcfeoMgs4P8apaZM3JrnbzBiixKUv+XR6i+BXrQh8WAnjaSPFO65Q==",
+      "dev": true
     },
     "plur": {
       "version": "2.1.2",

--- a/package.json
+++ b/package.json
@@ -6,8 +6,9 @@
   "types": "index.d.ts",
   "scripts": {
     "test": "jest",
-    "lint": "./node_modules/.bin/eslint src/* test/* build/*",
+    "lint": "./node_modules/.bin/eslint src/* test/* build/* bench/*",
     "build": "cross-env BABEL_ENV=build node build && npm run size",
+    "benchmark": "cross-env BABEL_ENV=build node bench",
     "sauce": "npx karma start karma.sauce.conf.js",
     "test:sauce": "npm run sauce -- 0 && npm run sauce -- 1 && npm run sauce -- 2  && npm run sauce -- 3",
     "size": "size-limit && gzip-size dayjs.min.js"
@@ -62,6 +63,7 @@
     "babel-core": "^7.0.0-bridge.0",
     "babel-jest": "^22.4.3",
     "babel-plugin-external-helpers": "^6.22.0",
+    "benchmark": "^2.1.4",
     "cross-env": "^5.1.6",
     "eslint": "^4.19.1",
     "eslint-config-airbnb-base": "^12.1.0",

--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
     "babel-plugin-external-helpers": "^6.22.0",
     "benchmark": "^2.1.4",
     "cross-env": "^5.1.6",
+    "date-fns": "^1.29.0",
     "eslint": "^4.19.1",
     "eslint-config-airbnb-base": "^12.1.0",
     "eslint-plugin-import": "^2.10.0",


### PR DESCRIPTION
Attempts to fix #32. Introduces a new script `npm run benchmark`. Single benchmarks can be run by `node bench/*.bench.js`.

Usage scenarios:

* Find methods, which are excessively slow. Suggest them for refactoring or redesigning.
* Compare performance of the same scenarios implemented in Moment.js.

