### PR TITLE
Fix docs about escaping with curly brackets

### DIFF
--- a/docs/en/API-reference.md
+++ b/docs/en/API-reference.md
@@ -257,12 +257,12 @@ dayjs().endOf('month')
 ### Format `.format(stringWithTokens: string)`
 
 Returns a `string` with the `Dayjs`'s formatted date.
-To escape characters, wrap them in square or curly brackets (e.g. `[G] {um}`).
+To escape characters, wrap them in square brackets (e.g. `[G] [um]`).
 
 ```js
 dayjs().format() // current date in ISO6801, without fraction seconds e.g. '2020-04-02T08:02:17-05:00'
 
-dayjs('2019-01-25').format('{YYYY} MM-DDTHH:mm:ssZ[Z]') // '{2019} 01-25T00:00:00-02:00Z'
+dayjs('2019-01-25').format('[YYYY] YYYY-MM-DDTHH:mm:ssZ[Z]') // 'YYYY 2019-01-25T00:00:00-02:00Z'
 
 dayjs('2019-01-25').format('DD/MM/YYYY') // '25/01/2019'
 ```


### PR DESCRIPTION
The current behavior is treat curly brackets as regular characters, only the square brackets have special behavior.

Related code:

https://github.com/iamkun/dayjs/blob/8ede9b76974a1aa7a14f144c58c5e4ce63c393d6/src/index.js#L304-L307

https://github.com/iamkun/dayjs/blob/8ede9b76974a1aa7a14f144c58c5e4ce63c393d6/src/constant.js#L30

