### PR TITLE
Added deltaZone in the equation when calculating diff and added utcOffset api method

### DIFF
--- a/docs/en/API-reference.md
+++ b/docs/en/API-reference.md
@@ -36,6 +36,7 @@ The `Dayjs` object is immutable, that is, all API operations that change the `Da
     - [Difference `.diff(compared: Dayjs, unit: string (default: 'milliseconds'), float?: boolean)`](#difference-diffcompared-dayjs-unit-string-default-milliseconds-float-boolean)
     - [Unix Timestamp (milliseconds) `.valueOf()`](#unix-timestamp-milliseconds-valueof)
     - [Unix Timestamp (seconds) `.unix()`](#unix-timestamp-seconds-unix)
+    - [UTC offset (minutes) `.utcOffset()`](#utc-offset-minutes-utcoffset)
     - [Days in the Month `.daysInMonth()`](#days-in-the-month-daysinmonth)
     - [As Javascript Date `.toDate()`](#as-javascript-date-todate)
     - [As Array `.toArray()`](#as-array-toarray)
@@ -72,7 +73,7 @@ Day.js also parses other date formats.
 #### [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) string
 
 ```js
-dayjs('2018-04-04T16:00:00.000Z');
+dayjs("2018-04-04T16:00:00.000Z");
 ```
 
 #### Native Javascript Date object
@@ -99,7 +100,8 @@ dayjs.unix(1318781876.721);
 ```
 
 ### Custom Parse Format
