### PR TITLE
Refactor regex

### DIFF
--- a/src/constant.js
+++ b/src/constant.js
@@ -26,7 +26,7 @@ export const FORMAT_DEFAULT = 'YYYY-MM-DDTHH:mm:ssZ'
 export const INVALID_DATE_STRING = 'Invalid Date'
 
 // regex
-export const REGEX_PARSE = /^(\d{4})-?(\d{1,2})-?(\d{0,2})[^0-9]*(\d{1,2})?:?(\d{1,2})?:?(\d{1,2})?\.?(\d{1,3})?$/
+export const REGEX_PARSE = /^(\d{4})-?(\d{1,2})-?(\d{0,2})$/
 export const REGEX_FORMAT = /\[.*?\]|Y{2,4}|M{1,4}|D{1,2}|d{1,4}|H{1,2}|h{1,2}|a|A|m{1,2}|s{1,2}|Z{1,2}|SSS/g
 
 export const en = {

--- a/src/constant.js
+++ b/src/constant.js
@@ -26,7 +26,7 @@ export const FORMAT_DEFAULT = 'YYYY-MM-DDTHH:mm:ssZ'
 export const INVALID_DATE_STRING = 'Invalid Date'
 
 // regex
-export const REGEX_PARSE = /^(\d{4})-?(\d{1,2})-?(\d{0,2})[^0-9]*(\d{1,2})?:?(\d{1,2})?:?(\d{1,2})?.?(\d{1,3})?$/
+export const REGEX_PARSE = /^(\d{4})-?(\d{1,2})-?(\d{0,2})[^0-9]*(\d{1,2})?:?(\d{1,2})?:?(\d{1,2})?\.?(\d{1,3})?$/
 export const REGEX_FORMAT = /\[.*?\]|Y{2,4}|M{1,4}|D{1,2}|d{1,4}|H{1,2}|h{1,2}|a|A|m{1,2}|s{1,2}|Z{1,2}|SSS/g
 
 export const en = {

--- a/src/index.js
+++ b/src/index.js
@@ -48,7 +48,7 @@ const parseDate = (date) => {
   if (date === null) return new Date(NaN) // null is invalid
   if (Utils.isUndefined(date)) return new Date() // today
   if (date instanceof Date) return date
-  if (typeof date === 'string' && !date.toLowerCase().endsWith('z')) {
+  if (typeof date === 'string') {
     const d = date.match(C.REGEX_PARSE)
     if (d) {
       return new Date(d[1], d[2] - 1, d[3] || 1, d[4] || 0, d[5] || 0, d[6] || 0, d[7] || 0)

--- a/src/index.js
+++ b/src/index.js
@@ -45,21 +45,17 @@ Utils.isDayjs = isDayjs
 Utils.wrapper = wrapper
 
 const parseDate = (date) => {
-  let reg
-  if (date === null) return new Date(NaN) // Treat null as an invalid date
-  if (Utils.isUndefined(date)) return new Date()
+  if (date === null) return new Date(NaN) // null is invalid
+  if (Utils.isUndefined(date)) return new Date() // today
   if (date instanceof Date) return date
-  // eslint-disable-next-line no-cond-assign
-  if ((typeof date === 'string')
-    && (/.*[^Z]$/i.test(date)) // looking for a better way
-    && (reg = date.match(C.REGEX_PARSE))) {
-    // 2018-08-08 or 20180808
-    return new Date(
-      reg[1], reg[2] - 1, reg[3] || 1,
-      reg[4] || 0, reg[5] || 0, reg[6] || 0, reg[7] || 0
-    )
+  if (typeof date === 'string' && !date.toLowerCase().endsWith('z')) {
+    const d = date.match(C.REGEX_PARSE)
+    if (d) {
+      return new Date(d[1], d[2] - 1, d[3] || 1, d[4] || 0, d[5] || 0, d[6] || 0, d[7] || 0)
+    }
   }
-  return new Date(date) // timestamp
+
+  return new Date(date) // everything else
 }
 
 class Dayjs {

--- a/src/index.js
+++ b/src/index.js
@@ -51,7 +51,7 @@ const parseDate = (date) => {
   if (typeof date === 'string') {
     const d = date.match(C.REGEX_PARSE)
     if (d) {
-      return new Date(d[1], d[2] - 1, d[3] || 1, d[4] || 0, d[5] || 0, d[6] || 0, d[7] || 0)
+      return new Date(d[1], d[2] - 1, d[3] || 1, d[4] || 0, 0, 0, 0, 0)
     }
   }
 

--- a/test/parse.test.js
+++ b/test/parse.test.js
@@ -15,7 +15,7 @@ describe('Parse', () => {
     expect(dayjs().valueOf()).toBe(moment().valueOf())
   })
 
-  it('String 20130208', () => {
+  it('moment-js like formatted dates', () => {
     global.console.warn = jest.genMockFunction()// moment.js '2018-4-1 1:1:1:22' will throw warn
     let d = '20130108'
     expect(dayjs(d).valueOf()).toBe(moment(d).valueOf())
@@ -44,6 +44,40 @@ describe('Parse', () => {
   it('String ISO 8601 date, time and zone', () => {
     const time = '2018-04-04T16:00:00.000Z'
     expect(dayjs(time).valueOf()).toBe(moment(time).valueOf())
+  })
+
+  it('String RFC 2822, time and zone', () => {
+    const time = 'Mon, 11 Feb 2019 09:46:50 GMT+1'
+    const expected = '2019-02-11T08:46:50.000Z'
+    const d = dayjs(time)
+    expect(d.toISOString()).toEqual(expected)
+    expect(d.valueOf()).toBe(moment(time).valueOf())
+  })
+
+  it('String ECMAScript, time and zone', () => {
+    // should parse dates formatted in ECMA script format
+    // see https://www.ecma-international.org/ecma-262/9.0/index.html#sec-date.prototype.tostring
+    const time = 'Mon Feb 11 2019 11:01:37 GMT+0100 (Mitteleuropäische Normalzeit)'
+    const expected = '2019-02-11T10:01:37.000Z'
+    const d = dayjs(time)
+    expect(d.toISOString()).toEqual(expected)
+    expect(d.valueOf()).toBe(moment(time).valueOf())
+  })
+
+  it('rejects invalid values', () => {
+    expect(dayjs({}).isValid()).toBe(false)
+    expect(dayjs(() => '2018-01-01').isValid()).toBe(false)
+    expect(dayjs(Infinity).isValid()).toBe(false)
+    expect(dayjs(NaN).isValid()).toBe(false)
+    expect(dayjs([2018, 5, 1, 13, 52, 44]).isValid()).toBe(false) // Arrays with time part
+  })
+
+  it('parses Arrays with date part', () => {
+    const dateParts = [2018, 5, 1]
+    const expected = '2018-05-01T00:00:00.000Z'
+    const d = dayjs(dateParts)
+    const normalized = d.add(d.utcOffset(), 'minutes') // make test run in every timezone
+    expect(normalized.toISOString()).toEqual(expected)
   })
 
   it('String Other, Null and isValid', () => {


### PR DESCRIPTION
@xxyuk @iamkun The regex refactoring. First commit just escapes the dot and removes the check for the trailing `'z'` /` 'Z'`, keeping tests green. The second commit shortens the regex, causing more strings to be run through the Date constructor. This should be verified against all Browsers in your CI build.