### PR TITLE
Word orders corrections for locale 'fa'

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ dayjs.min.js
 
 #dev
 demo.js
+/.vs/slnx.sqlite

--- a/.gitignore
+++ b/.gitignore
@@ -20,4 +20,3 @@ dayjs.min.js
 
 #dev
 demo.js
-/.vs/slnx.sqlite

--- a/src/locale/fa.js
+++ b/src/locale/fa.js
@@ -14,19 +14,19 @@ const locale = {
     LLLL: 'dddd, D MMMM YYYY HH:mm'
   },
   relativeTime: {
-    future: '%s در',
-    past: 'پیش %s',
+    future: 'در %s',
+    past: '%s پیش',
     s: 'چند ثانیه',
     m: 'یک دقیقه',
-    mm: 'دقیقه %d',
+    mm: '%d دقیقه',
     h: 'یک ساعت',
-    hh: 'ساعت %d',
+    hh: '%d ساعت',
     d: 'یک روز',
-    dd: 'روز %d',
+    dd: '%d روز',
     M: 'یک ماه',
-    MM: 'ماه %d',
+    MM: '%d ماه',
     y: 'یک سال',
-    yy: 'سال %d'
+    yy: '%d سال'
   }
 }
 


### PR DESCRIPTION
Word orders in relativeTime object has been corrected for locale 'fa'.