### PR TITLE
Created DaysInYear plugin

### DIFF
--- a/docs/en/API-reference.md
+++ b/docs/en/API-reference.md
@@ -36,6 +36,7 @@ The `Dayjs` object is immutable, that is, all API operations that change the `Da
     - [Difference `.diff(compared: Dayjs, unit: string (default: 'milliseconds'), float?: boolean)`](#difference-diffcompared-dayjs-unit-string-default-milliseconds-float-boolean)
     - [Unix Timestamp (milliseconds) `.valueOf()`](#unix-timestamp-milliseconds-valueof)
     - [Unix Timestamp (seconds) `.unix()`](#unix-timestamp-seconds-unix)
+    - [UTC offset (minutes) `.utcOffset()`](#utc-offset-minutes-utcoffset)
     - [Days in the Month `.daysInMonth()`](#days-in-the-month-daysinmonth)
     - [As Javascript Date `.toDate()`](#as-javascript-date-todate)
     - [As Array `.toArray()`](#as-array-toarray)
@@ -72,7 +73,7 @@ Day.js also parses other date formats.
 #### [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) string
 
 ```js
-dayjs('2018-04-04T16:00:00.000Z');
+dayjs("2018-04-04T16:00:00.000Z");
 ```
 
 #### Native Javascript Date object
@@ -99,7 +100,8 @@ dayjs.unix(1318781876.721);
 ```
 
 ### Custom Parse Format
