### PR TITLE
Initial work to make plugins type-safe (typescript)

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "scripts": {
     "test": "TZ=Pacific/Auckland npm run test-tz && TZ=Europe/London npm run test-tz && npm run test-tz && jest",
     "test-tz": "jest test/timezone.test --coverage=false",
-    "lint": "./node_modules/.bin/eslint src/* test/* build/*",
+    "lint": "./node_modules/.bin/eslint src/*.js test/*.js build/*.js",
     "prettier": "prettier --write \"docs/**/*.md\"",
     "babel": "cross-env BABEL_ENV=build babel src --out-dir esm --copy-files",
     "build": "cross-env BABEL_ENV=build node build && npm run size",

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,5 +1,7 @@
 export = dayjs;
-declare function dayjs (config?: dayjs.ConfigType, option?: dayjs.OptionType): dayjs.Dayjs
+type WithReturnType<TFunction, TExtendedReturnType> = TFunction extends (...args: infer U) => infer R ? (...args: U) => R & TExtendedReturnType : TFunction;
+
+declare function dayjs(config?: dayjs.ConfigType, option?: dayjs.OptionType): dayjs.Dayjs
 
 declare namespace dayjs {
   export type ConfigType = string | number | Date | Dayjs
@@ -85,14 +87,14 @@ declare namespace dayjs {
 
     isAfter(dayjs: ConfigType, unit?: OpUnitType): boolean
 
-    isLeapYear(): boolean
-
     locale(arg1: any, arg2?: any): Dayjs
   }
 
   export type PluginFunc<TPlugin> = (option: ConfigType, d1: Dayjs, d2: Dayjs) => void
 
-  export function extend<TPlugin>(plugin: PluginFunc<TPlugin>, option?: ConfigType): Dayjs & TPlugin
+  export type dayjsWithPlugin<TPlugin extends object> = WithReturnType<typeof dayjs, TPlugin>;
+
+  export function extend<TPlugin extends object>(plugin: PluginFunc<TPlugin>, option?: ConfigType): dayjsWithPlugin<TPlugin>;
 
   export function locale(arg1: any, arg2?: any): string
 

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,94 +1,100 @@
+declare const dayjs: dayjs;
+export = dayjs;
 
-declare const dayjs: dayjs
-export default dayjs
+declare namespace dayjs {
+  type ConfigType = string | number | Date | Dayjs
 
-export type ConfigType = string | number | Date | Dayjs
+  type OptionType = { locale: string }
 
-export type OptionType = { locale: string }
+  type UnitTypeShort = 'd' | 'M' | 'y' | 'h' | 'm' | 's' | 'ms'
+  type UnitTypeSingular = 'millisecond' | 'second' | 'minute' | 'hour' | 'day' | 'week' | 'month' | 'quarter' | 'year' | 'date' | UnitTypeShort;
+  type UnitTypePlural = 'milliseconds' | 'seconds' | 'minutes' | 'hours' | 'days' | 'weeks' | 'months' | 'quarters' | 'years' | 'dates'
+  type UnitType = UnitTypeSingular | UnitTypePlural
 
-export type UnitTypeShort = 'd' | 'M' | 'y' | 'h' | 'm' | 's' | 'ms'
-export type UnitTypeSingular = 'millisecond' | 'second' | 'minute' | 'hour' | 'day' | 'week' | 'month' | 'quarter' | 'year' | 'date' | UnitTypeShort;
-export type UnitTypePlural = 'milliseconds' | 'seconds' | 'minutes' | 'hours' | 'days' | 'weeks' | 'months' | 'quarters' | 'years' | 'dates'
-export type UnitType = UnitTypeSingular | UnitTypePlural
+  type OpUnitTypeShort = 'w'
+  type OpUnitType = UnitType | "week" | OpUnitTypeShort;
 
-export type OpUnitTypeShort = 'w'
-export type OpUnitType = UnitType | "week" | OpUnitTypeShort;
-
-export type PluginFunc<TPlugin> = (option: ConfigType, d1: Dayjs, d2: Dayjs) => void
-
-export interface dayjs<TPlugin = {}> {
-  (config?: ConfigType, option?: OptionType): {} extends TPlugin ? Dayjs : Dayjs & TPlugin
-
-  extend<UPlugin extends object>(plugin: PluginFunc<UPlugin>, option?: ConfigType): dayjs<TPlugin & UPlugin>
-  locale(arg1: any, arg2?: any): string
-  isDayjs(d: any): d is Dayjs
-  unix(t: number): Dayjs
+  type PluginFunc<TPlugin> = (option: ConfigType, d1: Dayjs, d2: Dayjs) => void
 }
 
- export interface DayjsObject {
-  years: number
-  months: number
-  date: number
-  hours: number
-  minutes: number
-  seconds: number
-  milliseconds: number
+interface dayjs<TPlugin = {}> {
+  (config?: dayjs.ConfigType, option?: dayjs.OptionType): {} extends TPlugin
+    ? Dayjs
+    : Dayjs & TPlugin;
+
+  extend<UPlugin extends object>(
+    plugin: dayjs.PluginFunc<UPlugin>,
+    option?: dayjs.ConfigType
+  ): dayjs<TPlugin & UPlugin>;
+  locale(arg1: any, arg2?: any): string;
+  isDayjs(d: any): d is Dayjs;
+  unix(t: number): Dayjs;
 }
 
- export class Dayjs {
-  constructor(config?: ConfigType)
+declare interface DayjsObject {
+  years: number;
+  months: number;
+  date: number;
+  hours: number;
+  minutes: number;
+  seconds: number;
+  milliseconds: number;
+}
 
-  clone(): Dayjs
+declare class Dayjs {
+  constructor(config?: dayjs.ConfigType);
 
-  isValid(): boolean
+  clone(): Dayjs;
 
-  year(): number
+  isValid(): boolean;
 
-  month(): number
+  year(): number;
 
-  date(): number
+  month(): number;
 
-  day(): number
+  date(): number;
 
-  hour(): number
+  day(): number;
 
-  minute(): number
+  hour(): number;
 
-  second(): number
+  minute(): number;
 
-  millisecond(): number
+  second(): number;
 
-  set(unit: UnitType, value: number): Dayjs
+  millisecond(): number;
 
-  add(value: number, unit: OpUnitType): Dayjs
+  set(unit: dayjs.UnitType, value: number): Dayjs;
 
-  subtract(value: number, unit: OpUnitType): Dayjs
+  add(value: number, unit: dayjs.OpUnitType): Dayjs;
 
-  startOf(unit: OpUnitType): Dayjs
+  subtract(value: number, unit: dayjs.OpUnitType): Dayjs;
 
-  endOf(unit: OpUnitType): Dayjs
+  startOf(unit: dayjs.OpUnitType): Dayjs;
 
-  format(template?: string): string
+  endOf(unit: dayjs.OpUnitType): Dayjs;
+
+  format(template?: string): string;
 
     diff(dayjs: ConfigType, unit: OpUnitType, float?: boolean): number
 
-  valueOf(): number
+  valueOf(): number;
 
-  unix(): number
+  unix(): number;
 
-  daysInMonth(): number
+  daysInMonth(): number;
 
-  toDate(): Date
+  toDate(): Date;
 
-  toArray(): number[]
+  toArray(): number[];
 
-  toJSON(): string
+  toJSON(): string;
 
-  toISOString(): string
+  toISOString(): string;
 
-  toObject(): DayjsObject
+  toObject(): DayjsObject;
 
-  toString(): string
+  toString(): string;
 
     isBefore(dayjs: ConfigType, unit?: OpUnitType): boolean
 
@@ -96,5 +102,5 @@ export interface dayjs<TPlugin = {}> {
 
     isAfter(dayjs: ConfigType, unit?: OpUnitType): boolean
 
-  locale(arg1: any, arg2?: any): Dayjs
+  locale(arg1: any, arg2?: any): Dayjs;
 }

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -6,13 +6,13 @@ export type ConfigType = string | number | Date | Dayjs
 
 export type OptionType = { locale: string }
 
-  export type UnitTypeShort = 'd' | 'M' | 'y' | 'h' | 'm' | 's' | 'ms'
-  export type UnitTypeSingular = 'millisecond' | 'second' | 'minute' | 'hour' | 'day' | 'week' | 'month' | 'quarter' | 'year' | 'date' | UnitTypeShort;
+export type UnitTypeShort = 'd' | 'M' | 'y' | 'h' | 'm' | 's' | 'ms'
+export type UnitTypeSingular = 'millisecond' | 'second' | 'minute' | 'hour' | 'day' | 'week' | 'month' | 'quarter' | 'year' | 'date' | UnitTypeShort;
 export type UnitTypePlural = 'milliseconds' | 'seconds' | 'minutes' | 'hours' | 'days' | 'weeks' | 'months' | 'quarters' | 'years' | 'dates'
 export type UnitType = UnitTypeSingular | UnitTypePlural
 
-  type OpUnitTypeShort = 'w'
-  export type OpUnitType = UnitType | "week" | OpUnitTypeShort;
+export type OpUnitTypeShort = 'w'
+export type OpUnitType = UnitType | "week" | OpUnitTypeShort;
 
 export type PluginFunc<TPlugin> = (option: ConfigType, d1: Dayjs, d2: Dayjs) => void
 
@@ -60,13 +60,13 @@ export interface dayjs<TPlugin = {}> {
 
   set(unit: UnitType, value: number): Dayjs
 
-    add(value: number, unit: OpUnitType): Dayjs
+  add(value: number, unit: OpUnitType): Dayjs
 
-    subtract(value: number, unit: OpUnitType): Dayjs
+  subtract(value: number, unit: OpUnitType): Dayjs
 
-    startOf(unit: OpUnitType): Dayjs
+  startOf(unit: OpUnitType): Dayjs
 
-    endOf(unit: OpUnitType): Dayjs
+  endOf(unit: OpUnitType): Dayjs
 
   format(template?: string): string
 

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -6,8 +6,10 @@ declare namespace dayjs {
 
   export type OptionType = { locale: string }
 
-  type UnitTypeShort = 'd' | 'M' | 'y' | 'h' | 'm' | 's' | 'ms'
-  export type UnitType = 'millisecond' | 'second' | 'minute' | 'hour' | 'day' | 'month' | 'quarter' | 'year' | 'date' | UnitTypeShort;
+  export type UnitTypeShort = 'd' | 'M' | 'y' | 'h' | 'm' | 's' | 'ms'
+  export type UnitTypeSingular = 'millisecond' | 'second' | 'minute' | 'hour' | 'day' | 'week' | 'month' | 'quarter' | 'year' | 'date' | UnitTypeShort;
+  export type UnitTypePlural = 'milliseconds' | 'seconds' | 'minutes' | 'hours' | 'days' | 'weeks' | 'months' | 'quarters' | 'years' | 'dates'
+  export type UnitType = UnitTypeSingular | UnitTypePlural
 
   type OpUnitTypeShort = 'w'
   export type OpUnitType = UnitType | "week" | OpUnitTypeShort;
@@ -88,13 +90,13 @@ declare namespace dayjs {
     locale(arg1: any, arg2?: any): Dayjs
   }
 
-  export type PluginFunc = (option: ConfigType, d1: Dayjs, d2: Dayjs) => void
+  export type PluginFunc<TPlugin> = (option: ConfigType, d1: Dayjs, d2: Dayjs) => void
 
-  export function extend(plugin: PluginFunc, option?: ConfigType): Dayjs
+  export function extend<TPlugin>(plugin: PluginFunc<TPlugin>, option?: ConfigType): Dayjs & TPlugin
 
   export function locale(arg1: any, arg2?: any): string
 
   export function isDayjs(d: any): d is Dayjs
-  
+
   export function unix(t: number): Dayjs
 }

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -14,7 +14,15 @@ declare namespace dayjs {
   type OpUnitTypeShort = 'w'
   type OpUnitType = UnitType | "week" | OpUnitTypeShort;
 
-  type PluginFunc<TPlugin> = (option: ConfigType, d1: Dayjs, d2: Dayjs) => void
+  type PluginFunc<TPlugin> = (option: ConfigType, dayjsClass: InstanceType<Dayjs>, dayjsFactory: dayjs) => void;
+
+  /**
+   * Branding for static plugins, to enable better type inference.
+   * `extend` from this to make the plugin static
+   */
+  interface StaticPlugin {
+    __staticPlugin: never;
+  }
 }
 
 interface dayjs<TPlugin = {}> {
@@ -25,7 +33,7 @@ interface dayjs<TPlugin = {}> {
   extend<UPlugin extends object>(
     plugin: dayjs.PluginFunc<UPlugin>,
     option?: dayjs.ConfigType
-  ): dayjs<TPlugin & UPlugin>;
+  ): UPlugin extends dayjs.StaticPlugin ? (dayjs<TPlugin> & UPlugin) : dayjs<TPlugin & UPlugin>;
   locale(arg1: any, arg2?: any): string;
   isDayjs(d: any): d is Dayjs;
   unix(t: number): Dayjs;
@@ -76,7 +84,7 @@ declare class Dayjs {
 
   format(template?: string): string;
 
-    diff(dayjs: ConfigType, unit: OpUnitType, float?: boolean): number
+  diff(dayjs: ConfigType, unit: OpUnitType, float?: boolean): number
 
   valueOf(): number;
 
@@ -96,11 +104,11 @@ declare class Dayjs {
 
   toString(): string;
 
-    isBefore(dayjs: ConfigType, unit?: OpUnitType): boolean
+  isBefore(dayjs: ConfigType, unit?: OpUnitType): boolean
 
-    isSame(dayjs: ConfigType, unit?: OpUnitType): boolean
+  isSame(dayjs: ConfigType, unit?: OpUnitType): boolean
 
-    isAfter(dayjs: ConfigType, unit?: OpUnitType): boolean
+  isAfter(dayjs: ConfigType, unit?: OpUnitType): boolean
 
   locale(arg1: any, arg2?: any): Dayjs;
 }

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,55 +1,64 @@
-export = dayjs;
-type WithReturnType<TFunction, TExtendedReturnType> = TFunction extends (...args: infer U) => infer R ? (...args: U) => R & TExtendedReturnType : TFunction;
 
-declare function dayjs(config?: dayjs.ConfigType, option?: dayjs.OptionType): dayjs.Dayjs
+declare const dayjs: dayjs
+export default dayjs
 
-declare namespace dayjs {
-  export type ConfigType = string | number | Date | Dayjs
+export type ConfigType = string | number | Date | Dayjs
 
-  export type OptionType = { locale: string }
+export type OptionType = { locale: string }
 
   export type UnitTypeShort = 'd' | 'M' | 'y' | 'h' | 'm' | 's' | 'ms'
   export type UnitTypeSingular = 'millisecond' | 'second' | 'minute' | 'hour' | 'day' | 'week' | 'month' | 'quarter' | 'year' | 'date' | UnitTypeShort;
-  export type UnitTypePlural = 'milliseconds' | 'seconds' | 'minutes' | 'hours' | 'days' | 'weeks' | 'months' | 'quarters' | 'years' | 'dates'
-  export type UnitType = UnitTypeSingular | UnitTypePlural
+export type UnitTypePlural = 'milliseconds' | 'seconds' | 'minutes' | 'hours' | 'days' | 'weeks' | 'months' | 'quarters' | 'years' | 'dates'
+export type UnitType = UnitTypeSingular | UnitTypePlural
 
   type OpUnitTypeShort = 'w'
   export type OpUnitType = UnitType | "week" | OpUnitTypeShort;
 
-  interface DayjsObject {
-    years: number
-    months: number
-    date: number
-    hours: number
-    minutes: number
-    seconds: number
-    milliseconds: number
-  }
+export type PluginFunc<TPlugin> = (option: ConfigType, d1: Dayjs, d2: Dayjs) => void
 
-  class Dayjs {
-    constructor (config?: ConfigType)
+export interface dayjs<TPlugin = {}> {
+  (config?: ConfigType, option?: OptionType): {} extends TPlugin ? Dayjs : Dayjs & TPlugin
 
-    clone(): Dayjs
+  extend<UPlugin extends object>(plugin: PluginFunc<UPlugin>, option?: ConfigType): dayjs<TPlugin & UPlugin>
+  locale(arg1: any, arg2?: any): string
+  isDayjs(d: any): d is Dayjs
+  unix(t: number): Dayjs
+}
 
-    isValid(): boolean
+ export interface DayjsObject {
+  years: number
+  months: number
+  date: number
+  hours: number
+  minutes: number
+  seconds: number
+  milliseconds: number
+}
 
-    year(): number
+ export class Dayjs {
+  constructor(config?: ConfigType)
 
-    month(): number
+  clone(): Dayjs
 
-    date(): number
+  isValid(): boolean
 
-    day(): number
+  year(): number
 
-    hour(): number
+  month(): number
 
-    minute(): number
+  date(): number
 
-    second(): number
+  day(): number
 
-    millisecond(): number
+  hour(): number
 
-    set(unit: UnitType, value: number): Dayjs
+  minute(): number
+
+  second(): number
+
+  millisecond(): number
+
+  set(unit: UnitType, value: number): Dayjs
 
     add(value: number, unit: OpUnitType): Dayjs
 
@@ -59,27 +68,27 @@ declare namespace dayjs {
 
     endOf(unit: OpUnitType): Dayjs
 
-    format(template?: string): string
+  format(template?: string): string
 
     diff(dayjs: ConfigType, unit: OpUnitType, float?: boolean): number
 
-    valueOf(): number
+  valueOf(): number
 
-    unix(): number
+  unix(): number
 
-    daysInMonth(): number
+  daysInMonth(): number
 
-    toDate(): Date
+  toDate(): Date
 
-    toArray(): number[]
+  toArray(): number[]
 
-    toJSON(): string
+  toJSON(): string
 
-    toISOString(): string
+  toISOString(): string
 
-    toObject(): DayjsObject
+  toObject(): DayjsObject
 
-    toString(): string
+  toString(): string
 
     isBefore(dayjs: ConfigType, unit?: OpUnitType): boolean
 
@@ -87,18 +96,5 @@ declare namespace dayjs {
 
     isAfter(dayjs: ConfigType, unit?: OpUnitType): boolean
 
-    locale(arg1: any, arg2?: any): Dayjs
-  }
-
-  export type PluginFunc<TPlugin> = (option: ConfigType, d1: Dayjs, d2: Dayjs) => void
-
-  export type dayjsWithPlugin<TPlugin extends object> = WithReturnType<typeof dayjs, TPlugin>;
-
-  export function extend<TPlugin extends object>(plugin: PluginFunc<TPlugin>, option?: ConfigType): dayjsWithPlugin<TPlugin>;
-
-  export function locale(arg1: any, arg2?: any): string
-
-  export function isDayjs(d: any): d is Dayjs
-
-  export function unix(t: number): Dayjs
+  locale(arg1: any, arg2?: any): Dayjs
 }

--- a/src/plugin/advancedFormat/index.d.ts
+++ b/src/plugin/advancedFormat/index.d.ts
@@ -1,0 +1,8 @@
+import { ConfigType, PluginFunc } from '../../index'
+
+interface AdvancedFormatPlugin {
+  format(advancedFormat: string): string
+}
+
+declare const pluginFn: PluginFunc<AdvancedFormatPlugin>
+export default pluginFn

--- a/src/plugin/buddhistEra/index.d.ts
+++ b/src/plugin/buddhistEra/index.d.ts
@@ -1,0 +1,8 @@
+import { ConfigType, PluginFunc } from '../../index'
+
+interface BuddhistEraPlugin {
+  format(buddhistEraFormat: string): string
+}
+
+declare const pluginFn: PluginFunc<BuddhistEraPlugin>
+export default pluginFn

--- a/src/plugin/customParseFormat/index.d.ts
+++ b/src/plugin/customParseFormat/index.d.ts
@@ -1,0 +1,8 @@
+import { ConfigType, PluginFunc, StaticPlugin } from '../../index'
+
+interface CustomParseFormatPlugin extends StaticPlugin {
+  (input: string, format: string): this;
+}
+
+declare const pluginFn: PluginFunc<CustomParseFormatPlugin>;
+export default pluginFn

--- a/src/plugin/isBetween/index.d.ts
+++ b/src/plugin/isBetween/index.d.ts
@@ -1,0 +1,8 @@
+import { ConfigType, PluginFunc, UnitType } from '../../index'
+
+interface IsBetweenPlugin {
+  isBetween(d1: ConfigType, d2: ConfigType, unit: UnitType): boolean;
+}
+
+declare const pluginFn: PluginFunc<IsBetweenPlugin>
+export default pluginFn

--- a/src/plugin/isLeapYear/index.d.ts
+++ b/src/plugin/isLeapYear/index.d.ts
@@ -1,0 +1,8 @@
+import { ConfigType, PluginFunc } from '../../index'
+
+interface IsLeapYearPlugin {
+  isLeapYear(): boolean
+}
+
+declare const pluginFn: PluginFunc<IsLeapYearPlugin>
+export default pluginFn

--- a/src/plugin/relativeTime/index.d.ts
+++ b/src/plugin/relativeTime/index.d.ts
@@ -1,0 +1,11 @@
+import { ConfigType, PluginFunc } from '../../index'
+
+interface RelativeTimePlugin {
+  fromNow(withoutSuffix?: boolean): string
+  from(compared: ConfigType, withoutSuffix?: boolean): string
+  toNow(withoutSuffix?: boolean): string
+  to(compared: ConfigType, withoutSuffix?: boolean): string
+}
+
+declare const pluginFn: PluginFunc<RelativeTimePlugin>
+export default pluginFn

--- a/test/index.d.test.ts
+++ b/test/index.d.test.ts
@@ -81,9 +81,12 @@ dayjs().isSame(dayjs(), 'hours')
 
 dayjs().isAfter(dayjs(), 'year')
 
-
 dayjs.extend(relativeTime)().toNow()
 dayjs.extend(advancedFormat)().format()
 dayjs.extend(buddhistEra)().format()
-dayjs.extend(isLeapYear)('2000-01-01').isLeapYear();
-dayjs.extend(isBetween)('2010-10-20').isBetween('2010-10-19', dayjs('2010-10-25'), 'year');
+dayjs.extend(isLeapYear)('2000-01-01').isLeapYear()
+dayjs.extend(isBetween)('2010-10-20').isBetween('2010-10-19', dayjs('2010-10-25'), 'year')
+
+const multiplePluginsDayjs = dayjs.extend(relativeTime).extend(isLeapYear)()
+multiplePluginsDayjs.toNow()
+multiplePluginsDayjs.isLeapYear()

--- a/test/index.d.test.ts
+++ b/test/index.d.test.ts
@@ -2,6 +2,7 @@ import dayjs from '../src'
 import relativeTime from '../src/plugin/relativeTime'
 import advancedFormat from '../src/plugin/advancedFormat'
 import buddhistEra from '../src/plugin/buddhistEra'
+import isLeapYear from '../src/plugin/isLeapYear'
 
 dayjs()
 
@@ -79,8 +80,8 @@ dayjs().isSame(dayjs(), 'hours')
 
 dayjs().isAfter(dayjs(), 'year')
 
-dayjs('2000-01-01').isLeapYear()
 
-dayjs.extend(relativeTime).toNow()
-dayjs.extend(advancedFormat).format()
-dayjs.extend(buddhistEra).format()
+dayjs.extend(relativeTime)().toNow()
+dayjs.extend(advancedFormat)().format()
+dayjs.extend(buddhistEra)().format()
+dayjs.extend(isLeapYear)('2000-01-01').isLeapYear();

--- a/test/index.d.test.ts
+++ b/test/index.d.test.ts
@@ -3,6 +3,7 @@ import relativeTime from '../src/plugin/relativeTime'
 import advancedFormat from '../src/plugin/advancedFormat'
 import buddhistEra from '../src/plugin/buddhistEra'
 import isLeapYear from '../src/plugin/isLeapYear'
+import isBetween from '../src/plugin/isBetween'
 
 dayjs()
 
@@ -85,3 +86,4 @@ dayjs.extend(relativeTime)().toNow()
 dayjs.extend(advancedFormat)().format()
 dayjs.extend(buddhistEra)().format()
 dayjs.extend(isLeapYear)('2000-01-01').isLeapYear();
+dayjs.extend(isBetween)('2010-10-20').isBetween('2010-10-19', dayjs('2010-10-25'), 'year');

--- a/test/index.d.test.ts
+++ b/test/index.d.test.ts
@@ -1,6 +1,7 @@
 import dayjs from '../src'
 import relativeTime from '../src/plugin/relativeTime'
 import advancedFormat from '../src/plugin/advancedFormat'
+import buddhistEra from '../src/plugin/buddhistEra'
 
 dayjs()
 
@@ -82,3 +83,4 @@ dayjs('2000-01-01').isLeapYear()
 
 dayjs.extend(relativeTime).toNow()
 dayjs.extend(advancedFormat).format()
+dayjs.extend(buddhistEra).format()

--- a/test/index.d.test.ts
+++ b/test/index.d.test.ts
@@ -1,5 +1,6 @@
 import dayjs from '../src'
-import relativeTime from '../src/plugin/relativeTime/index'
+import relativeTime from '../src/plugin/relativeTime'
+import advancedFormat from '../src/plugin/advancedFormat'
 
 dayjs()
 
@@ -80,3 +81,4 @@ dayjs().isAfter(dayjs(), 'year')
 dayjs('2000-01-01').isLeapYear()
 
 dayjs.extend(relativeTime).toNow()
+dayjs.extend(advancedFormat).format()

--- a/test/index.d.test.ts
+++ b/test/index.d.test.ts
@@ -1,4 +1,5 @@
 import dayjs from '../src'
+import relativeTime from '../src/plugin/relativeTime/index'
 
 dayjs()
 
@@ -77,3 +78,5 @@ dayjs().isSame(dayjs(), 'hours')
 dayjs().isAfter(dayjs(), 'year')
 
 dayjs('2000-01-01').isLeapYear()
+
+dayjs.extend(relativeTime).toNow()

--- a/test/index.test.d.ts
+++ b/test/index.test.d.ts
@@ -4,6 +4,7 @@ import advancedFormat from '../src/plugin/advancedFormat'
 import buddhistEra from '../src/plugin/buddhistEra'
 import isLeapYear from '../src/plugin/isLeapYear'
 import isBetween from '../src/plugin/isBetween'
+import customParseFormat from '../src/plugin/customParseFormat'
 
 dayjs()
 
@@ -90,3 +91,6 @@ dayjs.extend(isBetween)('2010-10-20').isBetween('2010-10-19', dayjs('2010-10-25'
 const multiplePluginsDayjs = dayjs.extend(relativeTime).extend(isLeapYear)()
 multiplePluginsDayjs.toNow()
 multiplePluginsDayjs.isLeapYear()
+
+const dayjsWithCustomParseFormat = dayjs.extend(customParseFormat);
+dayjsWithCustomParseFormat('05/02/69 1:02:03 PM -05:00', 'MM/DD/YY H:mm:ss A Z');

--- a/test/plugins.test.js
+++ b/test/plugins.test.js
@@ -1,0 +1,23 @@
+import MockDate from 'mockdate'
+import dayjs from '../src'
+import relativeTime from '../src/plugin/relativeTime'
+import isLeapYear from '../src/plugin/isLeapYear'
+
+beforeEach(() => {
+  MockDate.set(new Date())
+})
+
+afterEach(() => {
+  MockDate.reset()
+})
+
+it('should allow multiple plugin chaining', () => {
+  const now = dayjs()
+  expect(now.fromNow).not.toBeDefined()
+  expect(now.isLeapYear).not.toBeDefined()
+
+  const extendedDayjs = dayjs.extend(relativeTime).extend(isLeapYear)
+  const extendedNow = extendedDayjs()
+  expect(typeof extendedNow.fromNow).toBe('function')
+  expect(typeof extendedNow.isLeapYear).toBe('function')
+})


### PR DESCRIPTION
All changes are in types only, and and thus not breaking changes as far as runtime is concerned.

The changes are essentially an implementation of option 3 from [my comment](https://github.com/iamkun/dayjs/issues/364#issuecomment-447406906) in #364.

Do note that it will break plugins that reference `PluginFunc`, since it now requires a generic (this _can_ be avoided with default generics, but there's a good point not to give defaults in this case. I can expand on this if needed).

I also made a small change to the type of `UnitType` to allow more units to be passed in, seeing that [the source](https://github.com/iamkun/dayjs/blob/dev/src/utils.js#L39) allows it. I can pull that into a separate PR if needed.

Lastly, I moved the `index.d.ts` file into the `/src` folder, for easier automatic detection by tsc inside the repo. **This is unsolved** (together with the definition file for the `relativeTime` plugin I made as an example. Both of these files **should be copied over** and included in the final bundle.

Update: adding types for so-called "static plugins" is now possible (like the `customParseFormat` plugin, which modifies the dayjs namespace, and not the prototype). There is a little overhead for plugin type authors, but it's very minimal. See the type for `customParseFormat` plugin as an example.