### PR TITLE
Added deltaZone in the equation when calculating diff

### DIFF
--- a/src/constant.js
+++ b/src/constant.js
@@ -34,4 +34,3 @@ export const en = {
   weekdays: 'Sunday_Monday_Tuesday_Wednesday_Thursday_Friday_Saturday'.split('_'),
   months: 'January_February_March_April_May_June_July_August_September_October_November_December'.split('_')
 }
-

--- a/src/index.js
+++ b/src/index.js
@@ -212,7 +212,6 @@ class Dayjs {
     return this
   }
 
-
   set(string, int) {
     return this.clone().$set(string, int)
   }
@@ -303,9 +302,14 @@ class Dayjs {
     })
   }
 
+  utcOffset() {
+    return -Math.round(this.$d.getTimezoneOffset() / 15) * 15
+  }
+
   diff(input, units, float) {
     const unit = Utils.prettyUnit(units)
     const that = dayjs(input)
+    const zoneDelta = (that.utcOffset() - this.utcOffset()) * C.MILLISECONDS_A_MINUTE
     const diff = this - that
     let result = Utils.monthDiff(this, that)
 
@@ -313,8 +317,8 @@ class Dayjs {
       [C.Y]: result / 12,
       [C.M]: result,
       [C.Q]: result / 3,
-      [C.W]: diff / C.MILLISECONDS_A_WEEK,
-      [C.D]: diff / C.MILLISECONDS_A_DAY,
+      [C.W]: (diff - zoneDelta) / C.MILLISECONDS_A_WEEK,
+      [C.D]: (diff - zoneDelta) / C.MILLISECONDS_A_DAY,
       [C.H]: diff / C.MILLISECONDS_A_HOUR,
       [C.MIN]: diff / C.MILLISECONDS_A_MINUTE,
       [C.S]: diff / C.MILLISECONDS_A_SECOND


### PR DESCRIPTION
I've looked into `momentjs` code, and tried to understand why method `dayjs().diff()` was returning different values than `moment().diff()` when the unit was `day`. Happens that `momentjs` uses the offset of each element to calculate hour zone difference, and adds it to the equation.

I've had to add the `utcOffset()` method in the core (where the `diff()` method is), but only the `get` version.

This should resolve #384 