### PR TITLE
add spanish documentation & extra locale

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-English | [简体中文](./docs/zh-cn/README.zh-CN.md) | [日本語](./docs/ja/README-ja.md) | [Português Brasileiro](./docs/pt-br/README-pt-br.md) | [한국어](./docs/ko/README-ko.md)
+English | [简体中文](./docs/zh-cn/README.zh-CN.md) | [日本語](./docs/ja/README-ja.md) | [Português Brasileiro](./docs/pt-br/README-pt-br.md) | [한국어](./docs/ko/README-ko.md) | [Español (España)](./docs/es-es/README-es-es.md)
 
 <p align="center"><a href="#" target="_blank" rel="noopener noreferrer"><img width="550"
                                                                              src="https://user-images.githubusercontent.com/17680888/39081119-3057bbe2-456e-11e8-862c-646133ad4b43.png"

--- a/docs/es-es/API-reference.md
+++ b/docs/es-es/API-reference.md
@@ -1,0 +1,443 @@
+# Referencia de la API
+
+En lugar de modificar el `Date.prototype` nativo, Day.js construye una abstracción sobre el objeto `Date`: el objeto `Dayjs`.
+
+El objeto `Dayjs` es inmutable, por lo que toda operación de la API que altere de alguna forma la información contenida en el objeto `Dayjs` devolverá una nueva instancia de este.
+
+- [Referencia de la API](#referencia-de-la-api)
+  - [Análisis](#análisis)
+    - [Constructor `dayjs(existing?: string | number | Date | Dayjs)`](#constructor-dayjsexisting-string--number--date--dayjs)
+      - [Cadena [ISO 8601]](#cadena-iso-8601)
+      - [Objeto `Date` nativo](#objeto-date-nativo)
+      - [Tiempo Unix (milisegundos)](#tiempo-unix-milisegundos)
+    - [Tiempo Unix (segundos)](#tiempo-unix-segundos-unixvalue-number)
+    - [Clonar `.clone() | dayjs(original: Dayjs)`](#clonar-clone--dayjsoriginal-dayjs)
+    - [Validación `.isValid()`](#validación-isvalid)
+  - [Get y Set](#get-y-set)
+    - [Año `.year()`](#año-year)
+    - [Mes `.month()`](#mes-month)
+    - [Día del mes `.date()`](#día-del-mes-date)
+    - [Día de la semana `.day()`](#día-de-la-semana-day)
+    - [Hora `.hour()`](#hora-hour)
+    - [Minuto `.minute()`](#minuto-minute)
+    - [Segundo `.second()`](#segundo-second)
+    - [Milisegundo `.millisecond()`](#milisegundo-millisecond)
+    - [Set `.set(unit: string, value: number)`](#set-setunit-string-value-number)
+      - [Lista de unidades disponibles](#lista-de-unidades-disponibles)
+  - [Manipulación](#manipulación)
+    - [Añadir `.add(value: number, unit: string)`](#añadir-addvalue-number-unit-string)
+    - [Restar `.subtract(value: number, unit: string)`](#restar-subtractvalue-number-unit-string)
+    - [Principio de `.startOf(unit: string)`](#principio-de-startofunit-string)
+    - [Fin de `.endOf(unit: string)`](#fin-de-endofunit-string)
+  - [Presentación](#presentación)
+    - [Dar formato `.format(stringWithTokens: string)`](#dar-formato-formatstringwithtokens-string)
+      - [Lista de formatos disponibles](#lista-de-formatos-disponibles)
+    - [Diferencia `.diff(compared: Dayjs, unit: string (predeterminada: 'milliseconds'), float?: boolean)`](#diferencia-diffcompared-dayjs-unit-string-predeterminada-milliseconds-float-boolean)
+    - [Tiempo Unix (milisegundos) `.valueOf()`](#tiempo-unix-milisegundos-valueof)
+    - [Tiempo Unix (segundos) `.unix()`](#tiempo-unix-segundos-unix)
+    - [Días en el mes `.daysInMonth()`](#días-en-el-mes-daysinmonth)
+    - [Como objeto `Date` `.toDate()`](#como-objeto-date-todate)
+    - [Como array `.toArray()`](#como-array-toarray)
+    - [Como JSON `.toJSON()`](#como-json-tojson)
+    - [Como cadena ISO 8601 `.toISOString()`](#como-cadena-iso-8601-toisostring)
+    - [Como objeto `.toObject()`](#como-objecto-toobject)
+    - [Como cadena `.toString()`](#como-cadena-tostring)
+  - [Consulta](#consulta)
+    - [Anterior a `.isBefore(compared: Dayjs)`](#anterior-a-isbeforecompared-dayjs)
+    - [Igual que `.isSame(compared: Dayjs)`](#igual-que-issamecompared-dayjs)
+    - [Posterior a `.isAfter(compared: Dayjs)`](#posterior-a-isaftercompared-dayjs)
+    - [Es Dayjs `.isDayjs()`](#es-dayjs-isdayjscompared-any)
+  - [API de complementos](#api-de-complementos)
+    - [RelativeTime](#relativetime)
+    - [IsLeapYear](#isleapyear)
+    - [WeekOfYear](#weekofyear)
+    - [IsBetween](#isbetween)
+
+## Análisis
+
+### Constructor `dayjs(existing?: string | number | Date | Dayjs)`
+
+Si se llama al constructor sin parámetros, este devuelve un nuevo objeto `Dayjs` con la fecha y hora actual.
+
+```js
+dayjs();
+```
+
+Day.js también analiza otros formatos de fecha.
+
+#### Cadena [ISO 8601](https://es.wikipedia.org/wiki/ISO_8601)
+
+```js
+dayjs('2018-04-04T16:00:00.000Z');
+```
+
+#### Objeto `Date` nativo
+
+```js
+dayjs(new Date(2018, 8, 18));
+```
+
+#### Tiempo Unix (milisegundos)
+
+Devuelve un objeto `Dayjs` a partir de un tiempo unix (milisegundos desde la época Unix).
+
+```js
+dayjs(1318781876406);
+```
+
+### Tiempo Unix (segundos) `.unix(value: number)`
+
+Devuelve un objeto `Dayjs` a partir de un tiempo Unix (segundos desde la época Unix).
+
+```js
+dayjs.unix(1318781876);
+dayjs.unix(1318781876.721);
+```
+
+### Clonar `.clone() | dayjs(original: Dayjs)`
+
+Devuelve una copia de `Dayjs`.
+
+```js
+dayjs().clone();
+dayjs(dayjs('2019-01-25')); // si el constructor recibe un objeto Dayjs también lo clonará
+```
+
+### Validación `.isValid()`
+
+Devuelve un dato de tipo `boolean`, que indica si la fecha `Dayjs` es válida o no.
+
+```js
+dayjs().isValid();
+```
+
+## Get y Set
+
+### Año `.year()`
+
+Devuelve un dato de tipo `number`, que representa el año del objeto `Dayjs`.
+
+```js
+dayjs().year();
+```
+
+### Mes `.month()`
+
+Devuelve un dato de tipo `number`, que representa el mes del objeto `Dayjs`. Se cuenta desde 0, que se corresponde con enero.
+
+```js
+dayjs().month();
+```
+
+### Día del mes `.date()`
+
+Devuelve un dato de tipo `number`, que indica el día del mes del objeto `Dayjs`. Empieza por el día 1.
+
+```js
+dayjs().date();
+```
+
+### Día de la semana `.day()`
+
+Devuelve un dato de tipo `number`, que indica el día de la semana del objeto `Dayjs`. Se cuenta desde 0, que se corresponde con el domingo.
+
+```js
+dayjs().day();
+```
+
+### Hora `.hour()`
+
+Devuelve un dato de tipo `number`, que indica la hora del objeto `Dayjs`.
+
+```js
+dayjs().hour();
+```
+
+### Minuto `.minute()`
+
+Devuelve un dato de tipo `number`, que indica los minutos del objeto `Dayjs`.
+
+```js
+dayjs().minute();
+```
+
+### Segundo `.second()`
+
+Devuelve un dato de tipo `number`, que indica los segundos del objeto `Dayjs`.
+
+```js
+dayjs().second();
+```
+
+### Milisegundo `.millisecond()`
+
+Devuelve un dato de tipo `number`, que indica los milisegundos del objeto `Dayjs`.
+
+```js
+dayjs().millisecond();
+```
+
+### Set `.set(unit: string, value: number)`
+
+Devuelve un nuevo objeto `Dayjs` con los cambios aplicados.
+
+```js
+dayjs().set('date', 1);
+dayjs().set('month', 3); // Abril
+dayjs().set('second', 30);
+```
+
+#### Lista de unidades disponibles
+
+| Unit          | Abreviatura | Descripción                                 |
+| ------------- | ----------- | ------------------------------------------  |
+| `date`        |             | Día del mes                                 |
+| `day`         | `d`         | Día de la semana (de domingo 0, a sábado 6) |
+| `month`       | `M`         | Mes                                         |
+| `year`        | `y`         | Año                                         |
+| `hour`        | `h`         | Hora                                        |
+| `minute`      | `m`         | Minuto                                      |
+| `second`      | `s`         | Segundo                                     |
+| `millisecond` | `ms`        | Milisegundo                                 |
+
+## Manipulación
+
+Los objetos `Dayjs` pueden manipularse de diversas formas.
+
+```js
+dayjs('2019-01-25')
+  .add(1, 'day')
+  .subtract(1, 'year').toString(); // Fri, 26 Jan 2018 00:00:00 GMT
+```
+
+### Añadir `.add(value: number, unit: string)`
+
+Devuelve un nuevo objeto `Dayjs`, resultante de añadir al actual el tiempo indicado.
+
+```js
+dayjs().add(7, 'day');
+```
+
+### Restar `.subtract(value: number, unit: string)`
+
+Devuelve un nuevo objeto `Dayjs`, resultante de restar al actual el tiempo indicado.
+
+```js
+dayjs().subtract(7, 'year');
+```
+
+### Principio de `.startOf(unit: string)`
+
+Devuelve un nuevo objeto `Dayjs`, resultante de ajustar el actual al principio de la unidad de tiempo indicada.
+
+```js
+dayjs().startOf('week');
+```
+
+### Fin de `.endOf(unit: string)`
+
+Devuelve un nuevo objeto `Dayjs`, resultante de ajustar el actual al final de la unidad de tiempo indicada.
+
+```js
+dayjs().endOf('month');
+```
+
+## Presentación
+
+### Dar formato `.format(stringWithTokens: string)`
+
+Devuelve un dato de tipo `string` con la fecha del objeto `Dayjs` formateada.
+Para escapar caracteres, estos se han de encerrar entre corchetes o llaves (p.ej.: `[G] {um}`).
+
+```js
+dayjs().format(); // fecha actual en ISO6801, sin fracciones de segundo p.ej. '2020-04-02T08:02:17-05:00'
+
+dayjs('2019-01-25').format('{YYYY} MM-DDTHH:mm:ssZ[Z]'); // '{2019} 01-25T00:00:00-02:00Z'
+
+dayjs('2019-01-25').format('DD/MM/YYYY'); // '25/01/2019'
+```
+
+#### Lista de formatos disponibles
+
+| Formato | Salida           | Descripción                               |
+| ------- | ---------------- | ----------------------------------------- |
+| `YY`    | 18               | Año, con 2 dígitos                        |
+| `YYYY`  | 2018             | Año, con 4 dígitos                        |
+| `M`     | 1-12             | Mes, contando desde 1                     |
+| `MM`    | 01-12            | Mes, con 2 dígitos                        |
+| `MMM`   | Jan-Dec          | Nombre abreviado del mes                  |
+| `MMMM`  | January-December | Nombre completo del mes                   |
+| `D`     | 1-31             | Día del mes                               |
+| `DD`    | 01-31            | Día del mes, con 2 dígitos                |
+| `d`     | 0-6              | Día de la semana, siendo el domingo el 0  |
+| `dd`    | Su-Sa            | Nombre mínimo del día de la semana        |
+| `ddd`   | Sun-Sat          | Nombre abreviado del día de la semana     |
+| `dddd`  | Sunday-Saturday  | Nombre del día de la semana               |
+| `H`     | 0-23             | Hora                                      |
+| `HH`    | 00-23            | Hora, con 2 dígitos                       |
+| `h`     | 1-12             | Hora, formato de 12 horas                 |
+| `hh`    | 01-12            | Hora, formato de 12 horas, con 2 dígitos  |
+| `m`     | 0-59             | Minutos                                   |
+| `mm`    | 00-59            | Minutos, con 2 dígitos                    |
+| `s`     | 0-59             | Segundos                                  |
+| `ss`    | 00-59            | Segundos, con 2 dígitos                   |
+| `SSS`   | 000-999          | Milisegundos, con 3 dígitos               |
+| `Z`     | +5:00            | Diferencia horaria UTC                    |
+| `ZZ`    | +0500            | Diferencia horaria UTC, con 2 dígitos     |
+| `A`     | AM PM            |                                           |
+| `a`     | am pm            |                                           |
+
+\* Más formatos disponibles `Q Do k kk X x ...` con el complemento [`AdvancedFormat`](./Plugin.md#advancedformat)
+
+### Diferencia `.diff(compared: Dayjs, unit: string (predeterminada: 'milliseconds'), float?: boolean)`
+
+Devuelve un dato de tipo `number`, que indica la diferencia existente entre dos objetos `Dayjs`, expresada en la unidad de tiempo dada.
+
+```js
+const date1 = dayjs('2019-01-25');
+const date2 = dayjs('2018-06-05');
+date1.diff(date2); // 20214000000
+date1.diff(date2, 'months'); // 7
+date1.diff(date2, 'months', true); // 7.645161290322581
+date1.diff(date2, 'days'); // 233
+```
+
+### Tiempo Unix (milisegundos) `.valueOf()`
+
+Devuelve un dato de tipo `number`, que indica el número de milisegundos transcurridos desde la época Unix para el objeto `Dayjs`.
+
+```js
+dayjs('2019-01-25').valueOf(); // 1548381600000
+```
+
+### Tiempo Unix (segundos) `.unix()`
+
+Devuelve un dato de tipo `number`, que indica el número de segundos transcurridos desde la época Unix para el objeto `Dayjs`.
+
+```js
+dayjs('2019-01-25').unix(); // 1548381600
+```
+
+### Días en el mes `.daysInMonth()`
+
+Devuelve un dato de tipo `number`, que indica el número de días contenidos en el mes del objeto `Dayjs`.
+
+```js
+dayjs('2019-01-25').daysInMonth(); // 31
+```
+
+### Como objeto `Date` `.toDate()`
+
+Devuelve un objeto `Date` nativo, obtenido a partir del objeto `Dayjs`.
+
+```js
+dayjs('2019-01-25').toDate();
+```
+
+### Como array `.toArray()`
+
+Devuelve un array que reproduce los parámetros de `new Date()`.
+
+```js
+dayjs('2019-01-25').toArray(); // [ 2019, 0, 25, 0, 0, 0, 0 ]
+```
+
+### Como JSON `.toJSON()`
+
+Devuelve un objeto `Dayjs` formateado como una cadena ISO8601.
+
+```js
+dayjs('2019-01-25').toJSON(); // '2019-01-25T02:00:00.000Z'
+```
+
+### Como cadena ISO 8601 `.toISOString()`
+
+Devuelve un objeto `Dayjs` formateado como una cadena ISO8601.
+
+```js
+dayjs('2019-01-25').toISOString(); // '2019-01-25T02:00:00.000Z'
+```
+
+### Como objecto `.toObject()`
+
+Devuelve un dato de tipo `object`, con las propiedades de la fecha.
+
+```js
+dayjs('2019-01-25').toObject();
+/* { years: 2019,
+     months: 0,
+     date: 25,
+     hours: 0,
+     minutes: 0,
+     seconds: 0,
+     milliseconds: 0 } */
+```
+
+### Como cadena `.toString()`
+
+Devuelve un dato de tipo `string`, que representa la fecha.
+
+```js
+dayjs('2019-01-25').toString(); // 'Fri, 25 Jan 2019 02:00:00 GMT'
+```
+
+## Consulta
+
+### Anterior a `.isBefore(compared: Dayjs)`
+
+Devuelve un dato de tipo `boolean`, que indica si la fecha del objeto `Dayjs` inicial es anterior o no a la fecha del objeto `Dayjs` a comparar.
+
+```js
+dayjs().isBefore(dayjs()); // false
+```
+
+### Igual que `.isSame(compared: Dayjs)`
+
+Devuelve un dato de tipo `boolean`, que indica si la fecha del objeto `Dayjs` inicial es igual o no que la fecha del objeto `Dayjs` a comparar.
+
+```js
+dayjs().isSame(dayjs()); // true
+```
+
+### Posterior a `.isAfter(compared: Dayjs)`
+
+Devuelve un dato de tipo `boolean`, que indica si la fecha del objeto `Dayjs` inicial es posterior o no a la fecha del objeto `Dayjs` a comparar.
+
+```js
+dayjs().isAfter(dayjs()); // false
+```
+
+### Es Dayjs `.isDayjs(compared: any)`
+
+Devuelve un dato de tipo `boolean`, que indica si la variable proporcionada es un objeto `Dayjs` o no.
+
+```js
+dayjs.isDayjs(dayjs()); // true
+dayjs.isDayjs(new Date()); // false
+```
+
+## API de complementos
+
+### RelativeTime
+
+`.from` `.to` `.fromNow` `.toNow` para obtener el tiempo relativo
+
+complemento [`RelativeTime`](./Plugin.md#relativetime)
+
+### IsLeapYear
+
+`.isLeapYear` para saber si se trata de un año bisiesto o no
+
+complemento [`IsLeapYear`](./Plugin.md#isleapyear)
+
+### WeekOfYear
+
+`.week` para obtener la semana del año
+
+complemento [`WeekOfYear`](./Plugin.md#weekofyear)
+
+### IsBetween
+
+`.isBetween` para comprobar si una fecha se encuentra entre otras dos fechas dadas
+
+complemento [`IsBetween`](./Plugin.md#isbetween)

--- a/docs/es-es/I18n.md
+++ b/docs/es-es/I18n.md
@@ -1,0 +1,118 @@
+# Internacionalización
+
+Day.js soporta muy bien la internacionalización.
+
+Pero no se incluirá en tu compilación final a menos que así lo requieras.
+
+Por defecto, Day.js viene con la configuración regional de Estados Unidos (Inglés).
+
+Pero podemos cargar diferentes configuraciones regionales y alternar entre ellas fácilmente.
+
+[Lista de configuraciones regionales soportadas](../../src/locale)
+
+Estás más que invitado a añadir otra configuración regional abriendo una pull request :+1:.
+
+## API
+
+### Cambio de la configuración regional global
+
+* Devuelve una cadena de configuración regional
+
+```js
+import 'dayjs/locale/es'
+import de from 'dayjs/locale/de'
+dayjs.locale('es') // uso global de la configuración regional cargada
+// uso de la configuración regional y actualización de su nombre predeterminado
+dayjs.locale('de-german', de)
+// Ver más detalles en la sección «Personalización» más abajo
+const customizedLocaleObject = { ... }
+// uso de la configuración regional personalizada
+dayjs.locale(customizedLocaleObject)
+```
+
+* Cambiar la configuración regional global no afecta a las instancias ya existentes.
+
+#### Cambio local de configuraciones regionales
+
+* Devuelve un nuevo objeto `Dayjs` con la nueva configuración regional.
+
+Se usa igual que `dayjs#locale`, con la salvedad de que se utiliza `locale` sobre una instancia específica.
+
+```js
+import 'dayjs/locale/es'
+dayjs().locale('es').format() // uso local de la configuración regional cargada
+dayjs('2018-4-28', { locale: es }) // ídem, pero mediante el constructor
+```
+
+## Instalación
+
+* Vía NPM:
+
+```javascript
+import 'dayjs/locale/es' // carga bajo demanda
+// require('dayjs/locale/es') // CommonJS
+// import locale_es from 'dayjs/locale/es' -> carga y obtiene el objeto de configuración regional en locale_es
+
+dayjs.locale('es') // uso global de la configuración regional
+// uso de la configuración regional en una instancia específica
+dayjs().locale('es').format()
+```
+
+* Vía CDN:
+
+```html
+<script src="https://unpkg.com/dayjs"></script>
+<!-- Load locale as window.dayjs_locale_NAME -->
+<script src="https://unpkg.com/dayjs/locale/zh-cn"></script>
+<script>
+  dayjs.locale('zh-cn');
+  dayjs().locale('zh-cn').format()
+  // get locale object
+  var customLocale = window.dayjs_locale_zh_cn // zh-cn -> zh_cn
+</script>
+```
+
+## Personalización
+
+You could create your own locale.
+
+Feel free to open a pull request to share your locale.
+
+Template of a Day.js locale Object.
+```javascript
+const localeObject = {
+  name: 'es', // name String
+  weekdays: 'Domingo_Lunes ...'.split('_'), // weekdays Array
+  weekdaysShort: 'Sun_M'.split('_'), // OPTIONAL, short weekdays Array, use first three letters if not provided
+  weekdaysMin: 'Su_Mo'.split('_'), // OPTIONAL, min weekdays Array, use first two letters if not provided
+  months: 'Enero_Febrero ... '.split('_'), // months Array
+  monthsShort: 'Jan_F'.split('_'), // OPTIONAL, short months Array, use first three letters if not provided
+  ordinal: n => `${n}º`, // ordinal Function (number) => return number + output
+  relativeTime: { // relative time format strings, keep %s %d as the same
+    future: 'in %s', // e.g. in 2 hours, %s been replaced with 2hours
+    past: '%s ago',
+    s: 'a few seconds',
+    m: 'a minute',
+    mm: '%d minutes',
+    h: 'an hour',
+    hh: '%d hours', // e.g. 2 hours, %d been replaced with 2
+    d: 'a day',
+    dd: '%d days',
+    M: 'a month',
+    MM: '%d months',
+    y: 'a year',
+    yy: '%d years'
+  }
+}
+```
+
+Template of a Day.js locale file.
+```javascript
+import dayjs from 'dayjs'
+
+const locale = { ... } // Your Day.js locale Object.
+
+dayjs.locale(locale, null, true) // load locale for later use
+
+export default locale
+```

--- a/docs/es-es/Installation.md
+++ b/docs/es-es/Installation.md
@@ -1,0 +1,30 @@
+# Guía de instalación
+
+Tienes a tu disposición varias opciones para obtener y utilizar Day.js:
+
+* Vía NPM:
+
+```console
+npm install dayjs --save
+```
+
+```js
+import dayjs from 'dayjs'
+// O con CommonJS
+// var dayjs = require('dayjs');
+dayjs().format();
+```
+
+* Vía CDN:
+
+```html
+<!-- Última versión compilada y minificada -->
+<script src="https://unpkg.com/dayjs"></script>
+<script>
+  dayjs().format();
+</script>
+```
+
+* Vía descarga directa y autohospedaje:
+
+Simplemente descarga la última versión de Day.js en [https://unpkg.com/dayjs/](https://unpkg.com/dayjs/).

--- a/docs/es-es/Plugin.md
+++ b/docs/es-es/Plugin.md
@@ -1,0 +1,203 @@
+# Lista de complementos
+
+Un complemento o *plugin* es un módulo independiente que puede añadirse a Day.js para extender su funcionalidad o añadir nuevas características.
+
+Por defecto, Day.js viene sin ningún complemento preinstalado, incluyendo únicamente el núcleo de la librería.
+
+Puedes cargar diversos complementos según tus necesidades.
+
+## API
+
+### Extend
+
+* Devuelve un objeto dayjs
+
+Método para declarar el uso de un complemento.
+
+```js
+import nombreComplemento
+dayjs.extend(nombreComplemento)
+dayjs.extend(nombreComplemento, options) // uso del complemento con opciones
+```
+
+## Instalación
+
+* Vía NPM:
+
+```javascript
+import dayjs from 'dayjs'
+import AdvancedFormat from 'dayjs/plugin/advancedFormat' // carga bajo demanda
+
+dayjs.extend(AdvancedFormat) // uso del complemento
+```
+
+* Vía CDN:
+
+```html
+<script src="https://unpkg.com/dayjs"></script>
+<!-- Carga del complemento en window.dayjs_plugin_nombreComplemento -->
+<script src="https://unpkg.com/dayjs/plugin/advancedFormat"></script>
+<script>
+  dayjs.extend(dayjs_plugin_advancedFormat);
+</script>
+```
+
+## Lista de complementos oficiales
+
+### AdvancedFormat
+
+* AdvancedFormat extiende la API `dayjs().format` para proporcionar más opciones de formato.
+
+```javascript
+import advancedFormat from 'dayjs/plugin/advancedFormat'
+
+dayjs.extend(advancedFormat)
+
+dayjs().format('Q Do k kk X x')
+```
+
+Lista de formatos añadidos:
+
+| Formato | Salida           | Descripción                           |
+| ------- | ---------------- | ------------------------------------- |
+| `Q`     | 1-4              | Cuarto                                |
+| `Do`    | 1º 2º ... 31º    | Día del mes con ordinal               |
+| `k`     | 1-23             | Hora, contando desde 1                |
+| `kk`    | 01-23            | Hora, con 2 dígitos, contando desde 1 |
+| `X`     | 1360013296       | Tiempo Unix en segundos               |
+| `x`     | 1360013296123    | Tiempo Unix en milisegundos           |
+
+### RelativeTime
+
+* RelativeTime añade las API `.from` `.to` `.fromNow` `.toNow` para dar formato de tiempo relativo a fechas (p.ej.: hace 3 horas).
+
+```javascript
+import relativeTime from 'dayjs/plugin/relativeTime'
+
+dayjs.extend(relativeTime)
+
+dayjs().from(dayjs('1990')) // hace 2 años
+dayjs().from(dayjs(), true) // 2 años
+
+dayjs().fromNow()
+
+dayjs().to(dayjs())
+
+dayjs().toNow()
+```
+
+#### Tiempo desde ahora `.fromNow(withoutSuffix?: boolean)`
+
+Devuelve un dato de tipo `string`, con el tiempo relativo desde el instante actual.
+
+#### Tiempo desde X `.from(compared: Dayjs, withoutSuffix?: boolean)`
+
+Devuelve un dato de tipo `string`, con el tiempo relativo desde el instante X.
+
+#### Tiempo hasta ahora `.toNow(withoutSuffix?: boolean)`
+
+Devuelve dato de tipo `string`, con el tiempo relativo transcurrido desde la fecha representada por el objeto `Dayjs` dado hasta el instante actual.
+
+#### Tiempo hasta X  `.to(compared: Dayjs, withoutSuffix?: boolean)`
+
+Devuelve dato de tipo `string`, con el tiempo relativo transcurrido desde la fecha representada por el objeto `Dayjs` dado hasta el instante X especificado.
+
+| Rango                        | Clave  | Ejemplo de salida                  |
+| ---------------------------- | ------ | ---------------------------------- |
+| de 0 a 44 segundos           | s      | hace unos segundos                 |
+| de 45 a 89 segundos          | m      | hace un minuto                     |
+| de 90 segundos a 44 minutos  | mm     | hace 2 minutos ... hace 44 minutos |
+| de 45 a 89 minutos           | h      | hace una hora                      |
+| de 90 minutos a 21 horas     | hh     | hace 2 horas ... hace 21 horas     |
+| de 22 a 35 horas             | d      | hace un día                        |
+| de 36 horas a 25 días        | dd     | hace 2 días ... hace 25 días       |
+| de 26 a 45 días              | M      | hace un mes                        |
+| de 46 días a 10 meses        | MM     | hace 2 meses ... hace 10 meses     |
+| de 11 a 17 meses             | y      | hace un año                        |
+| más de 18 meses              | yy     | hace 2 años ... hace 20 años       |
+
+### IsLeapYear
+
+* IsLeapYear añade la API `.isLeapYear`, que devuelve un dato de tipo `boolean` indicando si el año del objeto `Dayjs` es bisiesto o no.
+
+```javascript
+import isLeapYear from 'dayjs/plugin/isLeapYear'
+
+dayjs.extend(isLeapYear)
+
+dayjs('2000-01-01').isLeapYear(); // true
+```
+
+### BuddhistEra
+
+* BuddhistEra extiende la API `dayjs().format` para añadir opciones de formato relacionadas con la Era Budista (B.E.)
+* La Era Budista es un sistema de numeración anual, usado principalmente en los países del sudeste del continente asiático: Camboya, Laos, Birmania y Tailandia,así como en Sri Lanka y entre la población china de Malasia y Singapur, por razones religiosas o en eventos oficiales ([Wikipedia](https://en.wikipedia.org/wiki/Buddhist_calendar))
+* Para calcular manualmente el año de la BE tan sólo hemos de sumar 543 al año. Por ejemplo, el 26 Mayo 1977 AD/EC debe mostrarse como 26 Mayo 2520 BE (1977 + 543)
+
+```javascript
+import buddhistEra from 'dayjs/plugin/buddhistEra'
+
+dayjs.extend(buddhistEra)
+
+dayjs().format('BBBB BB')
+```
+
+Lista de formatos añadidos:
+
+| Formato | Salida           | Descripción                           |
+| ------- | ---------------- | ------------------------------------- |
+| `BBBB`  | 2561             | Año BE completo (Año + 543)           |
+| `BB`    | 61               | Año BE con 2 dígitos                  |
+
+### WeekOfYear
+
+* WeekOfYear añade la API `.week()`, que devuelve un dato de tipo `number` indicando la semana del año correspondiente a la fecha del objeto `Dayjs`.
+
+```javascript
+import weekOfYear from 'dayjs/plugin/weekOfYear'
+
+dayjs.extend(weekOfYear)
+
+dayjs('06/27/2018').week() // 26
+```
+
+### IsBetween
+
+* IsBetween añade la API `.isBetween()`, que devuelve un dato de tipo `boolean` indicando si una fecha se encuentra o no entre otras dos dadas.
+
+```javascript
+import isBetween from 'dayjs/plugin/isBetween'
+
+dayjs.extend(isBetween)
+
+dayjs('2010-10-20').isBetween('2010-10-19', dayjs('2010-10-25')); // true
+```
+
+## Personalización
+
+Puedes construir tu propio complemento de Day.js para cubrir tus necesidades.
+
+Siéntete libre de abrir una pull request para compartir tu complemento.
+
+Plantilla de un complemento de Day.js.
+
+```javascript
+export default (option, dayjsClass, dayjsFactory) => {
+  // extensión de dayjs()
+  // p.ej.: se añade dayjs().isSameOrBefore()
+  dayjsClass.prototype.isSameOrBefore = function (arguments) {}
+
+  // extensión de dayjs
+  // p.ej.: se añade dayjs.utc()
+  dayjsFactory.utc = (arguments) => {}
+
+  // sobrescritura de la API existente
+  // p.ej.: extensión de dayjs().format()
+  const oldFormat = dayjsClass.prototype.format
+  dayjsClass.prototype.format = function (arguments) {
+    // result contiene el formato original
+    const result = oldFormat(arguments)
+    // se ha de devolver result modificado
+  }
+}
+```

--- a/docs/es-es/README-es-es.md
+++ b/docs/es-es/README-es-es.md
@@ -1,0 +1,116 @@
+<p align="center"><a href="#" target="_blank" rel="noopener noreferrer"><img width="550"
+                                                                             src="https://user-images.githubusercontent.com/17680888/39081119-3057bbe2-456e-11e8-862c-646133ad4b43.png"
+                                                                             alt="Day.js"></a></p>
+<p align="center">Alternativa ligera, <b>2kB</b>, a Moment.js, con la misma API moderna</p>
+<br>
+<p align="center">
+    <a href="https://unpkg.com/dayjs/dayjs.min.js"><img
+            src="http://img.badgesize.io/https://unpkg.com/dayjs/dayjs.min.js?compression=gzip&style=flat-square"
+            alt="Gzip Size"></a>
+    <a href="https://www.npmjs.com/package/dayjs"><img src="https://img.shields.io/npm/v/dayjs.svg?style=flat-square&colorB=51C838"
+                                                       alt="NPM Version"></a>
+    <a href="https://travis-ci.org/iamkun/dayjs"><img
+            src="https://img.shields.io/travis/iamkun/dayjs/master.svg?style=flat-square" alt="Build Status"></a>
+    <a href="https://codecov.io/gh/iamkun/dayjs"><img
+            src="https://img.shields.io/codecov/c/github/iamkun/dayjs/master.svg?style=flat-square" alt="Codecov"></a>
+    <a href="https://github.com/iamkun/dayjs/blob/master/LICENSE"><img
+            src="https://img.shields.io/badge/license-MIT-brightgreen.svg?style=flat-square" alt="License"></a>
+    <br>
+    <a href="https://saucelabs.com/u/dayjs">
+        <img width="750" src="https://user-images.githubusercontent.com/17680888/40040137-8e3323a6-584b-11e8-9dba-bbe577ee8a7b.png" alt="Sauce Test Status">
+    </a>
+</p>
+
+> Day.js es una librería JavaScript minimalista que analiza, valida, manipula y muestra fechas y horas para navegadores modernos, manteniendo una API casi totalmente compatible con Moment.js. Si usas Moment.js, ya sabes usar Day.js.
+
+```js
+dayjs().startOf('month').add(1, 'day').set('year', 2018).format('YYYY-MM-DD HH:mm:ss');
+```
+
+* 🕒 API & patrones familiares para usuarios de Moment.js
+* 💪 Inmutable
+* 🔥 Encadenable
+* 🌐 Soporta I18n
+* 📦 Mini librería de 2kb
+* 👫 Compatible con todos los navegadores
+
+---
+
+# Primeros pasos
+
+## Instalación
+
+```console
+npm install dayjs --save
+```
+
+📚[Guía de instalación](./Installation.md)
+
+## API
+
+Usar las API de Day.js para analizar, validar, manipular y mostrar fechas y horas es muy sencillo.
+
+```javascript
+dayjs('2018-08-08') // analiza
+
+dayjs().format('{YYYY} MM-DDTHH:mm:ss SSS [Z] A') // da formato
+
+dayjs().set('month', 3).month() // get & set
+
+dayjs().add(1, 'year') // manipula
+
+dayjs().isBefore(dayjs()) // consulta
+```
+
+📚[Referencia de la API](./API-reference.md)
+
+## I18n
+
+Day.js soporta muy bien la internacionalización.
+
+Pero no se incluirá en tu compilación final a menos que así lo requieras.
+
+```javascript
+import 'dayjs/locale/es' // carga bajo demanda
+
+dayjs.locale('es') // usar la configuración regional española globalmente
+
+dayjs('2018-05-05').locale('zh-cn').format() // usar el chino simplificado en una instancia concreta
+```
+
+📚[Internacionalización](./I18n.md)
+
+## Complementos
+
+Un complemento o *plugin* es un módulo independiente que puede añadirse a Day.js para extender su funcionalidad o añadir nuevas características.
+
+```javascript
+import advancedFormat from 'dayjs/plugin/advancedFormat' // carga bajo demanda
+
+dayjs.extend(advancedFormat) // uso del complemento
+
+dayjs().format('Q Do k kk X x') // ahora tenemos más formatos disponibles
+```
+
+📚[Lista de complementos](./Plugin.md)
+
+## Patrocinadores
+
+Apoya a este proyecto convirtiéndote en un patrocinador. Tu logo aparecerá aquí, enlazado a tu sitio web. [[Conviértete en un patrocinador](https://opencollective.com/dayjs#sponsor)]
+
+[![Avatar patrocinador 1](https://opencollective.com/dayjs/sponsor/0/avatar.svg)](https://opencollective.com/dayjs/sponsor/0/website)
+[![Avatar patrocinador 2](https://opencollective.com/dayjs/sponsor/1/avatar.svg)](https://opencollective.com/dayjs/sponsor/1/website)
+[![Avatar patrocinador 3](https://opencollective.com/dayjs/sponsor/2/avatar.svg)](https://opencollective.com/dayjs/sponsor/2/website)
+
+## Contribuidores
+
+Este proyecto existe gracias a todas las personas que contribuyen en él.
+
+Por favor, danos una 💖 estrella 💖 para apoyarnos. Gracias.
+
+¡Y gracias también a todos nuestros micromecenas! 🙏
+<a alt="Mural de avatares de micromecenas" href="https://opencollective.com/dayjs#backers" target="_blank"><img src="https://opencollective.com/dayjs/contributors.svg?width=890" /></a>
+
+## Licencia
+
+Day.js está licenciada bajo la [Licencia MIT](./LICENSE).

--- a/src/locale/es-es.js
+++ b/src/locale/es-es.js
@@ -1,0 +1,27 @@
+import dayjs from 'dayjs'
+
+const locale = {
+  name: 'es-es',
+  weekdays: 'Domingo_Lunes_Martes_Miércoles_Jueves_Viernes_Sábado'.split('_'),
+  months: 'Enero_Febrero_Marzo_Abril_Mayo_Junio_Julio_Agosto_Septiembre_Octubre_Noviembre_Diciembre'.split('_'),
+  relativeTime: {
+    future: 'en %s',
+    past: 'hace %s',
+    s: 'unos segundos',
+    m: 'un minuto',
+    mm: '%d minutos',
+    h: 'una hora',
+    hh: '%d horas',
+    d: 'un día',
+    dd: '%d días',
+    M: 'un mes',
+    MM: '%d meses',
+    y: 'un año',
+    yy: '%d años'
+  },
+  ordinal: n => `${n}º`
+}
+
+dayjs.locale(locale, null, true)
+
+export default locale


### PR DESCRIPTION
Note: I cloned `src/locale/es.js` into `src/locale/es-es.js`,
similarly to how was done with `pt` and `pt-br`.
The reason is obvious: so many Spanish dialects. Leaving it with only
`es` would be problematic, especially when someone from another
Spanish-speaking country come to suggest editions because of this
Spanish not being the Spanish he is used to (understandable). And this is, as far as I can see,
already done and accepted with, at least, `pt`, so I think this
will be OK. Tell me if not and I will edit it
(remove it `/src/locale/es-es`, docs better have that way, so much text, could
be so different between countries) but have in mind the previous reasoning ^^.