### PR TITLE
Add argument types for dayjs() methods

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,5 +1,6 @@
 export = dayjs;
 declare function dayjs (config?: dayjs.ConfigType, option?: dayjs.OptionType): dayjs.Dayjs
+declare function dayjs (config?: dayjs.ConfigType, format?: string): dayjs.Dayjs
 
 declare namespace dayjs {
   export type ConfigType = string | number | Date | Dayjs


### PR DESCRIPTION
- support usage `dayjs('01-01-2019','DD-MM-YYYY')`  in typescript