-* parse custom formats `dayjs("12-25-1995", "MM-DD-YYYY")` in plugin [`CustomParseFormat`](./Plugin.md#customparseformat)
+
+- parse custom formats `dayjs("12-25-1995", "MM-DD-YYYY")` in plugin [`CustomParseFormat`](./Plugin.md#customparseformat)
 
 ### Clone `.clone() | dayjs(original: Dayjs)`
 
@@ -107,7 +109,7 @@ Returns a cloned `Dayjs`.
 
 ```js
 dayjs().clone();
-dayjs(dayjs('2019-01-25')); // passing a Dayjs object to a constructor will also clone it
+dayjs(dayjs("2019-01-25")); // passing a Dayjs object to a constructor will also clone it
 ```
 
 ### Validation `.isValid()`
@@ -189,9 +191,9 @@ dayjs().millisecond();
 Returns a `Dayjs` with the applied changes.
 
 ```js
-dayjs().set('date', 1);
-dayjs().set('month', 3); // April
-dayjs().set('second', 30);
+dayjs().set("date", 1);
+dayjs().set("month", 3); // April
+dayjs().set("second", 30);
 ```
 
 #### List of all available units
@@ -212,9 +214,10 @@ dayjs().set('second', 30);
 `Dayjs` objects can be manipulated in many ways.
 
 ```js
-dayjs('2019-01-25')
-  .add(1, 'day')
-  .subtract(1, 'year').toString(); // Fri, 26 Jan 2018 00:00:00 GMT
+dayjs("2019-01-25")
+  .add(1, "day")
+  .subtract(1, "year")
+  .toString(); // Fri, 26 Jan 2018 00:00:00 GMT
 ```
 
 ### Add `.add(value: number, unit: string)`
@@ -222,7 +225,7 @@ dayjs('2019-01-25')
 Returns a cloned `Dayjs` with a specified amount of time added.
 
 ```js
-dayjs().add(7, 'day');
+dayjs().add(7, "day");
 ```
 
 ### Subtract `.subtract(value: number, unit: string)`
@@ -230,7 +233,7 @@ dayjs().add(7, 'day');
 Returns a cloned `Dayjs` with a specified amount of time subtracted.
 
 ```js
-dayjs().subtract(7, 'year');
+dayjs().subtract(7, "year");
 ```
 
 ### Start of Time `.startOf(unit: string)`
@@ -238,7 +241,7 @@ dayjs().subtract(7, 'year');
 Returns a cloned `Dayjs` set to the start of the specified unit of time.
 
 ```js
-dayjs().startOf('week');
+dayjs().startOf("week");
 ```
 
 ### End of Time `.endOf(unit: string)`
@@ -246,7 +249,7 @@ dayjs().startOf('week');
 Returns a cloned `Dayjs` set to the end of the specified unit of time.
 
 ```js
-dayjs().endOf('month');
+dayjs().endOf("month");
 ```
 
 ## Displaying
@@ -259,9 +262,9 @@ To escape characters, wrap them in square or curly brackets (e.g. `[G] {um}`).
 ```js
 dayjs().format(); // current date in ISO6801, without fraction seconds e.g. '2020-04-02T08:02:17-05:00'
 
-dayjs('2019-01-25').format('{YYYY} MM-DDTHH:mm:ssZ[Z]'); // '{2019} 01-25T00:00:00-02:00Z'
+dayjs("2019-01-25").format("{YYYY} MM-DDTHH:mm:ssZ[Z]"); // '{2019} 01-25T00:00:00-02:00Z'
 
-dayjs('2019-01-25').format('DD/MM/YYYY'); // '25/01/2019'
+dayjs("2019-01-25").format("DD/MM/YYYY"); // '25/01/2019'
 ```
 
 #### List of all available formats
@@ -294,19 +297,19 @@ dayjs('2019-01-25').format('DD/MM/YYYY'); // '25/01/2019'
 | `A`    | AM PM            |                                       |
 | `a`    | am pm            |                                       |
 
-* More available formats `Q Do k kk X x ...` in plugin [`AdvancedFormat`](./Plugin.md#advancedformat)
+- More available formats `Q Do k kk X x ...` in plugin [`AdvancedFormat`](./Plugin.md#advancedformat)
 
 ### Difference `.diff(compared: Dayjs, unit: string (default: 'milliseconds'), float?: boolean)`
 
 Returns a `number` indicating the difference of two `Dayjs`s in the specified unit.
 
 ```js
-const date1 = dayjs('2019-01-25');
-const date2 = dayjs('2018-06-05');
+const date1 = dayjs("2019-01-25");
+const date2 = dayjs("2018-06-05");
 date1.diff(date2); // 20214000000
-date1.diff(date2, 'month'); // 7
-date1.diff(date2, 'month', true); // 7.645161290322581
-date1.diff(date2, 'day'); // 233
+date1.diff(date2, "month"); // 7
+date1.diff(date2, "month", true); // 7.645161290322581
+date1.diff(date2, "day"); // 233
 ```
 
 ### Unix Timestamp (milliseconds) `.valueOf()`
@@ -314,7 +317,7 @@ date1.diff(date2, 'day'); // 233
 Returns the `number` of milliseconds since the Unix Epoch for the `Dayjs`.
 
 ```js
-dayjs('2019-01-25').valueOf(); // 1548381600000
+dayjs("2019-01-25").valueOf(); // 1548381600000
 ```
 
 ### Unix Timestamp (seconds) `.unix()`
@@ -322,7 +325,15 @@ dayjs('2019-01-25').valueOf(); // 1548381600000
 Returns the `number` of seconds since the Unix Epoch for the `Dayjs`.
 
 ```js
-dayjs('2019-01-25').unix(); // 1548381600
+dayjs("2019-01-25").unix(); // 1548381600
+```
+
+### UTC Offset (minutes) `.utcOffset()`
+
+Returns the UTC offset in minutes for the `Dayjs`.
+
+```js
+dayjs("2013-03-07T07:00:00+08:00").utcOffset(); // 60
 ```
 
 ### Days in the Month `.daysInMonth()`
@@ -330,7 +341,7 @@ dayjs('2019-01-25').unix(); // 1548381600
 Returns the `number` of days in the `Dayjs`'s month.
 
 ```js
-dayjs('2019-01-25').daysInMonth(); // 31
+dayjs("2019-01-25").daysInMonth(); // 31
 ```
 
 ### As Javascript Date `.toDate()`
@@ -338,7 +349,7 @@ dayjs('2019-01-25').daysInMonth(); // 31
 Returns a copy of the native `Date` object parsed from the `Dayjs` object.
 
 ```js
-dayjs('2019-01-25').toDate();
+dayjs("2019-01-25").toDate();
 ```
 
 ### As Array `.toArray()`
@@ -346,7 +357,7 @@ dayjs('2019-01-25').toDate();
 Returns an `array` that mirrors the parameters from new Date().
 
 ```js
-dayjs('2019-01-25').toArray(); // [ 2019, 0, 25, 0, 0, 0, 0 ]
+dayjs("2019-01-25").toArray(); // [ 2019, 0, 25, 0, 0, 0, 0 ]
 ```
 
 ### As JSON `.toJSON()`
@@ -354,7 +365,7 @@ dayjs('2019-01-25').toArray(); // [ 2019, 0, 25, 0, 0, 0, 0 ]
 Returns the `Dayjs` formatted in an ISO8601 `string`.
 
 ```js
-dayjs('2019-01-25').toJSON(); // '2019-01-25T02:00:00.000Z'
+dayjs("2019-01-25").toJSON(); // '2019-01-25T02:00:00.000Z'
 ```
 
 ### As ISO 8601 String `.toISOString()`
@@ -362,7 +373,7 @@ dayjs('2019-01-25').toJSON(); // '2019-01-25T02:00:00.000Z'
 Returns the `Dayjs` formatted in an ISO8601 `string`.
 
 ```js
-dayjs('2019-01-25').toISOString(); // '2019-01-25T02:00:00.000Z'
+dayjs("2019-01-25").toISOString(); // '2019-01-25T02:00:00.000Z'
 ```
 
 ### As Object `.toObject()`
@@ -370,7 +381,7 @@ dayjs('2019-01-25').toISOString(); // '2019-01-25T02:00:00.000Z'
 Returns an `object` with the date's properties.
 
 ```js
-dayjs('2019-01-25').toObject();
+dayjs("2019-01-25").toObject();
 /* { years: 2019,
      months: 0,
      date: 25,
@@ -385,7 +396,7 @@ dayjs('2019-01-25').toObject();
 Returns a `string` representation of the date.
 
 ```js
-dayjs('2019-01-25').toString(); // 'Fri, 25 Jan 2019 02:00:00 GMT'
+dayjs("2019-01-25").toString(); // 'Fri, 25 Jan 2019 02:00:00 GMT'
 ```
 
 ## Query
@@ -396,7 +407,7 @@ Returns a `boolean` indicating whether the `Dayjs`'s date is before the other su
 
 ```js
 dayjs().isBefore(dayjs()); // false
-dayjs().isBefore(dayjs(), 'year'); // false
+dayjs().isBefore(dayjs(), "year"); // false
 ```
 
 ### Is Same `.isSame(compared: Dayjs, unit?: string)`
@@ -405,7 +416,7 @@ Returns a `boolean` indicating whether the `Dayjs`'s date is the same as the oth
 
 ```js
 dayjs().isSame(dayjs()); // true
-dayjs().isSame(dayjs(), 'year'); // true
+dayjs().isSame(dayjs(), "year"); // true
 ```
 
 ### Is After `.isAfter(compared: Dayjs, unit?: string)`
@@ -414,7 +425,7 @@ Returns a `boolean` indicating whether the `Dayjs`'s date is after the other sup
 
 ```js
 dayjs().isAfter(dayjs()); // false
-dayjs().isAfter(dayjs(), 'year'); // false
+dayjs().isAfter(dayjs(), "year"); // false
 ```
 
 ### Is a Dayjs `.isDayjs(compared: any)`
@@ -429,7 +440,7 @@ dayjs.isDayjs(new Date()); // false
 The operator `instanceof` works equally well:
 
 ```js
-dayjs() instanceof dayjs // true
+dayjs() instanceof dayjs; // true
 ```
 
 ## Plugin APIs

--- a/docs/es-es/API-reference.md
+++ b/docs/es-es/API-reference.md
@@ -36,6 +36,7 @@ El objeto `Dayjs` es inmutable, por lo que toda operación de la API que altere 
     - [Diferencia `.diff(compared: Dayjs, unit: string (predeterminada: 'milliseconds'), float?: boolean)`](#diferencia-diffcompared-dayjs-unit-string-predeterminada-milliseconds-float-boolean)
     - [Tiempo Unix (milisegundos) `.valueOf()`](#tiempo-unix-milisegundos-valueof)
     - [Tiempo Unix (segundos) `.unix()`](#tiempo-unix-segundos-unix)
+    - [UTC offset (minutos) `.utcOffset()`](#utc-offset-minutos-utcoffset)
     - [Días en el mes `.daysInMonth()`](#días-en-el-mes-daysinmonth)
     - [Como objeto `Date` `.toDate()`](#como-objeto-date-todate)
     - [Como array `.toArray()`](#como-array-toarray)
@@ -72,7 +73,7 @@ Day.js también analiza otros formatos de fecha.
 #### Cadena [ISO 8601](https://es.wikipedia.org/wiki/ISO_8601)
 
 ```js
-dayjs('2018-04-04T16:00:00.000Z');
+dayjs("2018-04-04T16:00:00.000Z");
 ```
 
 #### Objeto `Date` nativo
@@ -99,7 +100,8 @@ dayjs.unix(1318781876.721);
 ```
 
 ### Custom Parse Format
-* parse custom formats `dayjs("12-25-1995", "MM-DD-YYYY")` in plugin [`CustomParseFormat`](./Plugin.md#customparseformat)
+
+- parse custom formats `dayjs("12-25-1995", "MM-DD-YYYY")` in plugin [`CustomParseFormat`](./Plugin.md#customparseformat)
 
 ### Clonar `.clone() | dayjs(original: Dayjs)`
 
@@ -107,7 +109,7 @@ Devuelve una copia de `Dayjs`.
 
 ```js
 dayjs().clone();
-dayjs(dayjs('2019-01-25')); // si el constructor recibe un objeto Dayjs también lo clonará
+dayjs(dayjs("2019-01-25")); // si el constructor recibe un objeto Dayjs también lo clonará
 ```
 
 ### Validación `.isValid()`
@@ -189,15 +191,15 @@ dayjs().millisecond();
 Devuelve un nuevo objeto `Dayjs` con los cambios aplicados.
 
 ```js
-dayjs().set('date', 1);
-dayjs().set('month', 3); // Abril
-dayjs().set('second', 30);
+dayjs().set("date", 1);
+dayjs().set("month", 3); // Abril
+dayjs().set("second", 30);
 ```
 
 #### Lista de unidades disponibles
 
 | Unit          | Abreviatura | Descripción                                 |
-| ------------- | ----------- | ------------------------------------------  |
+| ------------- | ----------- | ------------------------------------------- |
 | `date`        |             | Día del mes                                 |
 | `day`         | `d`         | Día de la semana (de domingo 0, a sábado 6) |
 | `month`       | `M`         | Mes                                         |
@@ -212,9 +214,10 @@ dayjs().set('second', 30);
 Los objetos `Dayjs` pueden manipularse de diversas formas.
 
 ```js
-dayjs('2019-01-25')
-  .add(1, 'day')
-  .subtract(1, 'year').toString(); // Fri, 26 Jan 2018 00:00:00 GMT
+dayjs("2019-01-25")
+  .add(1, "day")
+  .subtract(1, "year")
+  .toString(); // Fri, 26 Jan 2018 00:00:00 GMT
 ```
 
 ### Añadir `.add(value: number, unit: string)`
@@ -222,7 +225,7 @@ dayjs('2019-01-25')
 Devuelve un nuevo objeto `Dayjs`, resultante de añadir al actual el tiempo indicado.
 
 ```js
-dayjs().add(7, 'day');
+dayjs().add(7, "day");
 ```
 
 ### Restar `.subtract(value: number, unit: string)`
@@ -230,7 +233,7 @@ dayjs().add(7, 'day');
 Devuelve un nuevo objeto `Dayjs`, resultante de restar al actual el tiempo indicado.
 
 ```js
-dayjs().subtract(7, 'year');
+dayjs().subtract(7, "year");
 ```
 
 ### Principio de `.startOf(unit: string)`
@@ -238,7 +241,7 @@ dayjs().subtract(7, 'year');
 Devuelve un nuevo objeto `Dayjs`, resultante de ajustar el actual al principio de la unidad de tiempo indicada.
 
 ```js
-dayjs().startOf('week');
+dayjs().startOf("week");
 ```
 
 ### Fin de `.endOf(unit: string)`
@@ -246,7 +249,7 @@ dayjs().startOf('week');
 Devuelve un nuevo objeto `Dayjs`, resultante de ajustar el actual al final de la unidad de tiempo indicada.
 
 ```js
-dayjs().endOf('month');
+dayjs().endOf("month");
 ```
 
 ## Presentación
@@ -259,40 +262,40 @@ Para escapar caracteres, estos se han de encerrar entre corchetes o llaves (p.ej
 ```js
 dayjs().format(); // fecha actual en ISO6801, sin fracciones de segundo p.ej. '2020-04-02T08:02:17-05:00'
 
-dayjs('2019-01-25').format('{YYYY} MM-DDTHH:mm:ssZ[Z]'); // '{2019} 01-25T00:00:00-02:00Z'
+dayjs("2019-01-25").format("{YYYY} MM-DDTHH:mm:ssZ[Z]"); // '{2019} 01-25T00:00:00-02:00Z'
 
-dayjs('2019-01-25').format('DD/MM/YYYY'); // '25/01/2019'
+dayjs("2019-01-25").format("DD/MM/YYYY"); // '25/01/2019'
 ```
 
 #### Lista de formatos disponibles
 
-| Formato | Salida           | Descripción                               |
-| ------- | ---------------- | ----------------------------------------- |
-| `YY`    | 18               | Año, con 2 dígitos                        |
-| `YYYY`  | 2018             | Año, con 4 dígitos                        |
-| `M`     | 1-12             | Mes, contando desde 1                     |
-| `MM`    | 01-12            | Mes, con 2 dígitos                        |
-| `MMM`   | Jan-Dec          | Nombre abreviado del mes                  |
-| `MMMM`  | January-December | Nombre completo del mes                   |
-| `D`     | 1-31             | Día del mes                               |
-| `DD`    | 01-31            | Día del mes, con 2 dígitos                |
-| `d`     | 0-6              | Día de la semana, siendo el domingo el 0  |
-| `dd`    | Su-Sa            | Nombre mínimo del día de la semana        |
-| `ddd`   | Sun-Sat          | Nombre abreviado del día de la semana     |
-| `dddd`  | Sunday-Saturday  | Nombre del día de la semana               |
-| `H`     | 0-23             | Hora                                      |
-| `HH`    | 00-23            | Hora, con 2 dígitos                       |
-| `h`     | 1-12             | Hora, formato de 12 horas                 |
-| `hh`    | 01-12            | Hora, formato de 12 horas, con 2 dígitos  |
-| `m`     | 0-59             | Minutos                                   |
-| `mm`    | 00-59            | Minutos, con 2 dígitos                    |
-| `s`     | 0-59             | Segundos                                  |
-| `ss`    | 00-59            | Segundos, con 2 dígitos                   |
-| `SSS`   | 000-999          | Milisegundos, con 3 dígitos               |
-| `Z`     | +5:00            | Diferencia horaria UTC                    |
-| `ZZ`    | +0500            | Diferencia horaria UTC, con 2 dígitos     |
-| `A`     | AM PM            |                                           |
-| `a`     | am pm            |                                           |
+| Formato | Salida           | Descripción                              |
+| ------- | ---------------- | ---------------------------------------- |
+| `YY`    | 18               | Año, con 2 dígitos                       |
+| `YYYY`  | 2018             | Año, con 4 dígitos                       |
+| `M`     | 1-12             | Mes, contando desde 1                    |
+| `MM`    | 01-12            | Mes, con 2 dígitos                       |
+| `MMM`   | Jan-Dec          | Nombre abreviado del mes                 |
+| `MMMM`  | January-December | Nombre completo del mes                  |
+| `D`     | 1-31             | Día del mes                              |
+| `DD`    | 01-31            | Día del mes, con 2 dígitos               |
+| `d`     | 0-6              | Día de la semana, siendo el domingo el 0 |
+| `dd`    | Su-Sa            | Nombre mínimo del día de la semana       |
+| `ddd`   | Sun-Sat          | Nombre abreviado del día de la semana    |
+| `dddd`  | Sunday-Saturday  | Nombre del día de la semana              |
+| `H`     | 0-23             | Hora                                     |
+| `HH`    | 00-23            | Hora, con 2 dígitos                      |
+| `h`     | 1-12             | Hora, formato de 12 horas                |
+| `hh`    | 01-12            | Hora, formato de 12 horas, con 2 dígitos |
+| `m`     | 0-59             | Minutos                                  |
+| `mm`    | 00-59            | Minutos, con 2 dígitos                   |
+| `s`     | 0-59             | Segundos                                 |
+| `ss`    | 00-59            | Segundos, con 2 dígitos                  |
+| `SSS`   | 000-999          | Milisegundos, con 3 dígitos              |
+| `Z`     | +5:00            | Diferencia horaria UTC                   |
+| `ZZ`    | +0500            | Diferencia horaria UTC, con 2 dígitos    |
+| `A`     | AM PM            |                                          |
+| `a`     | am pm            |                                          |
 
 \* Más formatos disponibles `Q Do k kk X x ...` con el complemento [`AdvancedFormat`](./Plugin.md#advancedformat)
 
@@ -301,12 +304,12 @@ dayjs('2019-01-25').format('DD/MM/YYYY'); // '25/01/2019'
 Devuelve un dato de tipo `number`, que indica la diferencia existente entre dos objetos `Dayjs`, expresada en la unidad de tiempo dada.
 
 ```js
-const date1 = dayjs('2019-01-25');
-const date2 = dayjs('2018-06-05');
+const date1 = dayjs("2019-01-25");
+const date2 = dayjs("2018-06-05");
 date1.diff(date2); // 20214000000
-date1.diff(date2, 'month'); // 7
-date1.diff(date2, 'month', true); // 7.645161290322581
-date1.diff(date2, 'day'); // 233
+date1.diff(date2, "month"); // 7
+date1.diff(date2, "month", true); // 7.645161290322581
+date1.diff(date2, "day"); // 233
 ```
 
 ### Tiempo Unix (milisegundos) `.valueOf()`
@@ -314,7 +317,7 @@ date1.diff(date2, 'day'); // 233
 Devuelve un dato de tipo `number`, que indica el número de milisegundos transcurridos desde la época Unix para el objeto `Dayjs`.
 
 ```js
-dayjs('2019-01-25').valueOf(); // 1548381600000
+dayjs("2019-01-25").valueOf(); // 1548381600000
 ```
 
 ### Tiempo Unix (segundos) `.unix()`
@@ -322,7 +325,15 @@ dayjs('2019-01-25').valueOf(); // 1548381600000
 Devuelve un dato de tipo `number`, que indica el número de segundos transcurridos desde la época Unix para el objeto `Dayjs`.
 
 ```js
-dayjs('2019-01-25').unix(); // 1548381600
+dayjs("2019-01-25").unix(); // 1548381600
+```
+
+### UTC Offset (minutos) `.utcOffset()`
+
+Devuelve el UTC offset en minutos del `Dayjs`.
+
+```js
+dayjs("2013-03-07T07:00:00+08:00").utcOffset(); // 60
 ```
 
 ### Días en el mes `.daysInMonth()`
@@ -330,7 +341,7 @@ dayjs('2019-01-25').unix(); // 1548381600
 Devuelve un dato de tipo `number`, que indica el número de días contenidos en el mes del objeto `Dayjs`.
 
 ```js
-dayjs('2019-01-25').daysInMonth(); // 31
+dayjs("2019-01-25").daysInMonth(); // 31
 ```
 
 ### Como objeto `Date` `.toDate()`
@@ -338,7 +349,7 @@ dayjs('2019-01-25').daysInMonth(); // 31
 Devuelve un objeto `Date` nativo, obtenido a partir del objeto `Dayjs`.
 
 ```js
-dayjs('2019-01-25').toDate();
+dayjs("2019-01-25").toDate();
 ```
 
 ### Como array `.toArray()`
@@ -346,7 +357,7 @@ dayjs('2019-01-25').toDate();
 Devuelve un array que reproduce los parámetros de `new Date()`.
 
 ```js
-dayjs('2019-01-25').toArray(); // [ 2019, 0, 25, 0, 0, 0, 0 ]
+dayjs("2019-01-25").toArray(); // [ 2019, 0, 25, 0, 0, 0, 0 ]
 ```
 
 ### Como JSON `.toJSON()`
@@ -354,7 +365,7 @@ dayjs('2019-01-25').toArray(); // [ 2019, 0, 25, 0, 0, 0, 0 ]
 Devuelve un objeto `Dayjs` formateado como una cadena ISO8601.
 
 ```js
-dayjs('2019-01-25').toJSON(); // '2019-01-25T02:00:00.000Z'
+dayjs("2019-01-25").toJSON(); // '2019-01-25T02:00:00.000Z'
 ```
 
 ### Como cadena ISO 8601 `.toISOString()`
@@ -362,7 +373,7 @@ dayjs('2019-01-25').toJSON(); // '2019-01-25T02:00:00.000Z'
 Devuelve un objeto `Dayjs` formateado como una cadena ISO8601.
 
 ```js
-dayjs('2019-01-25').toISOString(); // '2019-01-25T02:00:00.000Z'
+dayjs("2019-01-25").toISOString(); // '2019-01-25T02:00:00.000Z'
 ```
 
 ### Como objecto `.toObject()`
@@ -370,7 +381,7 @@ dayjs('2019-01-25').toISOString(); // '2019-01-25T02:00:00.000Z'
 Devuelve un dato de tipo `object`, con las propiedades de la fecha.
 
 ```js
-dayjs('2019-01-25').toObject();
+dayjs("2019-01-25").toObject();
 /* { years: 2019,
      months: 0,
      date: 25,
@@ -385,7 +396,7 @@ dayjs('2019-01-25').toObject();
 Devuelve un dato de tipo `string`, que representa la fecha.
 
 ```js
-dayjs('2019-01-25').toString(); // 'Fri, 25 Jan 2019 02:00:00 GMT'
+dayjs("2019-01-25").toString(); // 'Fri, 25 Jan 2019 02:00:00 GMT'
 ```
 
 ## Consulta
@@ -396,7 +407,7 @@ Devuelve un dato de tipo `boolean`, que indica si la fecha del objeto `Dayjs` in
 
 ```js
 dayjs().isBefore(dayjs()); // false
-dayjs().isBefore(dayjs(), 'year'); // false
+dayjs().isBefore(dayjs(), "year"); // false
 ```
 
 ### Igual que `.isSame(compared: Dayjs, unit?: string)`
@@ -405,7 +416,7 @@ Devuelve un dato de tipo `boolean`, que indica si la fecha del objeto `Dayjs` in
 
 ```js
 dayjs().isSame(dayjs()); // true
-dayjs().isSame(dayjs(), 'year'); // true
+dayjs().isSame(dayjs(), "year"); // true
 ```
 
 ### Posterior a `.isAfter(compared: Dayjs, unit?: string)`
@@ -414,7 +425,7 @@ Devuelve un dato de tipo `boolean`, que indica si la fecha del objeto `Dayjs` in
 
 ```js
 dayjs().isAfter(dayjs()); // false
-dayjs().isAfter(dayjs(), 'year'); // false
+dayjs().isAfter(dayjs(), "year"); // false
 ```
 
 ### Es Dayjs `.isDayjs(compared: any)`
@@ -429,7 +440,7 @@ dayjs.isDayjs(new Date()); // false
 The operator `instanceof` works equally well:
 
 ```js
-dayjs() instanceof dayjs // true
+dayjs() instanceof dayjs; // true
 ```
 
 ## API de complementos

--- a/src/constant.js
+++ b/src/constant.js
@@ -34,4 +34,3 @@ export const en = {
   weekdays: 'Sunday_Monday_Tuesday_Wednesday_Thursday_Friday_Saturday'.split('_'),
   months: 'January_February_March_April_May_June_July_August_September_October_November_December'.split('_')
 }
-

--- a/src/index.js
+++ b/src/index.js
@@ -212,7 +212,6 @@ class Dayjs {
     return this
   }
 
-
   set(string, int) {
     return this.clone().$set(string, int)
   }
@@ -303,9 +302,14 @@ class Dayjs {
     })
   }
 
+  utcOffset() {
+    return -Math.round(this.$d.getTimezoneOffset() / 15) * 15
+  }
+
   diff(input, units, float) {
     const unit = Utils.prettyUnit(units)
     const that = dayjs(input)
+    const zoneDelta = (that.utcOffset() - this.utcOffset()) * C.MILLISECONDS_A_MINUTE
     const diff = this - that
     let result = Utils.monthDiff(this, that)
 
@@ -313,8 +317,8 @@ class Dayjs {
       [C.Y]: result / 12,
       [C.M]: result,
       [C.Q]: result / 3,
-      [C.W]: diff / C.MILLISECONDS_A_WEEK,
-      [C.D]: diff / C.MILLISECONDS_A_DAY,
+      [C.W]: (diff - zoneDelta) / C.MILLISECONDS_A_WEEK,
+      [C.D]: (diff - zoneDelta) / C.MILLISECONDS_A_DAY,
       [C.H]: diff / C.MILLISECONDS_A_HOUR,
       [C.MIN]: diff / C.MILLISECONDS_A_MINUTE,
       [C.S]: diff / C.MILLISECONDS_A_SECOND

--- a/src/index.js
+++ b/src/index.js
@@ -303,6 +303,8 @@ class Dayjs {
   }
 
   utcOffset() {
+    // Because a bug at FF24, we're rounding the timezone offset around 15 minutes
+    // https://github.com/moment/moment/pull/1871
     return -Math.round(this.$d.getTimezoneOffset() / 15) * 15
   }
 

--- a/test/display.test.js
+++ b/test/display.test.js
@@ -86,7 +86,6 @@ it('Format Second s ss SSS', () => {
   expect(dayjs(date).format('s-ss-SSS')).toBe(moment(date).format('s-ss-SSS'))
 })
 
-
 it('Format Time Zone ZZ', () => {
   MockDate.set(new Date('2018-05-02T23:00:00.000'), 60 * 8)
   expect(dayjs().format('Z')).toBe(moment().format('Z'))
@@ -104,9 +103,21 @@ it('Format Time Zone ZZ', () => {
 })
 
 it('Format ddd dd MMM with short locale', () => {
-  expect(dayjs().locale(th).format('dd')).toBe(moment().locale('th').format('dd'))
-  expect(dayjs().locale(th).format('ddd')).toBe(moment().locale('th').format('ddd'))
-  expect(dayjs().locale(th).format('MMM')).toBe(moment().locale('th').format('MMM'))
+  expect(dayjs()
+    .locale(th)
+    .format('dd')).toBe(moment()
+    .locale('th')
+    .format('dd'))
+  expect(dayjs()
+    .locale(th)
+    .format('ddd')).toBe(moment()
+    .locale('th')
+    .format('ddd'))
+  expect(dayjs()
+    .locale(th)
+    .format('MMM')).toBe(moment()
+    .locale('th')
+    .format('MMM'))
 })
 
 it('Format Complex with other string - : / ', () => {
@@ -170,7 +181,6 @@ describe('Difference', () => {
     })
   })
 
-
   it('MonthDiff', () => {
     expect(dayjs('2018-08-08').diff(dayjs('2018-08-08'), 'month')).toEqual(0)
     expect(dayjs('2018-09-08').diff(dayjs('2018-08-08'), 'month')).toEqual(1)
@@ -190,6 +200,11 @@ it('Unix Timestamp (seconds)', () => {
 it('Days in Month', () => {
   expect(dayjs().daysInMonth()).toBe(moment().daysInMonth())
   expect(dayjs('20140201').daysInMonth()).toBe(moment('20140201').daysInMonth())
+})
+
+it('Utc Offset', () => {
+  expect(dayjs('2013-01-01T00:00:00.000').utcOffset()).toBe(moment('2013-01-01T00:00:00.000').utcOffset())
+  expect(dayjs('2013-01-01T05:00:00.000').utcOffset()).toBe(moment('2013-01-01T05:00:00.000').utcOffset())
 })
 
 it('As Javascript Date -> toDate', () => {


### PR DESCRIPTION
I've looked into momentjs code, and tried to understand why method dayjs().diff() was returning different values than moment().diff() when the unit was day. Happens that momentjs uses the offset of each element to calculate hour zone difference, and adds it to the equation.

I've had to add the utcOffset() method in the core (where the diff() method is), but only the get version.

This should resolve #384

As mentioned at #452 I've added test and documentation for `utcOffset` method