-* parse custom formats `dayjs("12-25-1995", "MM-DD-YYYY")` in plugin [`CustomParseFormat`](./Plugin.md#customparseformat)
+
+- parse custom formats `dayjs("12-25-1995", "MM-DD-YYYY")` in plugin [`CustomParseFormat`](./Plugin.md#customparseformat)
 
 ### Clone `.clone() | dayjs(original: Dayjs)`
 
@@ -107,7 +109,7 @@ Returns a cloned `Dayjs`.
 
 ```js
 dayjs().clone();
-dayjs(dayjs('2019-01-25')); // passing a Dayjs object to a constructor will also clone it
+dayjs(dayjs("2019-01-25")); // passing a Dayjs object to a constructor will also clone it
 ```
 
 ### Validation `.isValid()`
@@ -189,9 +191,9 @@ dayjs().millisecond();
 Returns a `Dayjs` with the applied changes.
 
 ```js
-dayjs().set('date', 1);
-dayjs().set('month', 3); // April
-dayjs().set('second', 30);
+dayjs().set("date", 1);
+dayjs().set("month", 3); // April
+dayjs().set("second", 30);
 ```
 
 #### List of all available units
@@ -212,9 +214,10 @@ dayjs().set('second', 30);
 `Dayjs` objects can be manipulated in many ways.
 
 ```js
-dayjs('2019-01-25')
-  .add(1, 'day')
-  .subtract(1, 'year').toString(); // Fri, 26 Jan 2018 00:00:00 GMT
+dayjs("2019-01-25")
+  .add(1, "day")
+  .subtract(1, "year")
+  .toString(); // Fri, 26 Jan 2018 00:00:00 GMT
 ```
 
 ### Add `.add(value: number, unit: string)`
@@ -222,7 +225,7 @@ dayjs('2019-01-25')
 Returns a cloned `Dayjs` with a specified amount of time added.
 
 ```js
-dayjs().add(7, 'day');
+dayjs().add(7, "day");
 ```
 
 ### Subtract `.subtract(value: number, unit: string)`
@@ -230,7 +233,7 @@ dayjs().add(7, 'day');
 Returns a cloned `Dayjs` with a specified amount of time subtracted.
 
 ```js
-dayjs().subtract(7, 'year');
+dayjs().subtract(7, "year");
 ```
 
 ### Start of Time `.startOf(unit: string)`
@@ -238,7 +241,7 @@ dayjs().subtract(7, 'year');
 Returns a cloned `Dayjs` set to the start of the specified unit of time.
 
 ```js
-dayjs().startOf('week');
+dayjs().startOf("week");
 ```
 
 ### End of Time `.endOf(unit: string)`
@@ -246,7 +249,7 @@ dayjs().startOf('week');
 Returns a cloned `Dayjs` set to the end of the specified unit of time.
 
 ```js
-dayjs().endOf('month');
+dayjs().endOf("month");
 ```
 
 ## Displaying
@@ -259,9 +262,9 @@ To escape characters, wrap them in square or curly brackets (e.g. `[G] {um}`).
 ```js
 dayjs().format(); // current date in ISO6801, without fraction seconds e.g. '2020-04-02T08:02:17-05:00'
 
-dayjs('2019-01-25').format('{YYYY} MM-DDTHH:mm:ssZ[Z]'); // '{2019} 01-25T00:00:00-02:00Z'
+dayjs("2019-01-25").format("{YYYY} MM-DDTHH:mm:ssZ[Z]"); // '{2019} 01-25T00:00:00-02:00Z'
 
-dayjs('2019-01-25').format('DD/MM/YYYY'); // '25/01/2019'
+dayjs("2019-01-25").format("DD/MM/YYYY"); // '25/01/2019'
 ```
 
 #### List of all available formats
@@ -294,19 +297,19 @@ dayjs('2019-01-25').format('DD/MM/YYYY'); // '25/01/2019'
 | `A`    | AM PM            |                                       |
 | `a`    | am pm            |                                       |
 
-* More available formats `Q Do k kk X x ...` in plugin [`AdvancedFormat`](./Plugin.md#advancedformat)
+- More available formats `Q Do k kk X x ...` in plugin [`AdvancedFormat`](./Plugin.md#advancedformat)
 
 ### Difference `.diff(compared: Dayjs, unit: string (default: 'milliseconds'), float?: boolean)`
 
 Returns a `number` indicating the difference of two `Dayjs`s in the specified unit.
 
 ```js
-const date1 = dayjs('2019-01-25');
-const date2 = dayjs('2018-06-05');
+const date1 = dayjs("2019-01-25");
+const date2 = dayjs("2018-06-05");
 date1.diff(date2); // 20214000000
-date1.diff(date2, 'month'); // 7
-date1.diff(date2, 'month', true); // 7.645161290322581
-date1.diff(date2, 'day'); // 233
+date1.diff(date2, "month"); // 7
+date1.diff(date2, "month", true); // 7.645161290322581
+date1.diff(date2, "day"); // 233
 ```
 
 ### Unix Timestamp (milliseconds) `.valueOf()`
@@ -314,7 +317,7 @@ date1.diff(date2, 'day'); // 233
 Returns the `number` of milliseconds since the Unix Epoch for the `Dayjs`.
 
 ```js
-dayjs('2019-01-25').valueOf(); // 1548381600000
+dayjs("2019-01-25").valueOf(); // 1548381600000
 ```
 
 ### Unix Timestamp (seconds) `.unix()`
@@ -322,7 +325,15 @@ dayjs('2019-01-25').valueOf(); // 1548381600000
 Returns the `number` of seconds since the Unix Epoch for the `Dayjs`.
 
 ```js
-dayjs('2019-01-25').unix(); // 1548381600
+dayjs("2019-01-25").unix(); // 1548381600
+```
+
+### UTC Offset (minutes) `.utcOffset()`
+
+Returns the UTC offset in minutes for the `Dayjs`.
+
+```js
+dayjs("2013-03-07T07:00:00+08:00").utcOffset(); // 60
 ```
 
 ### Days in the Month `.daysInMonth()`
@@ -330,7 +341,7 @@ dayjs('2019-01-25').unix(); // 1548381600
 Returns the `number` of days in the `Dayjs`'s month.
 
 ```js
-dayjs('2019-01-25').daysInMonth(); // 31
+dayjs("2019-01-25").daysInMonth(); // 31
 ```
 
 ### As Javascript Date `.toDate()`
@@ -338,7 +349,7 @@ dayjs('2019-01-25').daysInMonth(); // 31
 Returns a copy of the native `Date` object parsed from the `Dayjs` object.
 
 ```js
-dayjs('2019-01-25').toDate();
+dayjs("2019-01-25").toDate();
 ```
 
 ### As Array `.toArray()`
@@ -346,7 +357,7 @@ dayjs('2019-01-25').toDate();
 Returns an `array` that mirrors the parameters from new Date().
 
 ```js
-dayjs('2019-01-25').toArray(); // [ 2019, 0, 25, 0, 0, 0, 0 ]
+dayjs("2019-01-25").toArray(); // [ 2019, 0, 25, 0, 0, 0, 0 ]
 ```
 
 ### As JSON `.toJSON()`
@@ -354,7 +365,7 @@ dayjs('2019-01-25').toArray(); // [ 2019, 0, 25, 0, 0, 0, 0 ]
 Returns the `Dayjs` formatted in an ISO8601 `string`.
 
 ```js
-dayjs('2019-01-25').toJSON(); // '2019-01-25T02:00:00.000Z'
+dayjs("2019-01-25").toJSON(); // '2019-01-25T02:00:00.000Z'
 ```
 
 ### As ISO 8601 String `.toISOString()`
@@ -362,7 +373,7 @@ dayjs('2019-01-25').toJSON(); // '2019-01-25T02:00:00.000Z'
 Returns the `Dayjs` formatted in an ISO8601 `string`.
 
 ```js
-dayjs('2019-01-25').toISOString(); // '2019-01-25T02:00:00.000Z'
+dayjs("2019-01-25").toISOString(); // '2019-01-25T02:00:00.000Z'
 ```
 
 ### As Object `.toObject()`
@@ -370,7 +381,7 @@ dayjs('2019-01-25').toISOString(); // '2019-01-25T02:00:00.000Z'
 Returns an `object` with the date's properties.
 
 ```js
-dayjs('2019-01-25').toObject();
+dayjs("2019-01-25").toObject();
 /* { years: 2019,
      months: 0,
      date: 25,
@@ -385,7 +396,7 @@ dayjs('2019-01-25').toObject();
 Returns a `string` representation of the date.
 
 ```js
-dayjs('2019-01-25').toString(); // 'Fri, 25 Jan 2019 02:00:00 GMT'
+dayjs("2019-01-25").toString(); // 'Fri, 25 Jan 2019 02:00:00 GMT'
 ```
 
 ## Query
@@ -396,7 +407,7 @@ Returns a `boolean` indicating whether the `Dayjs`'s date is before the other su
 
 ```js
 dayjs().isBefore(dayjs()); // false
-dayjs().isBefore(dayjs(), 'year'); // false
+dayjs().isBefore(dayjs(), "year"); // false
 ```
 
 ### Is Same `.isSame(compared: Dayjs, unit?: string)`
@@ -405,7 +416,7 @@ Returns a `boolean` indicating whether the `Dayjs`'s date is the same as the oth
 
 ```js
 dayjs().isSame(dayjs()); // true
-dayjs().isSame(dayjs(), 'year'); // true
+dayjs().isSame(dayjs(), "year"); // true
 ```
 
 ### Is After `.isAfter(compared: Dayjs, unit?: string)`
@@ -414,7 +425,7 @@ Returns a `boolean` indicating whether the `Dayjs`'s date is after the other sup
 
 ```js
 dayjs().isAfter(dayjs()); // false
-dayjs().isAfter(dayjs(), 'year'); // false
+dayjs().isAfter(dayjs(), "year"); // false
 ```
 
 ### Is a Dayjs `.isDayjs(compared: any)`
@@ -429,7 +440,7 @@ dayjs.isDayjs(new Date()); // false
 The operator `instanceof` works equally well:
 
 ```js
-dayjs() instanceof dayjs // true
+dayjs() instanceof dayjs; // true
 ```
 
 ## Plugin APIs

--- a/docs/en/Plugin.md
+++ b/docs/en/Plugin.md
@@ -10,7 +10,7 @@ You can load multiple plugins based on your need.
 
 #### Extend
 
-* Returns dayjs
+- Returns dayjs
 
 Use a plugin.
 
@@ -22,16 +22,17 @@ dayjs.extend(plugin, options) // with plugin options
 
 ## Installation
 
-* Via NPM:
+- Via NPM:
 
 ```javascript
-import dayjs from 'dayjs'
-import AdvancedFormat from 'dayjs/plugin/advancedFormat' // load on demand
+import dayjs from "dayjs";
+import AdvancedFormat from "dayjs/plugin/advancedFormat"; // load on demand
 
-dayjs.extend(AdvancedFormat) // use plugin
+dayjs.extend(AdvancedFormat); // use plugin
 ```
 
-* Via CDN:
+- Via CDN:
+
 ```html
 <script src="https://unpkg.com/dayjs"></script>
 <!-- Load plugin as window.dayjs_plugin_NAME -->
@@ -44,50 +45,52 @@ dayjs.extend(AdvancedFormat) // use plugin
 ## List of official plugins
 
 ### AdvancedFormat
- - AdvancedFormat extends `dayjs().format` API to supply more format options.
+
+- AdvancedFormat extends `dayjs().format` API to supply more format options.
 
 ```javascript
-import advancedFormat from 'dayjs/plugin/advancedFormat'
+import advancedFormat from "dayjs/plugin/advancedFormat";
 
-dayjs.extend(advancedFormat)
+dayjs.extend(advancedFormat);
 
-dayjs().format('Q Do k kk X x')
+dayjs().format("Q Do k kk X x");
 ```
 
 List of added formats:
 
-| Format | Output           | Description                           |
-| ------ | ---------------- | ------------------------------------- |
-| `Q`    | 1-4              | Quarter                               |
-| `Do`   | 1st 2nd ... 31st | Day of Month with ordinal             |
-| `k`    | 1-23             | The hour, beginning at 1              |
-| `kk`   | 01-23            | The hour, 2-digits, beginning at 1    |
-| `X`    | 1360013296       | Unix Timestamp in second              |
-| `x`    | 1360013296123    | Unix Timestamp in millisecond         |
+| Format | Output           | Description                        |
+| ------ | ---------------- | ---------------------------------- |
+| `Q`    | 1-4              | Quarter                            |
+| `Do`   | 1st 2nd ... 31st | Day of Month with ordinal          |
+| `k`    | 1-23             | The hour, beginning at 1           |
+| `kk`   | 01-23            | The hour, 2-digits, beginning at 1 |
+| `X`    | 1360013296       | Unix Timestamp in second           |
+| `x`    | 1360013296123    | Unix Timestamp in millisecond      |
 
 ### RelativeTime
- - RelativeTime adds `.from` `.to` `.fromNow` `.toNow` APIs to formats date to relative time strings (e.g. 3 hours ago).
+
+- RelativeTime adds `.from` `.to` `.fromNow` `.toNow` APIs to formats date to relative time strings (e.g. 3 hours ago).
 
 ```javascript
-import relativeTime from 'dayjs/plugin/relativeTime'
+import relativeTime from "dayjs/plugin/relativeTime";
 
-dayjs.extend(relativeTime)
+dayjs.extend(relativeTime);
 
-dayjs().from(dayjs('1990')) // 2 years ago
-dayjs().from(dayjs(), true) // 2 years
+dayjs().from(dayjs("1990")); // 2 years ago
+dayjs().from(dayjs(), true); // 2 years
 
-dayjs().fromNow()
+dayjs().fromNow();
 
-dayjs().to(dayjs())
+dayjs().to(dayjs());
 
-dayjs().toNow()
+dayjs().toNow();
 ```
 
 #### Time from now `.fromNow(withoutSuffix?: boolean)`
 
 Returns the `string` of relative time from now.
 
-#### Time from X  `.from(compared: Dayjs, withoutSuffix?: boolean)`
+#### Time from X `.from(compared: Dayjs, withoutSuffix?: boolean)`
 
 Returns the `string` of relative time from X.
 
@@ -95,149 +98,170 @@ Returns the `string` of relative time from X.
 
 Returns the `string` of relative time to now.
 
-#### Time to X  `.to(compared: Dayjs, withoutSuffix?: boolean)`
+#### Time to X `.to(compared: Dayjs, withoutSuffix?: boolean)`
 
 Returns the `string` of relative time to X.
 
-| Range                    | Key  | Sample Output                    |
-| ------------------------ | ---- | -------------------------------- |
-| 0 to 44 seconds          | s    | a few seconds ago                |
-| 45 to 89 seconds         | m    | a minute ago                     |
-| 90 seconds to 44 minutes | mm   | 2 minutes ago ... 44 minutes ago |
-| 45 to 89 minutes         | h    | an hour ago                      |
-| 90 minutes to 21 hours   | hh   | 2 hours ago ... 21 hours ago     |
-| 22 to 35 hours           | d    | a day ago                        |
-| 36 hours to 25 days      | dd   | 2 days ago ... 25 days ago       |
-| 26 to 45 days            | M    | a month ago                      |
-| 46 days to 10 months     | MM   | 2 months ago ... 10 months ago   |
-| 11 months to 17months    | y    | a year ago                       |
-| 18 months+               | yy   | 2 years ago ... 20 years ago     |
+| Range                    | Key | Sample Output                    |
+| ------------------------ | --- | -------------------------------- |
+| 0 to 44 seconds          | s   | a few seconds ago                |
+| 45 to 89 seconds         | m   | a minute ago                     |
+| 90 seconds to 44 minutes | mm  | 2 minutes ago ... 44 minutes ago |
+| 45 to 89 minutes         | h   | an hour ago                      |
+| 90 minutes to 21 hours   | hh  | 2 hours ago ... 21 hours ago     |
+| 22 to 35 hours           | d   | a day ago                        |
+| 36 hours to 25 days      | dd  | 2 days ago ... 25 days ago       |
+| 26 to 45 days            | M   | a month ago                      |
+| 46 days to 10 months     | MM  | 2 months ago ... 10 months ago   |
+| 11 months to 17months    | y   | a year ago                       |
+| 18 months+               | yy  | 2 years ago ... 20 years ago     |
 
 ### IsLeapYear
- - IsLeapYear adds `.isLeapYear` API to returns a `boolean` indicating whether the `Dayjs`'s year is a leap year or not.
+
+- IsLeapYear adds `.isLeapYear` API to returns a `boolean` indicating whether the `Dayjs`'s year is a leap year or not.
 
 ```javascript
-import isLeapYear from 'dayjs/plugin/isLeapYear'
+import isLeapYear from "dayjs/plugin/isLeapYear";
 
-dayjs.extend(isLeapYear)
+dayjs.extend(isLeapYear);
 
-dayjs('2000-01-01').isLeapYear(); // true
+dayjs("2000-01-01").isLeapYear(); // true
 ```
 
 ### BuddhistEra
+
 - BuddhistEra extends `dayjs().format` API to supply Buddhist Era (B.E.) format options.
-- Buddhist Era is a year numbering system that primarily used in  mainland Southeast Asian countries of Cambodia, Laos, Myanmar and Thailand as well as in Sri Lanka and Chinese populations of Malaysia and Singapore for religious or official occasions ([Wikipedia](https://en.wikipedia.org/wiki/Buddhist_calendar))
+- Buddhist Era is a year numbering system that primarily used in mainland Southeast Asian countries of Cambodia, Laos, Myanmar and Thailand as well as in Sri Lanka and Chinese populations of Malaysia and Singapore for religious or official occasions ([Wikipedia](https://en.wikipedia.org/wiki/Buddhist_calendar))
 - To calculate BE year manually, just add 543 to year. For example 26 May 1977 AD/CE should display as 26 May 2520 BE (1977 + 543)
 
 ```javascript
-import buddhistEra from 'dayjs/plugin/buddhistEra'
+import buddhistEra from "dayjs/plugin/buddhistEra";
 
-dayjs.extend(buddhistEra)
+dayjs.extend(buddhistEra);
 
-dayjs().format('BBBB BB')
+dayjs().format("BBBB BB");
 ```
 
 List of added formats:
 
-| Format | Output           | Description                           |
-| ------ | ---------------- | ------------------------------------- |
-| `BBBB` | 2561             | Full BE Year (Year + 543)             |
-| `BB`   | 61               | 2-digit of BE Year                    |
+| Format | Output | Description               |
+| ------ | ------ | ------------------------- |
+| `BBBB` | 2561   | Full BE Year (Year + 543) |
+| `BB`   | 61     | 2-digit of BE Year        |
 
 ### WeekOfYear
- - WeekOfYear adds `.week()` API to returns a `number` indicating the `Dayjs`'s week of the year.
+
+- WeekOfYear adds `.week()` API to returns a `number` indicating the `Dayjs`'s week of the year.
 
 ```javascript
-import weekOfYear from 'dayjs/plugin/weekOfYear'
+import weekOfYear from "dayjs/plugin/weekOfYear";
 
-dayjs.extend(weekOfYear)
+dayjs.extend(weekOfYear);
 
-dayjs('06/27/2018').week() // 26
+dayjs("06/27/2018").week(); // 26
 ```
 
 ### IsSameOrAfter
- - IsSameOrAfter adds `.isSameOrAfter()` API to returns a `boolean` indicating if a date is same of after another date.
+
+- IsSameOrAfter adds `.isSameOrAfter()` API to returns a `boolean` indicating if a date is same of after another date.
 
 ```javascript
-import isSameOrAfter from 'dayjs/plugin/isSameOrAfter'
+import isSameOrAfter from "dayjs/plugin/isSameOrAfter";
 
-dayjs.extend(isSameOrAfter)
+dayjs.extend(isSameOrAfter);
 
-dayjs('2010-10-20').isSameOrAfter('2010-10-19', 'year');
+dayjs("2010-10-20").isSameOrAfter("2010-10-19", "year");
 ```
 
 ### IsSameOrBefore
- - IsSameOrBefore adds `.isSameOrBefore()` API to returns a `boolean` indicating if a date is same of before another date.
+
+- IsSameOrBefore adds `.isSameOrBefore()` API to returns a `boolean` indicating if a date is same of before another date.
 
 ```javascript
-import isSameOrBefore from 'dayjs/plugin/isSameOrBefore'
+import isSameOrBefore from "dayjs/plugin/isSameOrBefore";
 
-dayjs.extend(isSameOrBefore)
+dayjs.extend(isSameOrBefore);
 
-dayjs('2010-10-20').isSameOrBefore('2010-10-19', 'year');
+dayjs("2010-10-20").isSameOrBefore("2010-10-19", "year");
 ```
 
 ### IsBetween
- - IsBetween adds `.isBetween()` API to returns a `boolean` indicating if a date is between two other dates.
+
+- IsBetween adds `.isBetween()` API to returns a `boolean` indicating if a date is between two other dates.
 
 ```javascript
-import isBetween from 'dayjs/plugin/isBetween'
+import isBetween from "dayjs/plugin/isBetween";
 
-dayjs.extend(isBetween)
+dayjs.extend(isBetween);
 
-dayjs('2010-10-20').isBetween('2010-10-19', dayjs('2010-10-25'), 'year');
+dayjs("2010-10-20").isBetween("2010-10-19", dayjs("2010-10-25"), "year");
 ```
 
 ### QuarterOfYear
+
 - QuarterOfYear add `.quarter()` API to return to which quarter of the year belongs a date
 
 ```javascript
-import quarterOfYear from 'dayjs/plugin/quarterOfYear'
+import quarterOfYear from "dayjs/plugin/quarterOfYear";
 
-dayjs.extend(quarterOfYear)
+dayjs.extend(quarterOfYear);
 
-dayjs('2010-04-01').quarter(); // 2
+dayjs("2010-04-01").quarter(); // 2
 ```
 
 ### CustomParseFormat
- - CustomParseFormat extends `dayjs()` constructor to support custom formats of input strings.
+
+- CustomParseFormat extends `dayjs()` constructor to support custom formats of input strings.
 
 To escape characters, wrap them in square brackets (e.g. `[G]`). Punctuation symbols (-:/.()) do not need to be wrapped.
 
 ```javascript
-import customParseFormat from 'dayjs/plugin/customParseFormat'
+import customParseFormat from "dayjs/plugin/customParseFormat";
 
-dayjs.extend(customParseFormat)
+dayjs.extend(customParseFormat);
 
-dayjs('05/02/69 1:02:03 PM -05:00', 'MM/DD/YY H:mm:ss A Z')
+dayjs("05/02/69 1:02:03 PM -05:00", "MM/DD/YY H:mm:ss A Z");
 // Returns an instance containing '1969-05-02T18:02:03.000Z'
 ```
 
 #### List of all available format tokens
 
-| Format | Output           | Description                       |
-| ------ | ---------------- | --------------------------------- |
-| `YY`   | 18               | Two-digit year                    |
-| `YYYY` | 2018             | Four-digit year                   |
-| `M`    | 1-12             | Month, beginning at 1             |
-| `MM`   | 01-12            | Month, 2-digits                   |
-| `D`    | 1-31             | Day of month                      |
-| `DD`   | 01-31            | Day of month, 2-digits            |
-| `H`    | 0-23             | Hours                             |
-| `HH`   | 00-23            | Hours, 2-digits                   |
-| `h`    | 1-12             | Hours, 12-hour clock              |
-| `hh`   | 01-12            | Hours, 12-hour clock, 2-digits    |
-| `m`    | 0-59             | Minutes                           |
-| `mm`   | 00-59            | Minutes, 2-digits                 |
-| `s`    | 0-59             | Seconds                           |
-| `ss`   | 00-59            | Seconds, 2-digits                 |
-| `S`    | 0-9              | Hundreds of milliseconds, 1-digit |
-| `SS`   | 00-99            | Tens of milliseconds, 2-digits    |
-| `SSS`  | 000-999          | Milliseconds, 3-digits            |
-| `Z`    | -5:00            | Offset from UTC                   |
-| `ZZ`   | -0500            | Compact offset from UTC, 2-digits |
-| `A`    | AM PM            | Post or ante meridiem, upper-case |
-| `a`    | am pm            | Post or ante meridiem, lower-case |
+| Format | Output  | Description                       |
+| ------ | ------- | --------------------------------- |
+| `YY`   | 18      | Two-digit year                    |
+| `YYYY` | 2018    | Four-digit year                   |
+| `M`    | 1-12    | Month, beginning at 1             |
+| `MM`   | 01-12   | Month, 2-digits                   |
+| `D`    | 1-31    | Day of month                      |
+| `DD`   | 01-31   | Day of month, 2-digits            |
+| `H`    | 0-23    | Hours                             |
+| `HH`   | 00-23   | Hours, 2-digits                   |
+| `h`    | 1-12    | Hours, 12-hour clock              |
+| `hh`   | 01-12   | Hours, 12-hour clock, 2-digits    |
+| `m`    | 0-59    | Minutes                           |
+| `mm`   | 00-59   | Minutes, 2-digits                 |
+| `s`    | 0-59    | Seconds                           |
+| `ss`   | 00-59   | Seconds, 2-digits                 |
+| `S`    | 0-9     | Hundreds of milliseconds, 1-digit |
+| `SS`   | 00-99   | Tens of milliseconds, 2-digits    |
+| `SSS`  | 000-999 | Milliseconds, 3-digits            |
+| `Z`    | -5:00   | Offset from UTC                   |
+| `ZZ`   | -0500   | Compact offset from UTC, 2-digits |
+| `A`    | AM PM   | Post or ante meridiem, upper-case |
+| `a`    | am pm   | Post or ante meridiem, lower-case |
+
+### DaysInYear
+
+- DaysInYear add `.daysInYear()` API to return how many days has the `daysjs` instance year
+
+```javascript
+import daysInYear from "dayjs/plugin/daysInYear";
+
+dayjs.extend(daysInYear);
+
+dayjs("2010-01-01").daysInYear(); // 365
+dayjs("2012-01-01").daysInYear(); // 366
+```
 
 ## Customize
 
@@ -246,23 +270,24 @@ You could build your own Day.js plugin to meet different needs.
 Feel free to open a pull request to share your plugin.
 
 Template of a Day.js plugin.
+
 ```javascript
 export default (option, dayjsClass, dayjsFactory) => {
   // extend dayjs()
   // e.g. add dayjs().isSameOrBefore()
-  dayjsClass.prototype.isSameOrBefore = function (arguments) {}
+  dayjsClass.prototype.isSameOrBefore = function(arguments) {};
 
   // extend dayjs
   // e.g. add dayjs.utc()
-  dayjsFactory.utc = (arguments) => {}
+  dayjsFactory.utc = arguments => {};
 
   // overriding existing API
   // e.g. extend dayjs().format()
-  const oldFormat = dayjsClass.prototype.format
-  dayjsClass.prototype.format = function (arguments) {
+  const oldFormat = dayjsClass.prototype.format;
+  dayjsClass.prototype.format = function(arguments) {
     // original format result
-    const result = oldFormat(arguments)
+    const result = oldFormat(arguments);
     // return modified result
-  }
-}
+  };
+};
 ```

--- a/docs/es-es/API-reference.md
+++ b/docs/es-es/API-reference.md
@@ -36,6 +36,7 @@ El objeto `Dayjs` es inmutable, por lo que toda operación de la API que altere 
     - [Diferencia `.diff(compared: Dayjs, unit: string (predeterminada: 'milliseconds'), float?: boolean)`](#diferencia-diffcompared-dayjs-unit-string-predeterminada-milliseconds-float-boolean)
     - [Tiempo Unix (milisegundos) `.valueOf()`](#tiempo-unix-milisegundos-valueof)
     - [Tiempo Unix (segundos) `.unix()`](#tiempo-unix-segundos-unix)
+    - [UTC offset (minutos) `.utcOffset()`](#utc-offset-minutos-utcoffset)
     - [Días en el mes `.daysInMonth()`](#días-en-el-mes-daysinmonth)
     - [Como objeto `Date` `.toDate()`](#como-objeto-date-todate)
     - [Como array `.toArray()`](#como-array-toarray)
@@ -72,7 +73,7 @@ Day.js también analiza otros formatos de fecha.
 #### Cadena [ISO 8601](https://es.wikipedia.org/wiki/ISO_8601)
 
 ```js
-dayjs('2018-04-04T16:00:00.000Z');
+dayjs("2018-04-04T16:00:00.000Z");
 ```
 
 #### Objeto `Date` nativo
@@ -99,7 +100,8 @@ dayjs.unix(1318781876.721);
 ```
 
 ### Custom Parse Format
-* parse custom formats `dayjs("12-25-1995", "MM-DD-YYYY")` in plugin [`CustomParseFormat`](./Plugin.md#customparseformat)
+
+- parse custom formats `dayjs("12-25-1995", "MM-DD-YYYY")` in plugin [`CustomParseFormat`](./Plugin.md#customparseformat)
 
 ### Clonar `.clone() | dayjs(original: Dayjs)`
 
@@ -107,7 +109,7 @@ Devuelve una copia de `Dayjs`.
 
 ```js
 dayjs().clone();
-dayjs(dayjs('2019-01-25')); // si el constructor recibe un objeto Dayjs también lo clonará
+dayjs(dayjs("2019-01-25")); // si el constructor recibe un objeto Dayjs también lo clonará
 ```
 
 ### Validación `.isValid()`
@@ -189,15 +191,15 @@ dayjs().millisecond();
 Devuelve un nuevo objeto `Dayjs` con los cambios aplicados.
 
 ```js
-dayjs().set('date', 1);
-dayjs().set('month', 3); // Abril
-dayjs().set('second', 30);
+dayjs().set("date", 1);
+dayjs().set("month", 3); // Abril
+dayjs().set("second", 30);
 ```
 
 #### Lista de unidades disponibles
 
 | Unit          | Abreviatura | Descripción                                 |
-| ------------- | ----------- | ------------------------------------------  |
+| ------------- | ----------- | ------------------------------------------- |
 | `date`        |             | Día del mes                                 |
 | `day`         | `d`         | Día de la semana (de domingo 0, a sábado 6) |
 | `month`       | `M`         | Mes                                         |
@@ -212,9 +214,10 @@ dayjs().set('second', 30);
 Los objetos `Dayjs` pueden manipularse de diversas formas.
 
 ```js
-dayjs('2019-01-25')
-  .add(1, 'day')
-  .subtract(1, 'year').toString(); // Fri, 26 Jan 2018 00:00:00 GMT
+dayjs("2019-01-25")
+  .add(1, "day")
+  .subtract(1, "year")
+  .toString(); // Fri, 26 Jan 2018 00:00:00 GMT
 ```
 
 ### Añadir `.add(value: number, unit: string)`
@@ -222,7 +225,7 @@ dayjs('2019-01-25')
 Devuelve un nuevo objeto `Dayjs`, resultante de añadir al actual el tiempo indicado.
 
 ```js
-dayjs().add(7, 'day');
+dayjs().add(7, "day");
 ```
 
 ### Restar `.subtract(value: number, unit: string)`
@@ -230,7 +233,7 @@ dayjs().add(7, 'day');
 Devuelve un nuevo objeto `Dayjs`, resultante de restar al actual el tiempo indicado.
 
 ```js
-dayjs().subtract(7, 'year');
+dayjs().subtract(7, "year");
 ```
 
 ### Principio de `.startOf(unit: string)`
@@ -238,7 +241,7 @@ dayjs().subtract(7, 'year');
 Devuelve un nuevo objeto `Dayjs`, resultante de ajustar el actual al principio de la unidad de tiempo indicada.
 
 ```js
-dayjs().startOf('week');
+dayjs().startOf("week");
 ```
 
 ### Fin de `.endOf(unit: string)`
@@ -246,7 +249,7 @@ dayjs().startOf('week');
 Devuelve un nuevo objeto `Dayjs`, resultante de ajustar el actual al final de la unidad de tiempo indicada.
 
 ```js
-dayjs().endOf('month');
+dayjs().endOf("month");
 ```
 
 ## Presentación
@@ -259,40 +262,40 @@ Para escapar caracteres, estos se han de encerrar entre corchetes o llaves (p.ej
 ```js
 dayjs().format(); // fecha actual en ISO6801, sin fracciones de segundo p.ej. '2020-04-02T08:02:17-05:00'
 
-dayjs('2019-01-25').format('{YYYY} MM-DDTHH:mm:ssZ[Z]'); // '{2019} 01-25T00:00:00-02:00Z'
+dayjs("2019-01-25").format("{YYYY} MM-DDTHH:mm:ssZ[Z]"); // '{2019} 01-25T00:00:00-02:00Z'
 
-dayjs('2019-01-25').format('DD/MM/YYYY'); // '25/01/2019'
+dayjs("2019-01-25").format("DD/MM/YYYY"); // '25/01/2019'
 ```
 
 #### Lista de formatos disponibles
 
-| Formato | Salida           | Descripción                               |
-| ------- | ---------------- | ----------------------------------------- |
-| `YY`    | 18               | Año, con 2 dígitos                        |
-| `YYYY`  | 2018             | Año, con 4 dígitos                        |
-| `M`     | 1-12             | Mes, contando desde 1                     |
-| `MM`    | 01-12            | Mes, con 2 dígitos                        |
-| `MMM`   | Jan-Dec          | Nombre abreviado del mes                  |
-| `MMMM`  | January-December | Nombre completo del mes                   |
-| `D`     | 1-31             | Día del mes                               |
-| `DD`    | 01-31            | Día del mes, con 2 dígitos                |
-| `d`     | 0-6              | Día de la semana, siendo el domingo el 0  |
-| `dd`    | Su-Sa            | Nombre mínimo del día de la semana        |
-| `ddd`   | Sun-Sat          | Nombre abreviado del día de la semana     |
-| `dddd`  | Sunday-Saturday  | Nombre del día de la semana               |
-| `H`     | 0-23             | Hora                                      |
-| `HH`    | 00-23            | Hora, con 2 dígitos                       |
-| `h`     | 1-12             | Hora, formato de 12 horas                 |
-| `hh`    | 01-12            | Hora, formato de 12 horas, con 2 dígitos  |
-| `m`     | 0-59             | Minutos                                   |
-| `mm`    | 00-59            | Minutos, con 2 dígitos                    |
-| `s`     | 0-59             | Segundos                                  |
-| `ss`    | 00-59            | Segundos, con 2 dígitos                   |
-| `SSS`   | 000-999          | Milisegundos, con 3 dígitos               |
-| `Z`     | +5:00            | Diferencia horaria UTC                    |
-| `ZZ`    | +0500            | Diferencia horaria UTC, con 2 dígitos     |
-| `A`     | AM PM            |                                           |
-| `a`     | am pm            |                                           |
+| Formato | Salida           | Descripción                              |
+| ------- | ---------------- | ---------------------------------------- |
+| `YY`    | 18               | Año, con 2 dígitos                       |
+| `YYYY`  | 2018             | Año, con 4 dígitos                       |
+| `M`     | 1-12             | Mes, contando desde 1                    |
+| `MM`    | 01-12            | Mes, con 2 dígitos                       |
+| `MMM`   | Jan-Dec          | Nombre abreviado del mes                 |
+| `MMMM`  | January-December | Nombre completo del mes                  |
+| `D`     | 1-31             | Día del mes                              |
+| `DD`    | 01-31            | Día del mes, con 2 dígitos               |
+| `d`     | 0-6              | Día de la semana, siendo el domingo el 0 |
+| `dd`    | Su-Sa            | Nombre mínimo del día de la semana       |
+| `ddd`   | Sun-Sat          | Nombre abreviado del día de la semana    |
+| `dddd`  | Sunday-Saturday  | Nombre del día de la semana              |
+| `H`     | 0-23             | Hora                                     |
+| `HH`    | 00-23            | Hora, con 2 dígitos                      |
+| `h`     | 1-12             | Hora, formato de 12 horas                |
+| `hh`    | 01-12            | Hora, formato de 12 horas, con 2 dígitos |
+| `m`     | 0-59             | Minutos                                  |
+| `mm`    | 00-59            | Minutos, con 2 dígitos                   |
+| `s`     | 0-59             | Segundos                                 |
+| `ss`    | 00-59            | Segundos, con 2 dígitos                  |
+| `SSS`   | 000-999          | Milisegundos, con 3 dígitos              |
+| `Z`     | +5:00            | Diferencia horaria UTC                   |
+| `ZZ`    | +0500            | Diferencia horaria UTC, con 2 dígitos    |
+| `A`     | AM PM            |                                          |
+| `a`     | am pm            |                                          |
 
 \* Más formatos disponibles `Q Do k kk X x ...` con el complemento [`AdvancedFormat`](./Plugin.md#advancedformat)
 
@@ -301,12 +304,12 @@ dayjs('2019-01-25').format('DD/MM/YYYY'); // '25/01/2019'
 Devuelve un dato de tipo `number`, que indica la diferencia existente entre dos objetos `Dayjs`, expresada en la unidad de tiempo dada.
 
 ```js
-const date1 = dayjs('2019-01-25');
-const date2 = dayjs('2018-06-05');
+const date1 = dayjs("2019-01-25");
+const date2 = dayjs("2018-06-05");
 date1.diff(date2); // 20214000000
-date1.diff(date2, 'month'); // 7
-date1.diff(date2, 'month', true); // 7.645161290322581
-date1.diff(date2, 'day'); // 233
+date1.diff(date2, "month"); // 7
+date1.diff(date2, "month", true); // 7.645161290322581
+date1.diff(date2, "day"); // 233
 ```
 
 ### Tiempo Unix (milisegundos) `.valueOf()`
@@ -314,7 +317,7 @@ date1.diff(date2, 'day'); // 233
 Devuelve un dato de tipo `number`, que indica el número de milisegundos transcurridos desde la época Unix para el objeto `Dayjs`.
 
 ```js
-dayjs('2019-01-25').valueOf(); // 1548381600000
+dayjs("2019-01-25").valueOf(); // 1548381600000
 ```
 
 ### Tiempo Unix (segundos) `.unix()`
@@ -322,7 +325,15 @@ dayjs('2019-01-25').valueOf(); // 1548381600000
 Devuelve un dato de tipo `number`, que indica el número de segundos transcurridos desde la época Unix para el objeto `Dayjs`.
 
 ```js
-dayjs('2019-01-25').unix(); // 1548381600
+dayjs("2019-01-25").unix(); // 1548381600
+```
+
+### UTC Offset (minutos) `.utcOffset()`
+
+Devuelve el UTC offset en minutos del `Dayjs`.
+
+```js
+dayjs("2013-03-07T07:00:00+08:00").utcOffset(); // 60
 ```
 
 ### Días en el mes `.daysInMonth()`
@@ -330,7 +341,7 @@ dayjs('2019-01-25').unix(); // 1548381600
 Devuelve un dato de tipo `number`, que indica el número de días contenidos en el mes del objeto `Dayjs`.
 
 ```js
-dayjs('2019-01-25').daysInMonth(); // 31
+dayjs("2019-01-25").daysInMonth(); // 31
 ```
 
 ### Como objeto `Date` `.toDate()`
@@ -338,7 +349,7 @@ dayjs('2019-01-25').daysInMonth(); // 31
 Devuelve un objeto `Date` nativo, obtenido a partir del objeto `Dayjs`.
 
 ```js
-dayjs('2019-01-25').toDate();
+dayjs("2019-01-25").toDate();
 ```
 
 ### Como array `.toArray()`
@@ -346,7 +357,7 @@ dayjs('2019-01-25').toDate();
 Devuelve un array que reproduce los parámetros de `new Date()`.
 
 ```js
-dayjs('2019-01-25').toArray(); // [ 2019, 0, 25, 0, 0, 0, 0 ]
+dayjs("2019-01-25").toArray(); // [ 2019, 0, 25, 0, 0, 0, 0 ]
 ```
 
 ### Como JSON `.toJSON()`
@@ -354,7 +365,7 @@ dayjs('2019-01-25').toArray(); // [ 2019, 0, 25, 0, 0, 0, 0 ]
 Devuelve un objeto `Dayjs` formateado como una cadena ISO8601.
 
 ```js
-dayjs('2019-01-25').toJSON(); // '2019-01-25T02:00:00.000Z'
+dayjs("2019-01-25").toJSON(); // '2019-01-25T02:00:00.000Z'
 ```
 
 ### Como cadena ISO 8601 `.toISOString()`
@@ -362,7 +373,7 @@ dayjs('2019-01-25').toJSON(); // '2019-01-25T02:00:00.000Z'
 Devuelve un objeto `Dayjs` formateado como una cadena ISO8601.
 
 ```js
-dayjs('2019-01-25').toISOString(); // '2019-01-25T02:00:00.000Z'
+dayjs("2019-01-25").toISOString(); // '2019-01-25T02:00:00.000Z'
 ```
 
 ### Como objecto `.toObject()`
@@ -370,7 +381,7 @@ dayjs('2019-01-25').toISOString(); // '2019-01-25T02:00:00.000Z'
 Devuelve un dato de tipo `object`, con las propiedades de la fecha.
 
 ```js
-dayjs('2019-01-25').toObject();
+dayjs("2019-01-25").toObject();
 /* { years: 2019,
      months: 0,
      date: 25,
@@ -385,7 +396,7 @@ dayjs('2019-01-25').toObject();
 Devuelve un dato de tipo `string`, que representa la fecha.
 
 ```js
-dayjs('2019-01-25').toString(); // 'Fri, 25 Jan 2019 02:00:00 GMT'
+dayjs("2019-01-25").toString(); // 'Fri, 25 Jan 2019 02:00:00 GMT'
 ```
 
 ## Consulta
@@ -396,7 +407,7 @@ Devuelve un dato de tipo `boolean`, que indica si la fecha del objeto `Dayjs` in
 
 ```js
 dayjs().isBefore(dayjs()); // false
-dayjs().isBefore(dayjs(), 'year'); // false
+dayjs().isBefore(dayjs(), "year"); // false
 ```
 
 ### Igual que `.isSame(compared: Dayjs, unit?: string)`
@@ -405,7 +416,7 @@ Devuelve un dato de tipo `boolean`, que indica si la fecha del objeto `Dayjs` in
 
 ```js
 dayjs().isSame(dayjs()); // true
-dayjs().isSame(dayjs(), 'year'); // true
+dayjs().isSame(dayjs(), "year"); // true
 ```
 
 ### Posterior a `.isAfter(compared: Dayjs, unit?: string)`
@@ -414,7 +425,7 @@ Devuelve un dato de tipo `boolean`, que indica si la fecha del objeto `Dayjs` in
 
 ```js
 dayjs().isAfter(dayjs()); // false
-dayjs().isAfter(dayjs(), 'year'); // false
+dayjs().isAfter(dayjs(), "year"); // false
 ```
 
 ### Es Dayjs `.isDayjs(compared: any)`
@@ -429,7 +440,7 @@ dayjs.isDayjs(new Date()); // false
 The operator `instanceof` works equally well:
 
 ```js
-dayjs() instanceof dayjs // true
+dayjs() instanceof dayjs; // true
 ```
 
 ## API de complementos

--- a/docs/es-es/Plugin.md
+++ b/docs/es-es/Plugin.md
@@ -1,6 +1,6 @@
 # Lista de complementos
 
-Un complemento o *plugin* es un módulo independiente que puede añadirse a Day.js para extender su funcionalidad o añadir nuevas características.
+Un complemento o _plugin_ es un módulo independiente que puede añadirse a Day.js para extender su funcionalidad o añadir nuevas características.
 
 Por defecto, Day.js viene sin ningún complemento preinstalado, incluyendo únicamente el núcleo de la librería.
 
@@ -10,7 +10,7 @@ Puedes cargar diversos complementos según tus necesidades.
 
 ### Extend
 
-* Devuelve un objeto dayjs
+- Devuelve un objeto dayjs
 
 Método para declarar el uso de un complemento.
 
@@ -22,16 +22,16 @@ dayjs.extend(nombreComplemento, options) // uso del complemento con opciones
 
 ## Instalación
 
-* Vía NPM:
+- Vía NPM:
 
 ```javascript
-import dayjs from 'dayjs'
-import AdvancedFormat from 'dayjs/plugin/advancedFormat' // carga bajo demanda
+import dayjs from "dayjs";
+import AdvancedFormat from "dayjs/plugin/advancedFormat"; // carga bajo demanda
 
-dayjs.extend(AdvancedFormat) // uso del complemento
+dayjs.extend(AdvancedFormat); // uso del complemento
 ```
 
-* Vía CDN:
+- Vía CDN:
 
 ```html
 <script src="https://unpkg.com/dayjs"></script>
@@ -46,44 +46,44 @@ dayjs.extend(AdvancedFormat) // uso del complemento
 
 ### AdvancedFormat
 
-* AdvancedFormat extiende la API `dayjs().format` para proporcionar más opciones de formato.
+- AdvancedFormat extiende la API `dayjs().format` para proporcionar más opciones de formato.
 
 ```javascript
-import advancedFormat from 'dayjs/plugin/advancedFormat'
+import advancedFormat from "dayjs/plugin/advancedFormat";
 
-dayjs.extend(advancedFormat)
+dayjs.extend(advancedFormat);
 
-dayjs().format('Q Do k kk X x')
+dayjs().format("Q Do k kk X x");
 ```
 
 Lista de formatos añadidos:
 
-| Formato | Salida           | Descripción                           |
-| ------- | ---------------- | ------------------------------------- |
-| `Q`     | 1-4              | Cuarto                                |
-| `Do`    | 1º 2º ... 31º    | Día del mes con ordinal               |
-| `k`     | 1-23             | Hora, contando desde 1                |
-| `kk`    | 01-23            | Hora, con 2 dígitos, contando desde 1 |
-| `X`     | 1360013296       | Tiempo Unix en segundos               |
-| `x`     | 1360013296123    | Tiempo Unix en milisegundos           |
+| Formato | Salida        | Descripción                           |
+| ------- | ------------- | ------------------------------------- |
+| `Q`     | 1-4           | Cuarto                                |
+| `Do`    | 1º 2º ... 31º | Día del mes con ordinal               |
+| `k`     | 1-23          | Hora, contando desde 1                |
+| `kk`    | 01-23         | Hora, con 2 dígitos, contando desde 1 |
+| `X`     | 1360013296    | Tiempo Unix en segundos               |
+| `x`     | 1360013296123 | Tiempo Unix en milisegundos           |
 
 ### RelativeTime
 
-* RelativeTime añade las API `.from` `.to` `.fromNow` `.toNow` para dar formato de tiempo relativo a fechas (p.ej.: hace 3 horas).
+- RelativeTime añade las API `.from` `.to` `.fromNow` `.toNow` para dar formato de tiempo relativo a fechas (p.ej.: hace 3 horas).
 
 ```javascript
-import relativeTime from 'dayjs/plugin/relativeTime'
+import relativeTime from "dayjs/plugin/relativeTime";
 
-dayjs.extend(relativeTime)
+dayjs.extend(relativeTime);
 
-dayjs().from(dayjs('1990')) // hace 2 años
-dayjs().from(dayjs(), true) // 2 años
+dayjs().from(dayjs("1990")); // hace 2 años
+dayjs().from(dayjs(), true); // 2 años
 
-dayjs().fromNow()
+dayjs().fromNow();
 
-dayjs().to(dayjs())
+dayjs().to(dayjs());
 
-dayjs().toNow()
+dayjs().toNow();
 ```
 
 #### Tiempo desde ahora `.fromNow(withoutSuffix?: boolean)`
@@ -98,150 +98,167 @@ Devuelve un dato de tipo `string`, con el tiempo relativo desde el instante X.
 
 Devuelve dato de tipo `string`, con el tiempo relativo transcurrido desde la fecha representada por el objeto `Dayjs` dado hasta el instante actual.
 
-#### Tiempo hasta X  `.to(compared: Dayjs, withoutSuffix?: boolean)`
+#### Tiempo hasta X `.to(compared: Dayjs, withoutSuffix?: boolean)`
 
 Devuelve dato de tipo `string`, con el tiempo relativo transcurrido desde la fecha representada por el objeto `Dayjs` dado hasta el instante X especificado.
 
-| Rango                        | Clave  | Ejemplo de salida                  |
-| ---------------------------- | ------ | ---------------------------------- |
-| de 0 a 44 segundos           | s      | hace unos segundos                 |
-| de 45 a 89 segundos          | m      | hace un minuto                     |
-| de 90 segundos a 44 minutos  | mm     | hace 2 minutos ... hace 44 minutos |
-| de 45 a 89 minutos           | h      | hace una hora                      |
-| de 90 minutos a 21 horas     | hh     | hace 2 horas ... hace 21 horas     |
-| de 22 a 35 horas             | d      | hace un día                        |
-| de 36 horas a 25 días        | dd     | hace 2 días ... hace 25 días       |
-| de 26 a 45 días              | M      | hace un mes                        |
-| de 46 días a 10 meses        | MM     | hace 2 meses ... hace 10 meses     |
-| de 11 a 17 meses             | y      | hace un año                        |
-| más de 18 meses              | yy     | hace 2 años ... hace 20 años       |
+| Rango                       | Clave | Ejemplo de salida                  |
+| --------------------------- | ----- | ---------------------------------- |
+| de 0 a 44 segundos          | s     | hace unos segundos                 |
+| de 45 a 89 segundos         | m     | hace un minuto                     |
+| de 90 segundos a 44 minutos | mm    | hace 2 minutos ... hace 44 minutos |
+| de 45 a 89 minutos          | h     | hace una hora                      |
+| de 90 minutos a 21 horas    | hh    | hace 2 horas ... hace 21 horas     |
+| de 22 a 35 horas            | d     | hace un día                        |
+| de 36 horas a 25 días       | dd    | hace 2 días ... hace 25 días       |
+| de 26 a 45 días             | M     | hace un mes                        |
+| de 46 días a 10 meses       | MM    | hace 2 meses ... hace 10 meses     |
+| de 11 a 17 meses            | y     | hace un año                        |
+| más de 18 meses             | yy    | hace 2 años ... hace 20 años       |
 
 ### IsLeapYear
 
-* IsLeapYear añade la API `.isLeapYear`, que devuelve un dato de tipo `boolean` indicando si el año del objeto `Dayjs` es bisiesto o no.
+- IsLeapYear añade la API `.isLeapYear`, que devuelve un dato de tipo `boolean` indicando si el año del objeto `Dayjs` es bisiesto o no.
 
 ```javascript
-import isLeapYear from 'dayjs/plugin/isLeapYear'
+import isLeapYear from "dayjs/plugin/isLeapYear";
 
-dayjs.extend(isLeapYear)
+dayjs.extend(isLeapYear);
 
-dayjs('2000-01-01').isLeapYear(); // true
+dayjs("2000-01-01").isLeapYear(); // true
 ```
 
 ### BuddhistEra
 
-* BuddhistEra extiende la API `dayjs().format` para añadir opciones de formato relacionadas con la Era Budista (B.E.)
-* La Era Budista es un sistema de numeración anual, usado principalmente en los países del sudeste del continente asiático: Camboya, Laos, Birmania y Tailandia,así como en Sri Lanka y entre la población china de Malasia y Singapur, por razones religiosas o en eventos oficiales ([Wikipedia](https://en.wikipedia.org/wiki/Buddhist_calendar))
-* Para calcular manualmente el año de la BE tan sólo hemos de sumar 543 al año. Por ejemplo, el 26 Mayo 1977 AD/EC debe mostrarse como 26 Mayo 2520 BE (1977 + 543)
+- BuddhistEra extiende la API `dayjs().format` para añadir opciones de formato relacionadas con la Era Budista (B.E.)
+- La Era Budista es un sistema de numeración anual, usado principalmente en los países del sudeste del continente asiático: Camboya, Laos, Birmania y Tailandia,así como en Sri Lanka y entre la población china de Malasia y Singapur, por razones religiosas o en eventos oficiales ([Wikipedia](https://en.wikipedia.org/wiki/Buddhist_calendar))
+- Para calcular manualmente el año de la BE tan sólo hemos de sumar 543 al año. Por ejemplo, el 26 Mayo 1977 AD/EC debe mostrarse como 26 Mayo 2520 BE (1977 + 543)
 
 ```javascript
-import buddhistEra from 'dayjs/plugin/buddhistEra'
+import buddhistEra from "dayjs/plugin/buddhistEra";
 
-dayjs.extend(buddhistEra)
+dayjs.extend(buddhistEra);
 
-dayjs().format('BBBB BB')
+dayjs().format("BBBB BB");
 ```
 
 Lista de formatos añadidos:
 
-| Formato | Salida           | Descripción                           |
-| ------- | ---------------- | ------------------------------------- |
-| `BBBB`  | 2561             | Año BE completo (Año + 543)           |
-| `BB`    | 61               | Año BE con 2 dígitos                  |
+| Formato | Salida | Descripción                 |
+| ------- | ------ | --------------------------- |
+| `BBBB`  | 2561   | Año BE completo (Año + 543) |
+| `BB`    | 61     | Año BE con 2 dígitos        |
 
 ### WeekOfYear
 
-* WeekOfYear añade la API `.week()`, que devuelve un dato de tipo `number` indicando la semana del año correspondiente a la fecha del objeto `Dayjs`.
+- WeekOfYear añade la API `.week()`, que devuelve un dato de tipo `number` indicando la semana del año correspondiente a la fecha del objeto `Dayjs`.
 
 ```javascript
-import weekOfYear from 'dayjs/plugin/weekOfYear'
+import weekOfYear from "dayjs/plugin/weekOfYear";
 
-dayjs.extend(weekOfYear)
+dayjs.extend(weekOfYear);
 
-dayjs('06/27/2018').week() // 26
+dayjs("06/27/2018").week(); // 26
 ```
 
 ### IsSameOrAfter
- - IsSameOrAfter adds `.isSameOrAfter()` API to returns a `boolean` indicating if a date is same of after another date.
+
+- IsSameOrAfter adds `.isSameOrAfter()` API to returns a `boolean` indicating if a date is same of after another date.
 
 ```javascript
-import isSameOrAfter from 'dayjs/plugin/isSameOrAfter'
+import isSameOrAfter from "dayjs/plugin/isSameOrAfter";
 
-dayjs.extend(isSameOrAfter)
+dayjs.extend(isSameOrAfter);
 
-dayjs('2010-10-20').isSameOrAfter('2010-10-19', 'year');
+dayjs("2010-10-20").isSameOrAfter("2010-10-19", "year");
 ```
 
 ### IsSameOrBefore
- - IsSameOrBefore adds `.isSameOrBefore()` API to returns a `boolean` indicating if a date is same of before another date.
+
+- IsSameOrBefore adds `.isSameOrBefore()` API to returns a `boolean` indicating if a date is same of before another date.
 
 ```javascript
-import isSameOrBefore from 'dayjs/plugin/isSameOrBefore'
+import isSameOrBefore from "dayjs/plugin/isSameOrBefore";
 
-dayjs.extend(isSameOrBefore)
+dayjs.extend(isSameOrBefore);
 
-dayjs('2010-10-20').isSameOrBefore('2010-10-19', 'year');
+dayjs("2010-10-20").isSameOrBefore("2010-10-19", "year");
 ```
 
 ### IsBetween
 
-* IsBetween añade la API `.isBetween()`, que devuelve un dato de tipo `boolean` indicando si una fecha se encuentra o no entre otras dos dadas.
+- IsBetween añade la API `.isBetween()`, que devuelve un dato de tipo `boolean` indicando si una fecha se encuentra o no entre otras dos dadas.
 
 ```javascript
-import isBetween from 'dayjs/plugin/isBetween'
+import isBetween from "dayjs/plugin/isBetween";
 
-dayjs.extend(isBetween)
+dayjs.extend(isBetween);
 
-dayjs('2010-10-20').isBetween('2010-10-19', dayjs('2010-10-25'), 'year');
+dayjs("2010-10-20").isBetween("2010-10-19", dayjs("2010-10-25"), "year");
 ```
 
 ### QuarterOfYear
+
 - QuarterOfYear añade a la API `.quarter()` para devolver a que cuarto del año pertenece una fecha
 
 ```javascript
-import quarterOfYear from 'dayjs/plugin/quarterOfYear'
+import quarterOfYear from "dayjs/plugin/quarterOfYear";
 
-dayjs.extend(quarterOfYear)
+dayjs.extend(quarterOfYear);
 
-dayjs('2010-04-01').quarter(); // 2
+dayjs("2010-04-01").quarter(); // 2
 ```
 
 ### QuarterOfYear
+
 - QuarterOfYear add `.quarter()` API to return to which quarter of the year belongs a date
 
 ```javascript
-import quarterOfYear from 'dayjs/plugin/quarterOfYear'
+import quarterOfYear from "dayjs/plugin/quarterOfYear";
 
-dayjs.extend(quarterOfYear)
+dayjs.extend(quarterOfYear);
 
-dayjs('2010-04-01').quarter(); // 2
+dayjs("2010-04-01").quarter(); // 2
 ```
 
 #### List of all available format tokens
 
-| Format | Output           | Description                       |
-| ------ | ---------------- | --------------------------------- |
-| `YY`   | 18               | Two-digit year                    |
-| `YYYY` | 2018             | Four-digit year                   |
-| `M`    | 1-12             | Month, beginning at 1             |
-| `MM`   | 01-12            | Month, 2-digits                   |
-| `D`    | 1-31             | Day of month                      |
-| `DD`   | 01-31            | Day of month, 2-digits            |
-| `H`    | 0-23             | Hours                             |
-| `HH`   | 00-23            | Hours, 2-digits                   |
-| `h`    | 1-12             | Hours, 12-hour clock              |
-| `hh`   | 01-12            | Hours, 12-hour clock, 2-digits    |
-| `m`    | 0-59             | Minutes                           |
-| `mm`   | 00-59            | Minutes, 2-digits                 |
-| `s`    | 0-59             | Seconds                           |
-| `ss`   | 00-59            | Seconds, 2-digits                 |
-| `S`    | 0-9              | Hundreds of milliseconds, 1-digit |
-| `SS`   | 00-99            | Tens of milliseconds, 2-digits    |
-| `SSS`  | 000-999          | Milliseconds, 3-digits            |
-| `Z`    | -5:00            | Offset from UTC                   |
-| `ZZ`   | -0500            | Compact offset from UTC, 2-digits |
-| `A`    | AM PM            | Post or ante meridiem, upper-case |
-| `a`    | am pm            | Post or ante meridiem, lower-case |
+| Format | Output  | Description                       |
+| ------ | ------- | --------------------------------- |
+| `YY`   | 18      | Two-digit year                    |
+| `YYYY` | 2018    | Four-digit year                   |
+| `M`    | 1-12    | Month, beginning at 1             |
+| `MM`   | 01-12   | Month, 2-digits                   |
+| `D`    | 1-31    | Day of month                      |
+| `DD`   | 01-31   | Day of month, 2-digits            |
+| `H`    | 0-23    | Hours                             |
+| `HH`   | 00-23   | Hours, 2-digits                   |
+| `h`    | 1-12    | Hours, 12-hour clock              |
+| `hh`   | 01-12   | Hours, 12-hour clock, 2-digits    |
+| `m`    | 0-59    | Minutes                           |
+| `mm`   | 00-59   | Minutes, 2-digits                 |
+| `s`    | 0-59    | Seconds                           |
+| `ss`   | 00-59   | Seconds, 2-digits                 |
+| `S`    | 0-9     | Hundreds of milliseconds, 1-digit |
+| `SS`   | 00-99   | Tens of milliseconds, 2-digits    |
+| `SSS`  | 000-999 | Milliseconds, 3-digits            |
+| `Z`    | -5:00   | Offset from UTC                   |
+| `ZZ`   | -0500   | Compact offset from UTC, 2-digits |
+| `A`    | AM PM   | Post or ante meridiem, upper-case |
+| `a`    | am pm   | Post or ante meridiem, lower-case |
+
+### DaysInYear
+
+- DaysInYear añade la función `.daysInYear()` a la API para devolver cuántos días tiene el año de la instancia de `dayjs`
+
+```javascript
+import daysInYear from "dayjs/plugin/daysInYear";
+
+dayjs.extend(daysInYear);
+
+dayjs("2010-01-01").daysInYear(); // 365
+dayjs("2012-01-01").daysInYear(); // 366
+```
 
 ## Personalización
 
@@ -255,19 +272,19 @@ Plantilla de un complemento de Day.js.
 export default (option, dayjsClass, dayjsFactory) => {
   // extensión de dayjs()
   // p.ej.: se añade dayjs().isSameOrBefore()
-  dayjsClass.prototype.isSameOrBefore = function (arguments) {}
+  dayjsClass.prototype.isSameOrBefore = function(arguments) {};
 
   // extensión de dayjs
   // p.ej.: se añade dayjs.utc()
-  dayjsFactory.utc = (arguments) => {}
+  dayjsFactory.utc = arguments => {};
 
   // sobrescritura de la API existente
   // p.ej.: extensión de dayjs().format()
-  const oldFormat = dayjsClass.prototype.format
-  dayjsClass.prototype.format = function (arguments) {
+  const oldFormat = dayjsClass.prototype.format;
+  dayjsClass.prototype.format = function(arguments) {
     // result contiene el formato original
-    const result = oldFormat(arguments)
+    const result = oldFormat(arguments);
     // se ha de devolver result modificado
-  }
-}
+  };
+};
 ```

--- a/src/constant.js
+++ b/src/constant.js
@@ -34,4 +34,3 @@ export const en = {
   weekdays: 'Sunday_Monday_Tuesday_Wednesday_Thursday_Friday_Saturday'.split('_'),
   months: 'January_February_March_April_May_June_July_August_September_October_November_December'.split('_')
 }
-

--- a/src/index.js
+++ b/src/index.js
@@ -212,7 +212,6 @@ class Dayjs {
     return this
   }
 
-
   set(string, int) {
     return this.clone().$set(string, int)
   }
@@ -303,9 +302,14 @@ class Dayjs {
     })
   }
 
+  utcOffset() {
+    return -Math.round(this.$d.getTimezoneOffset() / 15) * 15
+  }
+
   diff(input, units, float) {
     const unit = Utils.prettyUnit(units)
     const that = dayjs(input)
+    const zoneDelta = (that.utcOffset() - this.utcOffset()) * C.MILLISECONDS_A_MINUTE
     const diff = this - that
     let result = Utils.monthDiff(this, that)
 
@@ -313,8 +317,8 @@ class Dayjs {
       [C.Y]: result / 12,
       [C.M]: result,
       [C.Q]: result / 3,
-      [C.W]: diff / C.MILLISECONDS_A_WEEK,
-      [C.D]: diff / C.MILLISECONDS_A_DAY,
+      [C.W]: (diff - zoneDelta) / C.MILLISECONDS_A_WEEK,
+      [C.D]: (diff - zoneDelta) / C.MILLISECONDS_A_DAY,
       [C.H]: diff / C.MILLISECONDS_A_HOUR,
       [C.MIN]: diff / C.MILLISECONDS_A_MINUTE,
       [C.S]: diff / C.MILLISECONDS_A_SECOND

--- a/src/plugin/daysInYear/index.js
+++ b/src/plugin/daysInYear/index.js
@@ -1,0 +1,7 @@
+export default (o, c) => {
+  const proto = c.prototype
+  proto.daysInYear = function () {
+    const isLeapYear = (this.$y % 4 === 0 && this.$y % 100 !== 0) || this.$y % 400 === 0
+    return isLeapYear ? 366 : 365
+  }
+}

--- a/test/display.test.js
+++ b/test/display.test.js
@@ -86,7 +86,6 @@ it('Format Second s ss SSS', () => {
   expect(dayjs(date).format('s-ss-SSS')).toBe(moment(date).format('s-ss-SSS'))
 })
 
-
 it('Format Time Zone ZZ', () => {
   MockDate.set(new Date('2018-05-02T23:00:00.000'), 60 * 8)
   expect(dayjs().format('Z')).toBe(moment().format('Z'))
@@ -104,9 +103,21 @@ it('Format Time Zone ZZ', () => {
 })
 
 it('Format ddd dd MMM with short locale', () => {
-  expect(dayjs().locale(th).format('dd')).toBe(moment().locale('th').format('dd'))
-  expect(dayjs().locale(th).format('ddd')).toBe(moment().locale('th').format('ddd'))
-  expect(dayjs().locale(th).format('MMM')).toBe(moment().locale('th').format('MMM'))
+  expect(dayjs()
+    .locale(th)
+    .format('dd')).toBe(moment()
+    .locale('th')
+    .format('dd'))
+  expect(dayjs()
+    .locale(th)
+    .format('ddd')).toBe(moment()
+    .locale('th')
+    .format('ddd'))
+  expect(dayjs()
+    .locale(th)
+    .format('MMM')).toBe(moment()
+    .locale('th')
+    .format('MMM'))
 })
 
 it('Format Complex with other string - : / ', () => {
@@ -170,7 +181,6 @@ describe('Difference', () => {
     })
   })
 
-
   it('MonthDiff', () => {
     expect(dayjs('2018-08-08').diff(dayjs('2018-08-08'), 'month')).toEqual(0)
     expect(dayjs('2018-09-08').diff(dayjs('2018-08-08'), 'month')).toEqual(1)
@@ -190,6 +200,11 @@ it('Unix Timestamp (seconds)', () => {
 it('Days in Month', () => {
   expect(dayjs().daysInMonth()).toBe(moment().daysInMonth())
   expect(dayjs('20140201').daysInMonth()).toBe(moment('20140201').daysInMonth())
+})
+
+it('Utc Offset', () => {
+  expect(dayjs('2013-01-01T00:00:00.000').utcOffset()).toBe(moment('2013-01-01T00:00:00.000').utcOffset())
+  expect(dayjs('2013-01-01T05:00:00.000').utcOffset()).toBe(moment('2013-01-01T05:00:00.000').utcOffset())
 })
 
 it('As Javascript Date -> toDate', () => {

--- a/test/plugin/daysInYear.test.js
+++ b/test/plugin/daysInYear.test.js
@@ -1,0 +1,20 @@
+import MockDate from 'mockdate'
+import dayjs from '../../src'
+import daysInYear from '../../src/plugin/daysInYear'
+
+dayjs.extend(daysInYear)
+
+beforeEach(() => {
+  MockDate.set(new Date())
+})
+
+afterEach(() => {
+  MockDate.reset()
+})
+
+it('DaysInYear', () => {
+  expect(dayjs('2010-01-01').daysInYear()).toBe(365)
+  expect(dayjs('2011-01-01').daysInYear()).toBe(365)
+  expect(dayjs('2012-01-01').daysInYear()).toBe(366)
+  expect(dayjs('2013-01-01').daysInYear()).toBe(365)
+})


### PR DESCRIPTION
Created daysInYear plugin, which adds `daysInYear()` API method to retrieve how many days has the `dayjs` instance year.