### PR TITLE
Fix .diff() UnitType for Typescript.

### DIFF
--- a/docs/en/API-reference.md
+++ b/docs/en/API-reference.md
@@ -299,7 +299,7 @@ const date2 = dayjs('2018-06-05');
 date1.diff(date2); // 20214000000
 date1.diff(date2, 'months'); // 7
 date1.diff(date2, 'months', true); // 7.645161290322581
-date1.diff(date2, 'days'); // 233
+date1.diff(date2, 'day'); // 233
 ```
 
 ### Unix Timestamp (milliseconds) `.valueOf()`

--- a/docs/en/API-reference.md
+++ b/docs/en/API-reference.md
@@ -297,8 +297,8 @@ Returns a `number` indicating the difference of two `Dayjs`s in the specified un
 const date1 = dayjs('2019-01-25');
 const date2 = dayjs('2018-06-05');
 date1.diff(date2); // 20214000000
-date1.diff(date2, 'months'); // 7
-date1.diff(date2, 'months', true); // 7.645161290322581
+date1.diff(date2, 'month'); // 7
+date1.diff(date2, 'month', true); // 7.645161290322581
 date1.diff(date2, 'day'); // 233
 ```
 

--- a/docs/es-es/API-reference.md
+++ b/docs/es-es/API-reference.md
@@ -297,9 +297,9 @@ Devuelve un dato de tipo `number`, que indica la diferencia existente entre dos 
 const date1 = dayjs('2019-01-25');
 const date2 = dayjs('2018-06-05');
 date1.diff(date2); // 20214000000
-date1.diff(date2, 'months'); // 7
-date1.diff(date2, 'months', true); // 7.645161290322581
-date1.diff(date2, 'days'); // 233
+date1.diff(date2, 'month'); // 7
+date1.diff(date2, 'month', true); // 7.645161290322581
+date1.diff(date2, 'day'); // 233
 ```
 
 ### Tiempo Unix (milisegundos) `.valueOf()`

--- a/docs/ja/API-reference.md
+++ b/docs/ja/API-reference.md
@@ -341,8 +341,12 @@ dayjs().format('{YYYY} MM-DDTHH:mm:ssZ[Z]'); // "{2014} 09-08T08:02:17-05:00Z"
 2つの `Dayjs` オブジェクトの差をミリ秒単位で取得します。
 
 ```js
-dayjs().diff(Dayjs, unit);
-dayjs().diff(dayjs(), 'years'); // 0
+const date1 = dayjs('2019-01-25');
+const date2 = dayjs('2018-06-05');
+date1.diff(date2); // 20214000000
+date1.diff(date2, 'month'); // 7
+date1.diff(date2, 'month', true); // 7.645161290322581
+date1.diff(date2, 'day'); // 233
 ```
 
 #### Unix Timestamp (milliseconds)

--- a/docs/ko/API-reference.md
+++ b/docs/ko/API-reference.md
@@ -296,9 +296,9 @@ dayjs('2019-01-25').format('DD/MM/YYYY'); // '25/01/2019'
 const date1 = dayjs('2019-01-25');
 const date2 = dayjs('2018-06-05');
 date1.diff(date2); // 20214000000
-date1.diff(date2, 'months'); // 7
-date1.diff(date2, 'months', true); // 7.645161290322581
-date1.diff(date2, 'days'); // 233
+date1.diff(date2, 'month'); // 7
+date1.diff(date2, 'month', true); // 7.645161290322581
+date1.diff(date2, 'day'); // 233
 ```
 
 ### Unix Timestamp (milliseconds) `.valueOf()`

--- a/docs/pt-br/API-reference.md
+++ b/docs/pt-br/API-reference.md
@@ -295,9 +295,9 @@ Retorna um `number` indicando a diferença entre dois objetos `Dayjs` na unidade
 const date1 = dayjs('2019-01-25');
 const date2 = dayjs('2018-06-05');
 date1.diff(date2); // 20214000000
-date1.diff(date2, 'months'); // 7
-date1.diff(date2, 'months', true); // 7.645161290322581
-date1.diff(date2, 'days'); // 233
+date1.diff(date2, 'month'); // 7
+date1.diff(date2, 'month', true); // 7.645161290322581
+date1.diff(date2, 'day'); // 233
 ```
 
 ### Unix Timestamp (milissegundos) `.valueOf()`

--- a/docs/zh-cn/API-reference.md
+++ b/docs/zh-cn/API-reference.md
@@ -262,8 +262,12 @@ dayjs().format("{YYYY} MM-DDTHH:mm:ssZ[Z]"); // "{2014} 09-08T08:02:17-05:00Z"
 
 获取两个 `Dayjs` 对象的时间差，默认毫秒。
 ```js
-dayjs().diff(Dayjs, unit);
-dayjs().diff(dayjs(), 'years'); // 0
+const date1 = dayjs('2019-01-25');
+const date2 = dayjs('2018-06-05');
+date1.diff(date2); // 20214000000
+date1.diff(date2, 'month'); // 7
+date1.diff(date2, 'month', true); // 7.645161290322581
+date1.diff(date2, 'day'); // 233
 ```
 #### Unix 时间戳 (毫秒)
 - return Number


### PR DESCRIPTION
```
export type UnitType = 'millisecond' | 'second' | 'minute' | 'hour' | 'day' | 'week' | 'month' | 'quarter' | 'year' | 'date'
```