### PR TITLE
fix: add support for year before 100

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -50,14 +50,22 @@ const parseDate = (cfg) => {
   if (date === null) return new Date(NaN) // null is invalid
   if (Utils.u(date)) return new Date() // today
   if (date instanceof Date) return new Date(date)
+
   if (typeof date === 'string' && !/Z$/i.test(date)) {
     const d = date.match(C.REGEX_PARSE)
     if (d) {
+      let dt
+
       if (utc) {
-        return new Date(Date.UTC(d[1], d[2] - 1, d[3]
+        dt = new Date(Date.UTC(d[1], d[2] - 1, d[3]
           || 1, d[4] || 0, d[5] || 0, d[6] || 0, d[7] || 0))
+      } else {
+        dt = new Date(d[1], d[2] - 1, d[3] || 1, d[4] || 0, d[5] || 0, d[6] || 0, d[7] || 0)
       }
-      return new Date(d[1], d[2] - 1, d[3] || 1, d[4] || 0, d[5] || 0, d[6] || 0, d[7] || 0)
+
+      dt.setUTCFullYear(d[1])
+
+      return dt
     }
   }
 

--- a/test/parse.test.js
+++ b/test/parse.test.js
@@ -88,6 +88,15 @@ describe('Parse', () => {
     expect(dayjs('otherString').isValid()).toBe(false)
     expect(dayjs(null).toString().toLowerCase()).toBe(moment(null).toString().toLowerCase())
   })
+
+  it('Small value of year', () => {
+    let d = '0000-04-04'
+    expect(dayjs(d).valueOf()).toBe(moment(d).valueOf())
+    d = '00100405'
+    expect(dayjs(d).valueOf()).toBe(moment(d).valueOf())
+    d = '0900-04-04T11:12:13Z'
+    expect(dayjs(d).valueOf()).toBe(moment(d).valueOf())
+  })
 })
 
 it('Unix Timestamp Number (milliseconds) 1523520536000', () => {


### PR DESCRIPTION
This PR brings ability to use years between 0 and 99 while parse date string