### PR TITLE
Add install dayjs with yarn in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,8 +42,13 @@ dayjs().startOf('month').add(1, 'day').set('year', 2018).format('YYYY-MM-DD HH:m
 
 ### Installation
 
+Install dayjs using `npm`:
 ```console
 npm install dayjs --save
+```
+Or via `yarn`:
+```console
+yarn add dayjs
 ```
 
 📚[Installation Guide](./docs/en/Installation.md)

--- a/docs/en/Installation.md
+++ b/docs/en/Installation.md
@@ -8,6 +8,12 @@ You have multiple ways of getting Day.js:
 npm install dayjs --save
 ```
 
+* Via Yarn:
+
+```console
+yarn add dayjs
+```
+
 ```js
 import dayjs from 'dayjs'
 // Or CommonJS


### PR DESCRIPTION
I thought it would be great if we also give dayjs installation via yarn in the README and Installation guide. So it will be useful for developers, like me, who uses yarn to know that dayjs is available in yarn as well.

- Added yarn installation command in README.md
- Added yarn installation command in Installation.md