### PR TITLE
Added shorthand units to UnitType

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -7,7 +7,11 @@ declare namespace dayjs {
 
   export type OptionType = { locale: string }
 
-  export type UnitType = 'millisecond' | 'second' | 'minute' | 'hour' | 'day' | 'week' | 'month' | 'quarter' | 'year' | 'date' | 'd' | 'M' | 'y' | 'w' | 'h' | 'm' | 's' | 'ms'
+  type UnitTypeShort = 'd' | 'M' | 'y' | 'h' | 'm' | 's' | 'ms'
+  export type UnitType = 'millisecond' | 'second' | 'minute' | 'hour' | 'day' | 'month' | 'quarter' | 'year' | 'date' | UnitTypeShort;
+
+  type OpUnitTypeShort = 'w'
+  export type OpUnitType = UnitType | "week" | OpUnitTypeShort;
 
   interface DayjsObject {
     years: number
@@ -44,17 +48,17 @@ declare namespace dayjs {
 
     set(unit: UnitType, value: number): Dayjs
 
-    add(value: number, unit: UnitType): Dayjs
+    add(value: number, unit: OpUnitType): Dayjs
 
-    subtract(value: number, unit: UnitType): Dayjs
+    subtract(value: number, unit: OpUnitType): Dayjs
 
-    startOf(unit: UnitType): Dayjs
+    startOf(unit: OpUnitType): Dayjs
 
-    endOf(unit: UnitType): Dayjs
+    endOf(unit: OpUnitType): Dayjs
 
     format(template?: string): string
 
-    diff(dayjs: Dayjs, unit: UnitType, float?: boolean): number
+    diff(dayjs: Dayjs, unit: OpUnitType, float?: boolean): number
 
     valueOf(): number
 
@@ -74,11 +78,11 @@ declare namespace dayjs {
 
     toString(): string
 
-    isBefore(dayjs: Dayjs, unit?: UnitType): boolean
+    isBefore(dayjs: Dayjs, unit?: OpUnitType): boolean
 
-    isSame(dayjs: Dayjs, unit?: UnitType): boolean
+    isSame(dayjs: Dayjs, unit?: OpUnitType): boolean
 
-    isAfter(dayjs: Dayjs, unit?: UnitType): boolean
+    isAfter(dayjs: Dayjs, unit?: OpUnitType): boolean
 
     isLeapYear(): boolean
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -7,7 +7,7 @@ declare namespace dayjs {
 
   export type OptionType = { locale: string }
 
-  export type UnitType = 'millisecond' | 'second' | 'minute' | 'hour' | 'day' | 'week' | 'month' | 'quarter' | 'year' | 'date'
+  export type UnitType = 'millisecond' | 'second' | 'minute' | 'hour' | 'day' | 'week' | 'month' | 'quarter' | 'year' | 'date' | 'd' | 'M' | 'y' | 'w' | 'h' | 'm' | 's' | 'ms'
 
   interface DayjsObject {
     years: number


### PR DESCRIPTION
Thanks for this useful library!

When using Typescript, shorthand units were throwing errors because not recognized.

On a side note, I wonder if the same type (UnitType) should be used for `set()` and `add()/subtract()`methods. Because the former does not take a `week` as a unit (which would count as valid in TS typings). Just a thought.