### PR TITLE
 Invalid date format return `Invalid date`

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -255,6 +255,7 @@ class Dayjs {
   }
 
   format(formatStr) {
+    if (!this.isValid()) return 'Invalid date'
     const str = formatStr || C.FORMAT_DEFAULT
     const zoneStr = Utils.padZoneStr(this.$d.getTimezoneOffset())
     const locale = this.$locale()

--- a/test/display.test.js
+++ b/test/display.test.js
@@ -15,6 +15,11 @@ it('Format no formatStr', () => {
   expect(dayjs().format()).toBe(moment().format())
 })
 
+it('Format invalid date', () => {
+  expect(dayjs('').format()).toBe(moment('').format())
+  expect(dayjs('otherString').format()).toBe(moment('otherString').format())
+})
+
 it('Format Year YY YYYY', () => {
   expect(dayjs().format('YY')).toBe(moment().format('YY'))
   expect(dayjs().format('YYYY')).toBe(moment().format('YYYY'))

--- a/test/parse.test.js
+++ b/test/parse.test.js
@@ -46,6 +46,7 @@ describe('Parse', () => {
     global.console.warn = jest.genMockFunction()// moment.js otherString will throw warn
     expect(dayjs('otherString').toString().toLowerCase()).toBe(moment('otherString').toString().toLowerCase())
     expect(dayjs().isValid()).toBe(true)
+    expect(dayjs('').isValid()).toBe(false)
     expect(dayjs('otherString').isValid()).toBe(false)
     expect(dayjs(null).toString().toLowerCase()).toBe(moment(null).toString().toLowerCase())
   })


### PR DESCRIPTION
I use DayJs in a react project that uses redux, but DayJs throw warn when the state is Null String, causing my project to fail to run.