### PR TITLE
Update Swedish and Finnish locales

### DIFF
--- a/src/locale/fi.js
+++ b/src/locale/fi.js
@@ -6,7 +6,7 @@ const locale = {
   weekdaysShort: 'su_ma_ti_ke_to_pe_la'.split('_'), // There is no short form of weekdays in Finnish except this 2 letter format so it is used for both 'weekdaysShort' and 'weekdaysMin'
   weekdaysMin: 'su_ma_ti_ke_to_pe_la'.split('_'),
   months: 'tammikuu_helmikuu_maaliskuu_huhtikuu_toukokuu_kesäkuu_heinäkuu_elokuu_syyskuu_lokakuu_marraskuu_joulukuu'.split('_'), // Note month names are not capitalized in Finnish
-  monthsShort: 'tammikuu_helmikuu_maaliskuu_huhtikuu_toukokuu_kesäkuu_heinäkuu_elokuu_syyskuu_lokakuu_marraskuu_joulukuu'.split('_'), // There is no short form of months in Finnish so just use the regular long form always
+  monthsShort: 'tammi_helmi_maalis_huhti_touko_kesä_heinä_elo_syys_loka_marras_joulu'.split('_'),
   ordinal: n => `${n}.`,
   weekStart: 1,
   /*

--- a/src/locale/sv.js
+++ b/src/locale/sv.js
@@ -3,7 +3,10 @@ import dayjs from 'dayjs'
 const locale = {
   name: 'sv',
   weekdays: 'söndag_måndag_tisdag_onsdag_torsdag_fredag_lördag'.split('_'),
+  weekdaysShort: 'sön_mån_tis_ons_tor_fre_lör'.split('_'),
+  weekdaysMin: 'sö_må_ti_on_to_fr_lö'.split('_'),
   months: 'januari_februari_mars_april_maj_juni_juli_augusti_september_oktober_november_december'.split('_'),
+  monthsShort: 'jan_feb_mar_apr_maj_jun_jul_aug_sep_okt_nov_dec'.split('_'),
   weekStart: 1,
   ordinal: (n) => {
     const b = n % 10


### PR DESCRIPTION
Swedish locale was missing weekdaysShort and Min, and monthsShort.
Finnish locale's monthsShort was same as months. It is now updated to be similar to moment.