### PR TITLE
:sparkles: support set global config for calendar in locale file

### DIFF
--- a/src/plugin/calendar/index.js
+++ b/src/plugin/calendar/index.js
@@ -11,7 +11,7 @@ export default (o, c, d) => {
   }
   const proto = c.prototype
   proto.calendar = function (referenceTime, formats) {
-    const format = formats || calendarFormat
+    const format = formats || this.$locale().calendar || calendarFormat
     const referenceStartOfDay = d(referenceTime || undefined).startOf('d')
     const diff = this.diff(referenceStartOfDay, 'd', true)
     const sameElse = 'sameElse'

--- a/test/plugin/calendar.test.js
+++ b/test/plugin/calendar.test.js
@@ -2,6 +2,7 @@ import MockDate from 'mockdate'
 import moment from 'moment'
 import dayjs from '../../src'
 import calendar from '../../src/plugin/calendar'
+import zhCn from '../../src/locale/zh-cn'
 
 dayjs.extend(calendar)
 
@@ -78,4 +79,19 @@ it('Custom format', () => {
   const nextDayWithoutFormat = '2015-01-14T11:23:55.000Z'
   expect(dayjs(now).calendar(nextDayWithoutFormat, format))
     .toEqual(moment(now).calendar(nextDayWithoutFormat, format))
+})
+
+it('set global calendar in locale file', () => {
+  const now = '2019-04-03T14:21:22.000Z'
+  zhCn.calendar = {
+    sameDay: '[今天]HH:mm',
+    nextDay: '[明天]HH:mm',
+    nextWeek: '[下]ddddHH:mm',
+    lastDay: '[昨天]HH:mm',
+    lastWeek: '[上]ddddHH:mm',
+    sameElse: 'YYYY/MM/DD'
+  }
+  dayjs.locale(zhCn)
+  expect(dayjs(now).calendar())
+    .toEqual(moment(now).locale('zh-cn').calendar())
 })


### PR DESCRIPTION
in order to use global config, no need set the date format in every point