### PR TITLE
Keep Day.js instance immutable, when constructed with a Date instance

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -32,11 +32,14 @@ const dayjs = (date, c) => {
     return date.clone()
   }
   const cfg = c || {}
+  if (date instanceof Date && cfg.cloneDate !== false) {
+    date = new Date(date)
+  }
   cfg.date = date
   return new Dayjs(cfg) // eslint-disable-line no-use-before-define
 }
 
-const wrapper = (date, instance) => dayjs(date, { locale: instance.$L })
+const wrapper = (date, instance, cloneDate) => dayjs(date, { locale: instance.$L, cloneDate })
 
 const Utils = U // for plugin use
 Utils.parseLocale = parseLocale
@@ -153,16 +156,17 @@ class Dayjs {
     const isStartOf = !Utils.isUndefined(startOf) ? startOf : true
     const unit = Utils.prettyUnit(units)
     const instanceFactory = (d, m) => {
-      const ins = wrapper(new Date(this.$y, m, d), this)
+      const ins = wrapper(new Date(this.$y, m, d), this, false)
       return isStartOf ? ins : ins.endOf(C.D)
     }
     const instanceFactorySet = (method, slice) => {
       const argumentStart = [0, 0, 0, 0]
       const argumentEnd = [23, 59, 59, 999]
-      return wrapper(this.toDate()[method].apply( // eslint-disable-line prefer-spread
-        this.toDate(),
+      const date = this.toDate()
+      return wrapper(date[method].apply( // eslint-disable-line prefer-spread
+        date,
         isStartOf ? argumentStart.slice(slice) : argumentEnd.slice(slice)
-      ), this)
+      ), this, false)
     }
     switch (unit) {
       case C.Y:
@@ -390,7 +394,7 @@ class Dayjs {
   }
 
   clone() {
-    return wrapper(this.toDate(), this)
+    return wrapper(this.toDate(), this, false)
   }
 
   toDate() {

--- a/test/parse.test.js
+++ b/test/parse.test.js
@@ -65,6 +65,14 @@ it('Number 0', () => {
   expect(dayjs(0).valueOf()).toBe(moment(0).valueOf())
 })
 
+it('Original Date object does not affect the dayjs instance', () => {
+  const original = new Date()
+  const instance = dayjs(original)
+  const internal = instance.toDate()
+  original.setTime(original.getTime() - 3600000)
+  expect(instance.toDate()).toEqual(internal)
+})
+
 it('Clone not affect each other', () => {
   const base = dayjs(20170101)
   const year = base.year()


### PR DESCRIPTION
The Dayjs constructor called from the `dayjs` function stores the original `Date` instance, which was passed to it. It does not clone it. If that `Date` instance is modified later, it will affect the `dayjs` instance too. It will modify its internal `this.$d` object and make it inconsistent with the other `this.$*` variables. Such modification from outside is unexpected and it will break the immutability of `dayjs` instances too.

I made the `dayjs` function - the public interface - clone the input `Date` instance, before passing to the constructor. I added a boolean flag to the `wrapper` function to prevent double cloning. Premature optimization is evil, but being ignorant to unnecessary repeated operations too :-) The default behaviour is to clone to prevent hidden errors.
