### PR TITLE
Add a new plugin ‘timeStartOrEnd’

### DIFF
--- a/docs/zh-cn/API-reference.md
+++ b/docs/zh-cn/API-reference.md
@@ -378,3 +378,12 @@ dayjs.isDayjs(new Date()); // false
 `.isBetween` 返回一个时间是否介于两个时间之间
 
 plugin [`IsBetween`](./Plugin.md#isbetween)
+
+### 指定某天的开始/结束时间戳
+
+`.monthStart` 设置当前日期为当月第一天
+`.monthEnd` 设置当前日期为当月最后一天
+`.dayStart` 设置当前时间为当天第一毫秒
+`.dayEnd` 设置当前时间为当天最后一毫秒
+
+plugin [`timeStartOrEnd`](./Plugin.md#timeStartOrEnd)

--- a/docs/zh-cn/Plugin.md
+++ b/docs/zh-cn/Plugin.md
@@ -166,6 +166,26 @@ dayjs.extend(isBetween)
 dayjs('2010-10-20').isBetween('2010-10-19', dayjs('2010-10-25')); // true
 ```
 
+### timeStartOrEnd
+ - timeStartOrEnd 增加了四个方法,具体如下:
+|      方法名      |   参数  | 说明                        |
+| --------------- | --------| --------------------------- |
+| `.monthStart()` | false   | 设置当前日期为当月第一天      |
+| `.monthEnd()`   | false   | 设置当前日期为当月最后一天    |
+| `.dayStart()`   | false   | 设置当前时间为当天第一毫秒    |
+| `.dayEnd()`     | false   | 设置当前时间为当天最后一毫秒  |
+
+```javascript
+import timeStartOrEnd from 'dayjs/plugin/timeStartOrEnd'
+
+dayjs.extend(timeStartOrEnd)
+
+dayjs('2018-09-18').monthStart(); // '2018-09-01'
+dayjs('2018-09-18').monthEnd(); // '2018-09-30'
+dayjs('2018-09-18 12:00:00').dayStart(); // '2018-09-30 00:00:00'
+dayjs('2018-09-18 12:00:00').dayEnd(); // '2018-09-30 23:59:59:999'
+```
+
 ## 自定义
 
 你可以根据需要自由的编写一个Day.js插件

--- a/index.d.ts
+++ b/index.d.ts
@@ -83,6 +83,14 @@ declare namespace dayjs {
     isLeapYear(): boolean
 
     locale(arg1: any, arg2?: any): Dayjs
+
+    dayStart(): Dayjs
+
+    dayEnd(): Dayjs
+
+    monthStart(): Dayjs
+
+    monthEnd(): Dayjs
   }
 
   export type PluginFunc = (option: ConfigType, d1: Dayjs, d2: Dayjs) => void

--- a/src/plugin/timeStartOrEnd/index.js
+++ b/src/plugin/timeStartOrEnd/index.js
@@ -1,0 +1,36 @@
+export default (option, dayjsClass) => {
+  /**
+     * 当天开始时间
+     */
+  dayjsClass.prototype.dayStart = function () {
+    return this.set('hour', 0)
+      .set('minute', 0)
+      .set('second', 0)
+      .set('millisecond', 0)
+  }
+
+  /**
+     * 当天结束时间
+     */
+  dayjsClass.prototype.dayEnd = function () {
+    return this.set('hour', 23)
+      .set('minute', 59)
+      .set('second', 59)
+      .set('millisecond', 999)
+  }
+
+  /**
+     * 月初日期
+     */
+  dayjsClass.prototype.monthStart = function () {
+    return this.set('date', 1)
+  }
+
+  /**
+     * 月末日期
+     */
+  dayjsClass.prototype.monthEnd = function () {
+    const days = this.daysInMonth()
+    return this.set('date', days)
+  }
+}

--- a/test/index.d.test.ts
+++ b/test/index.d.test.ts
@@ -71,3 +71,11 @@ dayjs().isSame(dayjs())
 dayjs().isAfter(dayjs())
 
 dayjs('2000-01-01').isLeapYear()
+
+dayjs().monthStart()
+
+dayjs().monthEnd()
+
+dayjs().dayStart()
+
+dayjs().dayEnd()

--- a/test/plugin/timeStartOrEnd.test.js
+++ b/test/plugin/timeStartOrEnd.test.js
@@ -1,0 +1,59 @@
+import MockDate from 'mockdate'
+import dayjs from '../../src'
+import timeStartOrEnd from '../../src/plugin/timeStartOrEnd'
+
+dayjs.extend(timeStartOrEnd)
+
+beforeEach(() => {
+  MockDate.set(new Date())
+})
+
+afterEach(() => {
+  MockDate.reset()
+})
+
+it('timeStartOrEnd', () => {
+  // 当月第一天
+  expect(dayjs('2018-09-10')
+    .monthStart()
+    .valueOf()).toEqual(dayjs('2018-09-01').valueOf())
+
+  // 当月最后一天
+  expect(dayjs('2018-09-10')
+    .monthEnd()
+    .valueOf()).toEqual(dayjs('2018-09-30').valueOf())
+
+  // 当天第一毫秒
+  expect(dayjs('2018-09-10 12:09:09')
+    .dayStart()
+    .valueOf()).toEqual(dayjs('2018-09-10 00:00:00').valueOf())
+
+  // 当天最后一毫秒
+  expect(dayjs('2018-09-10 12:09:09')
+    .dayEnd()
+    .valueOf()).toEqual(dayjs('2018-09-10 23:59:59:999').valueOf())
+
+  // 当月第一天,最后毫秒
+  expect(dayjs('2018-09-10 12:09:09')
+    .monthStart()
+    .dayEnd()
+    .valueOf()).toEqual(dayjs('2018-09-01 23:59:59:999').valueOf())
+
+  // 当月最后一天,最后毫秒
+  expect(dayjs('2018-09-10 12:09:09')
+    .monthEnd()
+    .dayEnd()
+    .valueOf()).toEqual(dayjs('2018-09-30 23:59:59:999').valueOf())
+
+  // 当月第一天,第毫秒
+  expect(dayjs('2018-09-10 12:09:09')
+    .monthStart()
+    .dayStart()
+    .valueOf()).toEqual(dayjs('2018-09-01 00:00:00').valueOf())
+
+  // 当月最后一天,第毫秒
+  expect(dayjs('2018-09-10 12:09:09')
+    .monthEnd()
+    .dayStart()
+    .valueOf()).toEqual(dayjs('2018-09-30 00:00:00').valueOf())
+})


### PR DESCRIPTION
In my business, it is often necessary to use the timestamp of the start time and end time of the specified date.
So I added this plugin to quickly specify some status. See the documentation and test cases for specific usage and effects.