### PR TITLE
Fix Typescript definition to correctly reflect the usage

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,97 +1,77 @@
-export = dayjs;
+export default dayjs
 
-declare function dayjs (config?: dayjs.ConfigType, option?: dayjs.OptionType): dayjs.Dayjs
+declare const dayjs: DayjsFn
 
-declare namespace dayjs {
-  export type ConfigType = string | number | Date | Dayjs
+type DayjsFn = {
+  (config?: ConfigType, option?: OptionType): DayjsInstance
+  extend(plugin: PluginFunc, option?: ConfigType): DayjsInstance
+  locale(arg1: any, arg2?: any): string
+  isDayjs(d: any): d is DayjsInstance
+  unix(t: number): DayjsInstance
+}
 
-  export type OptionType = { locale: string }
+export type ConfigType = string | number | Date | DayjsInstance
 
-  export type UnitType = 'millisecond' | 'second' | 'minute' | 'hour' | 'day' | 'week' | 'month' | 'quarter' | 'year' | 'date'
+export type OptionType = { locale: string }
 
-  interface DayjsObject {
-    years: number
-    months: number
-    date: number
-    hours: number
-    minutes: number
-    seconds: number
-    milliseconds: number
-  }
+export type UnitType =
+  | 'millisecond'
+  | 'second'
+  | 'minute'
+  | 'hour'
+  | 'day'
+  | 'week'
+  | 'month'
+  | 'quarter'
+  | 'year'
+  | 'date'
 
-  class Dayjs {
-    constructor (config?: ConfigType)
+export type PluginFunc = (
+  option: ConfigType,
+  d1: DayjsInstance,
+  d2: DayjsInstance
+) => void
 
-    clone(): Dayjs
+export type DayjsPlainObject = {
+  years: number
+  months: number
+  date: number
+  hours: number
+  minutes: number
+  seconds: number
+  milliseconds: number
+}
 
-    isValid(): boolean
-
-    year(): number
-
-    month(): number
-
-    date(): number
-
-    day(): number
-
-    hour(): number
-
-    minute(): number
-
-    second(): number
-
-    millisecond(): number
-
-    set(unit: UnitType, value: number): Dayjs
-
-    add(value: number, unit: UnitType): Dayjs
-
-    subtract(value: number, unit: UnitType): Dayjs
-
-    startOf(unit: UnitType): Dayjs
-
-    endOf(unit: UnitType): Dayjs
-
-    format(template?: string): string
-
-    diff(dayjs: Dayjs, unit: UnitType, float?: boolean): number
-
-    valueOf(): number
-
-    unix(): number
-
-    daysInMonth(): number
-
-    toDate(): Date
-
-    toArray(): number[]
-
-    toJSON(): string
-
-    toISOString(): string
-
-    toObject(): DayjsObject
-
-    toString(): string
-
-    isBefore(dayjs: Dayjs, unit?: UnitType): boolean
-
-    isSame(dayjs: Dayjs, unit?: UnitType): boolean
-
-    isAfter(dayjs: Dayjs, unit?: UnitType): boolean
-
-    isLeapYear(): boolean
-
-    locale(arg1: any, arg2?: any): Dayjs
-  }
-
-  export type PluginFunc = (option: ConfigType, d1: Dayjs, d2: Dayjs) => void
-
-  export function extend(plugin: PluginFunc, option?: ConfigType): Dayjs
-
-  export function locale(arg1: any, arg2?: any): string
-
-  export function isDayjs(d: any): d is Dayjs
-  
-  export function unix(t: number): Dayjs
+export type DayjsInstance = {
+  clone(): DayjsInstance
+  isValid(): boolean
+  year(): number
+  month(): number
+  date(): number
+  day(): number
+  hour(): number
+  minute(): number
+  second(): number
+  millisecond(): number
+  set(unit: UnitType, value: number): DayjsInstance
+  add(value: number, unit: UnitType): DayjsInstance
+  subtract(value: number, unit: UnitType): DayjsInstance
+  startOf(unit: UnitType): DayjsInstance
+  endOf(unit: UnitType): DayjsInstance
+  format(template?: string): string
+  diff(dayjs: DayjsInstance, unit: UnitType, float?: boolean): number
+  valueOf(): number
+  unix(): number
+  daysInMonth(): number
+  toDate(): Date
+  toArray(): number[]
+  toJSON(): string
+  toISOString(): string
+  toObject(): DayjsPlainObject
+  toString(): string
+  isBefore(dayjs: DayjsInstance, unit?: UnitType): boolean
+  isSame(dayjs: DayjsInstance, unit?: UnitType): boolean
+  isAfter(dayjs: DayjsInstance, unit?: UnitType): boolean
+  isLeapYear(): boolean
+  locale(arg1: any, arg2?: any): DayjsInstance
 }

--- a/src/locale/cs.js
+++ b/src/locale/cs.js
@@ -1,0 +1,27 @@
+import dayjs from 'dayjs'
+
+const locale = {
+  name: 'cs',
+  weekdays: 'Neděle_Pondělí_Úterý_Středa_Čtvrtek_Pátek_Sobota'.split('_'),
+  months: 'leden_únor_březen_duben_květen_červen_červenec_srpen_září_říjen_listopad_prosinec'.split('_'),
+  relativeTime: {
+    future: 'za %s',
+    past: 'před %s',
+    s: 'několik sekund',
+    m: 'minuta',
+    mm: '%d minut',
+    h: 'hodina',
+    hh: '%d hodin',
+    d: 'den',
+    dd: '%d dnů',
+    M: 'měsíc',
+    MM: '%d měsíců',
+    y: 'rok',
+    yy: '%d roků'
+  },
+  ordinal: n => `${n}º`
+}
+
+dayjs.locale(locale, null, true)
+
+export default locale


### PR DESCRIPTION
Type definition files should only contain interfaces or types.

Besides, `dayjs` should be imported as `import dayjs from 'dayjs';`, instead of `import * as dayjs from 'dayjs'`, which means namespace is not necessary.