### PR TITLE
Add locales for relativeTime and formats from momentjs

### DIFF
--- a/src/locale/af.js
+++ b/src/locale/af.js
@@ -8,7 +8,30 @@ const locale = {
   weekdaysShort: 'Son_Maa_Din_Woe_Don_Vry_Sat'.split('_'),
   monthsShort: 'Jan_Feb_Mrt_Apr_Mei_Jun_Jul_Aug_Sep_Okt_Nov_Des'.split('_'),
   weekdaysMin: 'So_Ma_Di_Wo_Do_Vr_Sa'.split('_'),
-  ordinal: n => n
+  ordinal: n => n,
+  formats: {
+    LT: 'HH:mm',
+    LTS: 'HH:mm:ss',
+    L: 'DD/MM/YYYY',
+    LL: 'D MMMM YYYY',
+    LLL: 'D MMMM YYYY HH:mm',
+    LLLL: 'dddd, D MMMM YYYY HH:mm'
+  },
+  relativeTime: {
+    future: 'oor %s',
+    past: '%s gelede',
+    s: "'n paar sekondes",
+    m: "'n minuut",
+    mm: '%d minute',
+    h: "'n uur",
+    hh: '%d ure',
+    d: "'n dag",
+    dd: '%d dae',
+    M: "'n maand",
+    MM: '%d maande',
+    y: "'n jaar",
+    yy: '%d jaar'
+  }
 }
 
 dayjs.locale(locale, null, true)

--- a/src/locale/ar-dz.js
+++ b/src/locale/ar-dz.js
@@ -7,7 +7,30 @@ const locale = {
   weekdaysShort: 'احد_اثنين_ثلاثاء_اربعاء_خميس_جمعة_سبت'.split('_'),
   monthsShort: 'جانفي_فيفري_مارس_أفريل_ماي_جوان_جويلية_أوت_سبتمبر_أكتوبر_نوفمبر_ديسمبر'.split('_'),
   weekdaysMin: 'أح_إث_ثلا_أر_خم_جم_سب'.split('_'),
-  ordinal: n => n
+  ordinal: n => n,
+  formats: {
+    LT: 'HH:mm',
+    LTS: 'HH:mm:ss',
+    L: 'DD/MM/YYYY',
+    LL: 'D MMMM YYYY',
+    LLL: 'D MMMM YYYY HH:mm',
+    LLLL: 'dddd D MMMM YYYY HH:mm'
+  },
+  relativeTime: {
+    future: 'في %s',
+    past: 'منذ %s',
+    s: 'ثوان',
+    m: 'دقيقة',
+    mm: '%d دقائق',
+    h: 'ساعة',
+    hh: '%d ساعات',
+    d: 'يوم',
+    dd: '%d أيام',
+    M: 'شهر',
+    MM: '%d أشهر',
+    y: 'سنة',
+    yy: '%d سنوات'
+  }
 }
 
 dayjs.locale(locale, null, true)

--- a/src/locale/ar-kw.js
+++ b/src/locale/ar-kw.js
@@ -7,7 +7,30 @@ const locale = {
   weekdaysShort: 'احد_اتنين_ثلاثاء_اربعاء_خميس_جمعة_سبت'.split('_'),
   monthsShort: 'يناير_فبراير_مارس_أبريل_ماي_يونيو_يوليوز_غشت_شتنبر_أكتوبر_نونبر_دجنبر'.split('_'),
   weekdaysMin: 'ح_ن_ث_ر_خ_ج_س'.split('_'),
-  ordinal: n => n
+  ordinal: n => n,
+  formats: {
+    LT: 'HH:mm',
+    LTS: 'HH:mm:ss',
+    L: 'DD/MM/YYYY',
+    LL: 'D MMMM YYYY',
+    LLL: 'D MMMM YYYY HH:mm',
+    LLLL: 'dddd D MMMM YYYY HH:mm'
+  },
+  relativeTime: {
+    future: 'في %s',
+    past: 'منذ %s',
+    s: 'ثوان',
+    m: 'دقيقة',
+    mm: '%d دقائق',
+    h: 'ساعة',
+    hh: '%d ساعات',
+    d: 'يوم',
+    dd: '%d أيام',
+    M: 'شهر',
+    MM: '%d أشهر',
+    y: 'سنة',
+    yy: '%d سنوات'
+  }
 }
 
 dayjs.locale(locale, null, true)

--- a/src/locale/ar-ly.js
+++ b/src/locale/ar-ly.js
@@ -8,7 +8,15 @@ const locale = {
   weekdaysShort: 'أحد_إثنين_ثلاثاء_أربعاء_خميس_جمعة_سبت'.split('_'),
   monthsShort: 'يناير_فبراير_مارس_أبريل_مايو_يونيو_يوليو_أغسطس_سبتمبر_أكتوبر_نوفمبر_ديسمبر'.split('_'),
   weekdaysMin: 'ح_ن_ث_ر_خ_ج_س'.split('_'),
-  ordinal: n => n
+  ordinal: n => n,
+  formats: {
+    LT: 'HH:mm',
+    LTS: 'HH:mm:ss',
+    L: 'D/‏M/‏YYYY',
+    LL: 'D MMMM YYYY',
+    LLL: 'D MMMM YYYY HH:mm',
+    LLLL: 'dddd D MMMM YYYY HH:mm'
+  }
 }
 
 dayjs.locale(locale, null, true)

--- a/src/locale/ar-ma.js
+++ b/src/locale/ar-ma.js
@@ -8,7 +8,30 @@ const locale = {
   weekdaysShort: 'احد_اتنين_ثلاثاء_اربعاء_خميس_جمعة_سبت'.split('_'),
   monthsShort: 'يناير_فبراير_مارس_أبريل_ماي_يونيو_يوليوز_غشت_شتنبر_أكتوبر_نونبر_دجنبر'.split('_'),
   weekdaysMin: 'ح_ن_ث_ر_خ_ج_س'.split('_'),
-  ordinal: n => n
+  ordinal: n => n,
+  formats: {
+    LT: 'HH:mm',
+    LTS: 'HH:mm:ss',
+    L: 'DD/MM/YYYY',
+    LL: 'D MMMM YYYY',
+    LLL: 'D MMMM YYYY HH:mm',
+    LLLL: 'dddd D MMMM YYYY HH:mm'
+  },
+  relativeTime: {
+    future: 'في %s',
+    past: 'منذ %s',
+    s: 'ثوان',
+    m: 'دقيقة',
+    mm: '%d دقائق',
+    h: 'ساعة',
+    hh: '%d ساعات',
+    d: 'يوم',
+    dd: '%d أيام',
+    M: 'شهر',
+    MM: '%d أشهر',
+    y: 'سنة',
+    yy: '%d سنوات'
+  }
 }
 
 dayjs.locale(locale, null, true)

--- a/src/locale/ar-sa.js
+++ b/src/locale/ar-sa.js
@@ -7,7 +7,30 @@ const locale = {
   weekdaysShort: 'أحد_إثنين_ثلاثاء_أربعاء_خميس_جمعة_سبت'.split('_'),
   monthsShort: 'يناير_فبراير_مارس_أبريل_مايو_يونيو_يوليو_أغسطس_سبتمبر_أكتوبر_نوفمبر_ديسمبر'.split('_'),
   weekdaysMin: 'ح_ن_ث_ر_خ_ج_س'.split('_'),
-  ordinal: n => n
+  ordinal: n => n,
+  formats: {
+    LT: 'HH:mm',
+    LTS: 'HH:mm:ss',
+    L: 'DD/MM/YYYY',
+    LL: 'D MMMM YYYY',
+    LLL: 'D MMMM YYYY HH:mm',
+    LLLL: 'dddd D MMMM YYYY HH:mm'
+  },
+  relativeTime: {
+    future: 'في %s',
+    past: 'منذ %s',
+    s: 'ثوان',
+    m: 'دقيقة',
+    mm: '%d دقائق',
+    h: 'ساعة',
+    hh: '%d ساعات',
+    d: 'يوم',
+    dd: '%d أيام',
+    M: 'شهر',
+    MM: '%d أشهر',
+    y: 'سنة',
+    yy: '%d سنوات'
+  }
 }
 
 dayjs.locale(locale, null, true)

--- a/src/locale/ar-tn.js
+++ b/src/locale/ar-tn.js
@@ -8,7 +8,30 @@ const locale = {
   weekdaysShort: 'أحد_إثنين_ثلاثاء_أربعاء_خميس_جمعة_سبت'.split('_'),
   monthsShort: 'جانفي_فيفري_مارس_أفريل_ماي_جوان_جويلية_أوت_سبتمبر_أكتوبر_نوفمبر_ديسمبر'.split('_'),
   weekdaysMin: 'ح_ن_ث_ر_خ_ج_س'.split('_'),
-  ordinal: n => n
+  ordinal: n => n,
+  formats: {
+    LT: 'HH:mm',
+    LTS: 'HH:mm:ss',
+    L: 'DD/MM/YYYY',
+    LL: 'D MMMM YYYY',
+    LLL: 'D MMMM YYYY HH:mm',
+    LLLL: 'dddd D MMMM YYYY HH:mm'
+  },
+  relativeTime: {
+    future: 'في %s',
+    past: 'منذ %s',
+    s: 'ثوان',
+    m: 'دقيقة',
+    mm: '%d دقائق',
+    h: 'ساعة',
+    hh: '%d ساعات',
+    d: 'يوم',
+    dd: '%d أيام',
+    M: 'شهر',
+    MM: '%d أشهر',
+    y: 'سنة',
+    yy: '%d سنوات'
+  }
 }
 
 dayjs.locale(locale, null, true)

--- a/src/locale/ar.js
+++ b/src/locale/ar.js
@@ -20,9 +20,18 @@ const locale = {
     y: 'عام واحد',
     yy: 'أعوام %d'
   },
-  ordinal: n => n
+  ordinal: n => n,
+  formats: {
+    LT: 'HH:mm',
+    LTS: 'HH:mm:ss',
+    L: 'D/‏M/‏YYYY',
+    LL: 'D MMMM YYYY',
+    LLL: 'D MMMM YYYY HH:mm',
+    LLLL: 'dddd D MMMM YYYY HH:mm'
+  }
 }
 
 dayjs.locale(locale, null, true)
 
 export default locale
+

--- a/src/locale/az.js
+++ b/src/locale/az.js
@@ -37,3 +37,4 @@ const locale = {
 dayjs.locale(locale, null, true)
 
 export default locale
+

--- a/src/locale/be.js
+++ b/src/locale/be.js
@@ -8,7 +8,15 @@ const locale = {
   weekdaysShort: 'нд_пн_ат_ср_чц_пт_сб'.split('_'),
   monthsShort: 'студ_лют_сак_крас_трав_чэрв_ліп_жнів_вер_каст_ліст_снеж'.split('_'),
   weekdaysMin: 'нд_пн_ат_ср_чц_пт_сб'.split('_'),
-  ordinal: n => n
+  ordinal: n => n,
+  formats: {
+    LT: 'HH:mm',
+    LTS: 'HH:mm:ss',
+    L: 'DD.MM.YYYY',
+    LL: 'D MMMM YYYY г.',
+    LLL: 'D MMMM YYYY г., HH:mm',
+    LLLL: 'dddd, D MMMM YYYY г., HH:mm'
+  }
 }
 
 dayjs.locale(locale, null, true)

--- a/src/locale/bg.js
+++ b/src/locale/bg.js
@@ -13,9 +13,25 @@ const locale = {
     LL: 'D MMMM YYYY',
     LLL: 'D MMMM YYYY H:mm',
     LLLL: 'dddd, D MMMM YYYY H:mm'
+  },
+  relativeTime: {
+    future: 'след %s',
+    past: 'преди %s',
+    s: 'няколко секунди',
+    m: 'минута',
+    mm: '%d минути',
+    h: 'час',
+    hh: '%d часа',
+    d: 'ден',
+    dd: '%d дни',
+    M: 'месец',
+    MM: '%d месеца',
+    y: 'година',
+    yy: '%d години'
   }
 }
 
 dayjs.locale(locale, null, true)
 
 export default locale
+

--- a/src/locale/bm.js
+++ b/src/locale/bm.js
@@ -8,7 +8,30 @@ const locale = {
   weekdaysShort: 'Kar_Ntɛ_Tar_Ara_Ala_Jum_Sib'.split('_'),
   monthsShort: 'Zan_Few_Mar_Awi_Mɛ_Zuw_Zul_Uti_Sɛt_ɔku_Now_Des'.split('_'),
   weekdaysMin: 'Ka_Nt_Ta_Ar_Al_Ju_Si'.split('_'),
-  ordinal: n => n
+  ordinal: n => n,
+  formats: {
+    LT: 'HH:mm',
+    LTS: 'HH:mm:ss',
+    L: 'DD/MM/YYYY',
+    LL: 'MMMM [tile] D [san] YYYY',
+    LLL: 'MMMM [tile] D [san] YYYY [lɛrɛ] HH:mm',
+    LLLL: 'dddd MMMM [tile] D [san] YYYY [lɛrɛ] HH:mm'
+  },
+  relativeTime: {
+    future: '%s kɔnɔ',
+    past: 'a bɛ %s bɔ',
+    s: 'sanga dama dama',
+    m: 'miniti kelen',
+    mm: 'miniti %d',
+    h: 'lɛrɛ kelen',
+    hh: 'lɛrɛ %d',
+    d: 'tile kelen',
+    dd: 'tile %d',
+    M: 'kalo kelen',
+    MM: 'kalo %d',
+    y: 'san kelen',
+    yy: 'san %d'
+  }
 }
 
 dayjs.locale(locale, null, true)

--- a/src/locale/bn.js
+++ b/src/locale/bn.js
@@ -7,7 +7,30 @@ const locale = {
   weekdaysShort: 'রবি_সোম_মঙ্গল_বুধ_বৃহস্পতি_শুক্র_শনি'.split('_'),
   monthsShort: 'জানু_ফেব_মার্চ_এপ্র_মে_জুন_জুল_আগ_সেপ্ট_অক্টো_নভে_ডিসে'.split('_'),
   weekdaysMin: 'রবি_সোম_মঙ্গ_বুধ_বৃহঃ_শুক্র_শনি'.split('_'),
-  ordinal: n => n
+  ordinal: n => n,
+  formats: {
+    LT: 'A h:mm সময়',
+    LTS: 'A h:mm:ss সময়',
+    L: 'DD/MM/YYYY',
+    LL: 'D MMMM YYYY',
+    LLL: 'D MMMM YYYY, A h:mm সময়',
+    LLLL: 'dddd, D MMMM YYYY, A h:mm সময়'
+  },
+  relativeTime: {
+    future: '%s পরে',
+    past: '%s আগে',
+    s: 'কয়েক সেকেন্ড',
+    m: 'এক মিনিট',
+    mm: '%d মিনিট',
+    h: 'এক ঘন্টা',
+    hh: '%d ঘন্টা',
+    d: 'এক দিন',
+    dd: '%d দিন',
+    M: 'এক মাস',
+    MM: '%d মাস',
+    y: 'এক বছর',
+    yy: '%d বছর'
+  }
 }
 
 dayjs.locale(locale, null, true)

--- a/src/locale/bo.js
+++ b/src/locale/bo.js
@@ -7,7 +7,30 @@ const locale = {
   weekdaysShort: 'ཉི་མ་_ཟླ་བ་_མིག་དམར་_ལྷག་པ་_ཕུར་བུ_པ་སངས་_སྤེན་པ་'.split('_'),
   monthsShort: 'ཟླ་བ་དང་པོ_ཟླ་བ་གཉིས་པ_ཟླ་བ་གསུམ་པ_ཟླ་བ་བཞི་པ_ཟླ་བ་ལྔ་པ_ཟླ་བ་དྲུག་པ_ཟླ་བ་བདུན་པ_ཟླ་བ་བརྒྱད་པ_ཟླ་བ་དགུ་པ_ཟླ་བ་བཅུ་པ_ཟླ་བ་བཅུ་གཅིག་པ_ཟླ་བ་བཅུ་གཉིས་པ'.split('_'),
   weekdaysMin: 'ཉི་མ་_ཟླ་བ་_མིག་དམར་_ལྷག་པ་_ཕུར་བུ_པ་སངས་_སྤེན་པ་'.split('_'),
-  ordinal: n => n
+  ordinal: n => n,
+  formats: {
+    LT: 'A h:mm',
+    LTS: 'A h:mm:ss',
+    L: 'DD/MM/YYYY',
+    LL: 'D MMMM YYYY',
+    LLL: 'D MMMM YYYY, A h:mm',
+    LLLL: 'dddd, D MMMM YYYY, A h:mm'
+  },
+  relativeTime: {
+    future: '%s ལ་',
+    past: '%s སྔན་ལ',
+    s: 'ལམ་སང',
+    m: 'སྐར་མ་གཅིག',
+    mm: '%d སྐར་མ',
+    h: 'ཆུ་ཚོད་གཅིག',
+    hh: '%d ཆུ་ཚོད',
+    d: 'ཉིན་གཅིག',
+    dd: '%d ཉིན་',
+    M: 'ཟླ་བ་གཅིག',
+    MM: '%d ཟླ་བ',
+    y: 'ལོ་གཅིག',
+    yy: '%d ལོ'
+  }
 }
 
 dayjs.locale(locale, null, true)

--- a/src/locale/br.js
+++ b/src/locale/br.js
@@ -8,7 +8,15 @@ const locale = {
   weekdaysShort: 'Sul_Lun_Meu_Mer_Yao_Gwe_Sad'.split('_'),
   monthsShort: "Gen_C'hwe_Meu_Ebr_Mae_Eve_Gou_Eos_Gwe_Her_Du_Ker".split('_'),
   weekdaysMin: 'Su_Lu_Me_Mer_Ya_Gw_Sa'.split('_'),
-  ordinal: n => n
+  ordinal: n => n,
+  formats: {
+    LT: 'h[e]mm A',
+    LTS: 'h[e]mm:ss A',
+    L: 'DD/MM/YYYY',
+    LL: 'D [a viz] MMMM YYYY',
+    LLL: 'D [a viz] MMMM YYYY h[e]mm A',
+    LLLL: 'dddd, D [a viz] MMMM YYYY h[e]mm A'
+  }
 }
 
 dayjs.locale(locale, null, true)

--- a/src/locale/bs.js
+++ b/src/locale/bs.js
@@ -8,7 +8,15 @@ const locale = {
   weekdaysShort: 'ned._pon._uto._sri._čet._pet._sub.'.split('_'),
   monthsShort: 'jan._feb._mar._apr._maj._jun._jul._aug._sep._okt._nov._dec.'.split('_'),
   weekdaysMin: 'ne_po_ut_sr_če_pe_su'.split('_'),
-  ordinal: n => n
+  ordinal: n => n,
+  formats: {
+    LT: 'H:mm',
+    LTS: 'H:mm:ss',
+    L: 'DD.MM.YYYY',
+    LL: 'D. MMMM YYYY',
+    LLL: 'D. MMMM YYYY H:mm',
+    LLLL: 'dddd, D. MMMM YYYY H:mm'
+  }
 }
 
 dayjs.locale(locale, null, true)

--- a/src/locale/ca.js
+++ b/src/locale/ca.js
@@ -37,3 +37,4 @@ const locale = {
 dayjs.locale(locale, null, true)
 
 export default locale
+

--- a/src/locale/cs.js
+++ b/src/locale/cs.js
@@ -35,3 +35,4 @@ const locale = {
 dayjs.locale(locale, null, true)
 
 export default locale
+

--- a/src/locale/cv.js
+++ b/src/locale/cv.js
@@ -8,7 +8,15 @@ const locale = {
   weekdaysShort: 'выр_тун_ытл_юн_кӗҫ_эрн_шӑм'.split('_'),
   monthsShort: 'кӑр_нар_пуш_ака_май_ҫӗр_утӑ_ҫур_авн_юпа_чӳк_раш'.split('_'),
   weekdaysMin: 'вр_тн_ыт_юн_кҫ_эр_шм'.split('_'),
-  ordinal: n => n
+  ordinal: n => n,
+  formats: {
+    LT: 'HH:mm',
+    LTS: 'HH:mm:ss',
+    L: 'DD-MM-YYYY',
+    LL: 'YYYY [ҫулхи] MMMM [уйӑхӗн] D[-мӗшӗ]',
+    LLL: 'YYYY [ҫулхи] MMMM [уйӑхӗн] D[-мӗшӗ], HH:mm',
+    LLLL: 'dddd, YYYY [ҫулхи] MMMM [уйӑхӗн] D[-мӗшӗ], HH:mm'
+  }
 }
 
 dayjs.locale(locale, null, true)

--- a/src/locale/cy.js
+++ b/src/locale/cy.js
@@ -8,7 +8,30 @@ const locale = {
   weekdaysShort: 'Sul_Llun_Maw_Mer_Iau_Gwe_Sad'.split('_'),
   monthsShort: 'Ion_Chwe_Maw_Ebr_Mai_Meh_Gor_Aws_Med_Hyd_Tach_Rhag'.split('_'),
   weekdaysMin: 'Su_Ll_Ma_Me_Ia_Gw_Sa'.split('_'),
-  ordinal: n => n
+  ordinal: n => n,
+  formats: {
+    LT: 'HH:mm',
+    LTS: 'HH:mm:ss',
+    L: 'DD/MM/YYYY',
+    LL: 'D MMMM YYYY',
+    LLL: 'D MMMM YYYY HH:mm',
+    LLLL: 'dddd, D MMMM YYYY HH:mm'
+  },
+  relativeTime: {
+    future: 'mewn %s',
+    past: '%s yn ôl',
+    s: 'ychydig eiliadau',
+    m: 'munud',
+    mm: '%d munud',
+    h: 'awr',
+    hh: '%d awr',
+    d: 'diwrnod',
+    dd: '%d diwrnod',
+    M: 'mis',
+    MM: '%d mis',
+    y: 'blwyddyn',
+    yy: '%d flynedd'
+  }
 }
 
 dayjs.locale(locale, null, true)

--- a/src/locale/da.js
+++ b/src/locale/da.js
@@ -34,3 +34,4 @@ const locale = {
 dayjs.locale(locale, null, true)
 
 export default locale
+

--- a/src/locale/de-at.js
+++ b/src/locale/de-at.js
@@ -35,3 +35,4 @@ const locale = {
 dayjs.locale(locale, null, true)
 
 export default locale
+

--- a/src/locale/de-ch.js
+++ b/src/locale/de-ch.js
@@ -8,7 +8,15 @@ const locale = {
   weekdaysShort: 'So_Mo_Di_Mi_Do_Fr_Sa'.split('_'),
   monthsShort: 'Jan._Feb._März_Apr._Mai_Juni_Juli_Aug._Sep._Okt._Nov._Dez.'.split('_'),
   weekdaysMin: 'So_Mo_Di_Mi_Do_Fr_Sa'.split('_'),
-  ordinal: n => n
+  ordinal: n => n,
+  formats: {
+    LT: 'HH:mm',
+    LTS: 'HH:mm:ss',
+    L: 'DD.MM.YYYY',
+    LL: 'D. MMMM YYYY',
+    LLL: 'D. MMMM YYYY HH:mm',
+    LLLL: 'dddd, D. MMMM YYYY HH:mm'
+  }
 }
 
 dayjs.locale(locale, null, true)

--- a/src/locale/de.js
+++ b/src/locale/de.js
@@ -35,3 +35,4 @@ const locale = {
 dayjs.locale(locale, null, true)
 
 export default locale
+

--- a/src/locale/dv.js
+++ b/src/locale/dv.js
@@ -8,7 +8,30 @@ const locale = {
   weekdaysShort: 'އާދިއްތަ_ހޯމަ_އަންގާރަ_ބުދަ_ބުރާސްފަތި_ހުކުރު_ހޮނިހިރު'.split('_'),
   monthsShort: 'ޖެނުއަރީ_ފެބްރުއަރީ_މާރިޗު_އޭޕްރީލު_މޭ_ޖޫން_ޖުލައި_އޯގަސްޓު_ސެޕްޓެމްބަރު_އޮކްޓޯބަރު_ނޮވެމްބަރު_ޑިސެމްބަރު'.split('_'),
   weekdaysMin: 'އާދި_ހޯމަ_އަން_ބުދަ_ބުރާ_ހުކު_ހޮނި'.split('_'),
-  ordinal: n => n
+  ordinal: n => n,
+  formats: {
+    LT: 'HH:mm',
+    LTS: 'HH:mm:ss',
+    L: 'D/M/YYYY',
+    LL: 'D MMMM YYYY',
+    LLL: 'D MMMM YYYY HH:mm',
+    LLLL: 'dddd D MMMM YYYY HH:mm'
+  },
+  relativeTime: {
+    future: 'ތެރޭގައި %s',
+    past: 'ކުރިން %s',
+    s: 'ސިކުންތުކޮޅެއް',
+    m: 'މިނިޓެއް',
+    mm: 'މިނިޓު %d',
+    h: 'ގަޑިއިރެއް',
+    hh: 'ގަޑިއިރު %d',
+    d: 'ދުވަހެއް',
+    dd: 'ދުވަސް %d',
+    M: 'މަހެއް',
+    MM: 'މަސް %d',
+    y: 'އަހަރެއް',
+    yy: 'އަހަރު %d'
+  }
 }
 
 dayjs.locale(locale, null, true)

--- a/src/locale/el.js
+++ b/src/locale/el.js
@@ -21,9 +21,18 @@ const locale = {
     MM: '%d μήνες',
     y: 'ένα χρόνο',
     yy: '%d χρόνια'
+  },
+  formats: {
+    LT: 'h:mm A',
+    LTS: 'h:mm:ss A',
+    L: 'DD/MM/YYYY',
+    LL: 'D MMMM YYYY',
+    LLL: 'D MMMM YYYY h:mm A',
+    LLLL: 'dddd, D MMMM YYYY h:mm A'
   }
 }
 
 dayjs.locale(locale, null, true)
 
 export default locale
+

--- a/src/locale/en-SG.js
+++ b/src/locale/en-SG.js
@@ -8,7 +8,30 @@ const locale = {
   weekdaysShort: 'Sun_Mon_Tue_Wed_Thu_Fri_Sat'.split('_'),
   monthsShort: 'Jan_Feb_Mar_Apr_May_Jun_Jul_Aug_Sep_Oct_Nov_Dec'.split('_'),
   weekdaysMin: 'Su_Mo_Tu_We_Th_Fr_Sa'.split('_'),
-  ordinal: n => n
+  ordinal: n => n,
+  formats: {
+    LT: 'HH:mm',
+    LTS: 'HH:mm:ss',
+    L: 'DD/MM/YYYY',
+    LL: 'D MMMM YYYY',
+    LLL: 'D MMMM YYYY HH:mm',
+    LLLL: 'dddd, D MMMM YYYY HH:mm'
+  },
+  relativeTime: {
+    future: 'in %s',
+    past: '%s ago',
+    s: 'a few seconds',
+    m: 'a minute',
+    mm: '%d minutes',
+    h: 'an hour',
+    hh: '%d hours',
+    d: 'a day',
+    dd: '%d days',
+    M: 'a month',
+    MM: '%d months',
+    y: 'a year',
+    yy: '%d years'
+  }
 }
 
 dayjs.locale(locale, null, true)

--- a/src/locale/en-au.js
+++ b/src/locale/en-au.js
@@ -8,7 +8,30 @@ const locale = {
   weekdaysShort: 'Sun_Mon_Tue_Wed_Thu_Fri_Sat'.split('_'),
   monthsShort: 'Jan_Feb_Mar_Apr_May_Jun_Jul_Aug_Sep_Oct_Nov_Dec'.split('_'),
   weekdaysMin: 'Su_Mo_Tu_We_Th_Fr_Sa'.split('_'),
-  ordinal: n => n
+  ordinal: n => n,
+  formats: {
+    LT: 'h:mm A',
+    LTS: 'h:mm:ss A',
+    L: 'DD/MM/YYYY',
+    LL: 'D MMMM YYYY',
+    LLL: 'D MMMM YYYY h:mm A',
+    LLLL: 'dddd, D MMMM YYYY h:mm A'
+  },
+  relativeTime: {
+    future: 'in %s',
+    past: '%s ago',
+    s: 'a few seconds',
+    m: 'a minute',
+    mm: '%d minutes',
+    h: 'an hour',
+    hh: '%d hours',
+    d: 'a day',
+    dd: '%d days',
+    M: 'a month',
+    MM: '%d months',
+    y: 'a year',
+    yy: '%d years'
+  }
 }
 
 dayjs.locale(locale, null, true)

--- a/src/locale/en-ca.js
+++ b/src/locale/en-ca.js
@@ -7,7 +7,30 @@ const locale = {
   weekdaysShort: 'Sun_Mon_Tue_Wed_Thu_Fri_Sat'.split('_'),
   monthsShort: 'Jan_Feb_Mar_Apr_May_Jun_Jul_Aug_Sep_Oct_Nov_Dec'.split('_'),
   weekdaysMin: 'Su_Mo_Tu_We_Th_Fr_Sa'.split('_'),
-  ordinal: n => n
+  ordinal: n => n,
+  formats: {
+    LT: 'h:mm A',
+    LTS: 'h:mm:ss A',
+    L: 'YYYY-MM-DD',
+    LL: 'MMMM D, YYYY',
+    LLL: 'MMMM D, YYYY h:mm A',
+    LLLL: 'dddd, MMMM D, YYYY h:mm A'
+  },
+  relativeTime: {
+    future: 'in %s',
+    past: '%s ago',
+    s: 'a few seconds',
+    m: 'a minute',
+    mm: '%d minutes',
+    h: 'an hour',
+    hh: '%d hours',
+    d: 'a day',
+    dd: '%d days',
+    M: 'a month',
+    MM: '%d months',
+    y: 'a year',
+    yy: '%d years'
+  }
 }
 
 dayjs.locale(locale, null, true)

--- a/src/locale/en-gb.js
+++ b/src/locale/en-gb.js
@@ -41,3 +41,4 @@ const locale = {
 dayjs.locale(locale, null, true)
 
 export default locale
+

--- a/src/locale/en-ie.js
+++ b/src/locale/en-ie.js
@@ -8,7 +8,30 @@ const locale = {
   weekdaysShort: 'Sun_Mon_Tue_Wed_Thu_Fri_Sat'.split('_'),
   monthsShort: 'Jan_Feb_Mar_Apr_May_Jun_Jul_Aug_Sep_Oct_Nov_Dec'.split('_'),
   weekdaysMin: 'Su_Mo_Tu_We_Th_Fr_Sa'.split('_'),
-  ordinal: n => n
+  ordinal: n => n,
+  formats: {
+    LT: 'HH:mm',
+    LTS: 'HH:mm:ss',
+    L: 'DD/MM/YYYY',
+    LL: 'D MMMM YYYY',
+    LLL: 'D MMMM YYYY HH:mm',
+    LLLL: 'dddd D MMMM YYYY HH:mm'
+  },
+  relativeTime: {
+    future: 'in %s',
+    past: '%s ago',
+    s: 'a few seconds',
+    m: 'a minute',
+    mm: '%d minutes',
+    h: 'an hour',
+    hh: '%d hours',
+    d: 'a day',
+    dd: '%d days',
+    M: 'a month',
+    MM: '%d months',
+    y: 'a year',
+    yy: '%d years'
+  }
 }
 
 dayjs.locale(locale, null, true)

--- a/src/locale/en-il.js
+++ b/src/locale/en-il.js
@@ -7,7 +7,30 @@ const locale = {
   weekdaysShort: 'Sun_Mon_Tue_Wed_Thu_Fri_Sat'.split('_'),
   monthsShort: 'Jan_Feb_Mar_Apr_May_Jun_Jul_Aug_Sep_Oct_Nov_Dec'.split('_'),
   weekdaysMin: 'Su_Mo_Tu_We_Th_Fr_Sa'.split('_'),
-  ordinal: n => n
+  ordinal: n => n,
+  formats: {
+    LT: 'HH:mm',
+    LTS: 'HH:mm:ss',
+    L: 'DD/MM/YYYY',
+    LL: 'D MMMM YYYY',
+    LLL: 'D MMMM YYYY HH:mm',
+    LLLL: 'dddd, D MMMM YYYY HH:mm'
+  },
+  relativeTime: {
+    future: 'in %s',
+    past: '%s ago',
+    s: 'a few seconds',
+    m: 'a minute',
+    mm: '%d minutes',
+    h: 'an hour',
+    hh: '%d hours',
+    d: 'a day',
+    dd: '%d days',
+    M: 'a month',
+    MM: '%d months',
+    y: 'a year',
+    yy: '%d years'
+  }
 }
 
 dayjs.locale(locale, null, true)

--- a/src/locale/en-nz.js
+++ b/src/locale/en-nz.js
@@ -8,7 +8,30 @@ const locale = {
   weekdaysShort: 'Sun_Mon_Tue_Wed_Thu_Fri_Sat'.split('_'),
   monthsShort: 'Jan_Feb_Mar_Apr_May_Jun_Jul_Aug_Sep_Oct_Nov_Dec'.split('_'),
   weekdaysMin: 'Su_Mo_Tu_We_Th_Fr_Sa'.split('_'),
-  ordinal: n => n
+  ordinal: n => n,
+  formats: {
+    LT: 'h:mm A',
+    LTS: 'h:mm:ss A',
+    L: 'DD/MM/YYYY',
+    LL: 'D MMMM YYYY',
+    LLL: 'D MMMM YYYY h:mm A',
+    LLLL: 'dddd, D MMMM YYYY h:mm A'
+  },
+  relativeTime: {
+    future: 'in %s',
+    past: '%s ago',
+    s: 'a few seconds',
+    m: 'a minute',
+    mm: '%d minutes',
+    h: 'an hour',
+    hh: '%d hours',
+    d: 'a day',
+    dd: '%d days',
+    M: 'a month',
+    MM: '%d months',
+    y: 'a year',
+    yy: '%d years'
+  }
 }
 
 dayjs.locale(locale, null, true)

--- a/src/locale/eo.js
+++ b/src/locale/eo.js
@@ -8,7 +8,30 @@ const locale = {
   weekdaysShort: 'dim_lun_mard_merk_ĵaŭ_ven_sab'.split('_'),
   monthsShort: 'jan_feb_mar_apr_maj_jun_jul_aŭg_sep_okt_nov_dec'.split('_'),
   weekdaysMin: 'di_lu_ma_me_ĵa_ve_sa'.split('_'),
-  ordinal: n => n
+  ordinal: n => n,
+  formats: {
+    LT: 'HH:mm',
+    LTS: 'HH:mm:ss',
+    L: 'YYYY-MM-DD',
+    LL: 'D[-a de] MMMM, YYYY',
+    LLL: 'D[-a de] MMMM, YYYY HH:mm',
+    LLLL: 'dddd, [la] D[-a de] MMMM, YYYY HH:mm'
+  },
+  relativeTime: {
+    future: 'post %s',
+    past: 'antaŭ %s',
+    s: 'sekundoj',
+    m: 'minuto',
+    mm: '%d minutoj',
+    h: 'horo',
+    hh: '%d horoj',
+    d: 'tago',
+    dd: '%d tagoj',
+    M: 'monato',
+    MM: '%d monatoj',
+    y: 'jaro',
+    yy: '%d jaroj'
+  }
 }
 
 dayjs.locale(locale, null, true)

--- a/src/locale/es-do.js
+++ b/src/locale/es-do.js
@@ -23,9 +23,18 @@ const locale = {
     y: 'un año',
     yy: '%d años'
   },
-  ordinal: n => `${n}º`
+  ordinal: n => `${n}º`,
+  formats: {
+    LT: 'h:mm A',
+    LTS: 'h:mm:ss A',
+    L: 'DD/MM/YYYY',
+    LL: 'D [de] MMMM [de] YYYY',
+    LLL: 'D [de] MMMM [de] YYYY h:mm A',
+    LLLL: 'dddd, D [de] MMMM [de] YYYY h:mm A'
+  }
 }
 
 dayjs.locale(locale, null, true)
 
 export default locale
+

--- a/src/locale/es-us.js
+++ b/src/locale/es-us.js
@@ -22,9 +22,18 @@ const locale = {
     y: 'un año',
     yy: '%d años'
   },
-  ordinal: n => `${n}º`
+  ordinal: n => `${n}º`,
+  formats: {
+    LT: 'h:mm A',
+    LTS: 'h:mm:ss A',
+    L: 'MM/DD/YYYY',
+    LL: 'D [de] MMMM [de] YYYY',
+    LLL: 'D [de] MMMM [de] YYYY h:mm A',
+    LLLL: 'dddd, D [de] MMMM [de] YYYY h:mm A'
+  }
 }
 
 dayjs.locale(locale, null, true)
 
 export default locale
+

--- a/src/locale/es.js
+++ b/src/locale/es.js
@@ -37,3 +37,4 @@ const locale = {
 dayjs.locale(locale, null, true)
 
 export default locale
+

--- a/src/locale/et.js
+++ b/src/locale/et.js
@@ -31,9 +31,18 @@ const locale = {
     MM: '%d kuud', // for past tense
     y: 'aasta', // for past tense
     yy: '%d aastat' // for past tense
+  },
+  formats: {
+    LT: 'H:mm',
+    LTS: 'H:mm:ss',
+    L: 'DD.MM.YYYY',
+    LL: 'D. MMMM YYYY',
+    LLL: 'D. MMMM YYYY H:mm',
+    LLLL: 'dddd, D. MMMM YYYY H:mm'
   }
 }
 
 dayjs.locale(locale, null, true)
 
 export default locale
+

--- a/src/locale/eu.js
+++ b/src/locale/eu.js
@@ -8,7 +8,34 @@ const locale = {
   weekdaysShort: 'ig._al._ar._az._og._ol._lr.'.split('_'),
   monthsShort: 'urt._ots._mar._api._mai._eka._uzt._abu._ira._urr._aza._abe.'.split('_'),
   weekdaysMin: 'ig_al_ar_az_og_ol_lr'.split('_'),
-  ordinal: n => n
+  ordinal: n => n,
+  formats: {
+    LT: 'HH:mm',
+    LTS: 'HH:mm:ss',
+    L: 'YYYY-MM-DD',
+    LL: 'YYYY[ko] MMMM[ren] D[a]',
+    LLL: 'YYYY[ko] MMMM[ren] D[a] HH:mm',
+    LLLL: 'dddd, YYYY[ko] MMMM[ren] D[a] HH:mm',
+    l: 'YYYY-M-D',
+    ll: 'YYYY[ko] MMM D[a]',
+    lll: 'YYYY[ko] MMM D[a] HH:mm',
+    llll: 'ddd, YYYY[ko] MMM D[a] HH:mm'
+  },
+  relativeTime: {
+    future: '%s barru',
+    past: 'duela %s',
+    s: 'segundo batzuk',
+    m: 'minutu bat',
+    mm: '%d minutu',
+    h: 'ordu bat',
+    hh: '%d ordu',
+    d: 'egun bat',
+    dd: '%d egun',
+    M: 'hilabete bat',
+    MM: '%d hilabete',
+    y: 'urte bat',
+    yy: '%d urte'
+  }
 }
 
 dayjs.locale(locale, null, true)

--- a/src/locale/fa.js
+++ b/src/locale/fa.js
@@ -33,3 +33,4 @@ const locale = {
 dayjs.locale(locale, null, true)
 
 export default locale
+

--- a/src/locale/fi.js
+++ b/src/locale/fi.js
@@ -50,3 +50,4 @@ const locale = {
 dayjs.locale(locale, null, true)
 
 export default locale
+

--- a/src/locale/fo.js
+++ b/src/locale/fo.js
@@ -8,7 +8,30 @@ const locale = {
   weekdaysShort: 'sun_mán_týs_mik_hós_frí_ley'.split('_'),
   monthsShort: 'jan_feb_mar_apr_mai_jun_jul_aug_sep_okt_nov_des'.split('_'),
   weekdaysMin: 'su_má_tý_mi_hó_fr_le'.split('_'),
-  ordinal: n => n
+  ordinal: n => n,
+  formats: {
+    LT: 'HH:mm',
+    LTS: 'HH:mm:ss',
+    L: 'DD/MM/YYYY',
+    LL: 'D MMMM YYYY',
+    LLL: 'D MMMM YYYY HH:mm',
+    LLLL: 'dddd D. MMMM, YYYY HH:mm'
+  },
+  relativeTime: {
+    future: 'um %s',
+    past: '%s síðani',
+    s: 'fá sekund',
+    m: 'ein minuttur',
+    mm: '%d minuttir',
+    h: 'ein tími',
+    hh: '%d tímar',
+    d: 'ein dagur',
+    dd: '%d dagar',
+    M: 'ein mánaður',
+    MM: '%d mánaðir',
+    y: 'eitt ár',
+    yy: '%d ár'
+  }
 }
 
 dayjs.locale(locale, null, true)

--- a/src/locale/fr-ca.js
+++ b/src/locale/fr-ca.js
@@ -7,7 +7,30 @@ const locale = {
   weekdaysShort: 'dim._lun._mar._mer._jeu._ven._sam.'.split('_'),
   monthsShort: 'janv._févr._mars_avr._mai_juin_juil._août_sept._oct._nov._déc.'.split('_'),
   weekdaysMin: 'di_lu_ma_me_je_ve_sa'.split('_'),
-  ordinal: n => n
+  ordinal: n => n,
+  formats: {
+    LT: 'HH:mm',
+    LTS: 'HH:mm:ss',
+    L: 'YYYY-MM-DD',
+    LL: 'D MMMM YYYY',
+    LLL: 'D MMMM YYYY HH:mm',
+    LLLL: 'dddd D MMMM YYYY HH:mm'
+  },
+  relativeTime: {
+    future: 'dans %s',
+    past: 'il y a %s',
+    s: 'quelques secondes',
+    m: 'une minute',
+    mm: '%d minutes',
+    h: 'une heure',
+    hh: '%d heures',
+    d: 'un jour',
+    dd: '%d jours',
+    M: 'un mois',
+    MM: '%d mois',
+    y: 'un an',
+    yy: '%d ans'
+  }
 }
 
 dayjs.locale(locale, null, true)

--- a/src/locale/fr-ch.js
+++ b/src/locale/fr-ch.js
@@ -8,7 +8,30 @@ const locale = {
   weekdaysShort: 'dim._lun._mar._mer._jeu._ven._sam.'.split('_'),
   monthsShort: 'janv._févr._mars_avr._mai_juin_juil._août_sept._oct._nov._déc.'.split('_'),
   weekdaysMin: 'di_lu_ma_me_je_ve_sa'.split('_'),
-  ordinal: n => n
+  ordinal: n => n,
+  formats: {
+    LT: 'HH:mm',
+    LTS: 'HH:mm:ss',
+    L: 'DD.MM.YYYY',
+    LL: 'D MMMM YYYY',
+    LLL: 'D MMMM YYYY HH:mm',
+    LLLL: 'dddd D MMMM YYYY HH:mm'
+  },
+  relativeTime: {
+    future: 'dans %s',
+    past: 'il y a %s',
+    s: 'quelques secondes',
+    m: 'une minute',
+    mm: '%d minutes',
+    h: 'une heure',
+    hh: '%d heures',
+    d: 'un jour',
+    dd: '%d jours',
+    M: 'un mois',
+    MM: '%d mois',
+    y: 'un an',
+    yy: '%d ans'
+  }
 }
 
 dayjs.locale(locale, null, true)

--- a/src/locale/fr.js
+++ b/src/locale/fr.js
@@ -38,3 +38,4 @@ const locale = {
 dayjs.locale(locale, null, true)
 
 export default locale
+

--- a/src/locale/fy.js
+++ b/src/locale/fy.js
@@ -7,7 +7,30 @@ const locale = {
   weekStart: 1,
   weekdaysShort: 'si._mo._ti._wo._to._fr._so.'.split('_'),
   weekdaysMin: 'Si_Mo_Ti_Wo_To_Fr_So'.split('_'),
-  ordinal: n => n
+  ordinal: n => n,
+  formats: {
+    LT: 'HH:mm',
+    LTS: 'HH:mm:ss',
+    L: 'DD-MM-YYYY',
+    LL: 'D MMMM YYYY',
+    LLL: 'D MMMM YYYY HH:mm',
+    LLLL: 'dddd D MMMM YYYY HH:mm'
+  },
+  relativeTime: {
+    future: 'oer %s',
+    past: '%s lyn',
+    s: 'in pear sekonden',
+    m: 'ien minút',
+    mm: '%d minuten',
+    h: 'ien oere',
+    hh: '%d oeren',
+    d: 'ien dei',
+    dd: '%d dagen',
+    M: 'ien moanne',
+    MM: '%d moannen',
+    y: 'ien jier',
+    yy: '%d jierren'
+  }
 }
 
 dayjs.locale(locale, null, true)

--- a/src/locale/ga.js
+++ b/src/locale/ga.js
@@ -8,7 +8,30 @@ const locale = {
   weekdaysShort: 'Dom_Lua_Mái_Céa_Déa_hAo_Sat'.split('_'),
   monthsShort: 'Eaná_Feab_Márt_Aibr_Beal_Méit_Iúil_Lúna_Meán_Deai_Samh_Noll'.split('_'),
   weekdaysMin: 'Do_Lu_Má_Ce_Dé_hA_Sa'.split('_'),
-  ordinal: n => n
+  ordinal: n => n,
+  formats: {
+    LT: 'HH:mm',
+    LTS: 'HH:mm:ss',
+    L: 'DD/MM/YYYY',
+    LL: 'D MMMM YYYY',
+    LLL: 'D MMMM YYYY HH:mm',
+    LLLL: 'dddd, D MMMM YYYY HH:mm'
+  },
+  relativeTime: {
+    future: 'i %s',
+    past: '%s ó shin',
+    s: 'cúpla soicind',
+    m: 'nóiméad',
+    mm: '%d nóiméad',
+    h: 'uair an chloig',
+    hh: '%d uair an chloig',
+    d: 'lá',
+    dd: '%d lá',
+    M: 'mí',
+    MM: '%d mí',
+    y: 'bliain',
+    yy: '%d bliain'
+  }
 }
 
 dayjs.locale(locale, null, true)

--- a/src/locale/gd.js
+++ b/src/locale/gd.js
@@ -8,7 +8,30 @@ const locale = {
   weekdaysShort: 'Did_Dil_Dim_Dic_Dia_Dih_Dis'.split('_'),
   monthsShort: 'Faoi_Gear_Màrt_Gibl_Cèit_Ògmh_Iuch_Lùn_Sult_Dàmh_Samh_Dùbh'.split('_'),
   weekdaysMin: 'Dò_Lu_Mà_Ci_Ar_Ha_Sa'.split('_'),
-  ordinal: n => n
+  ordinal: n => n,
+  formats: {
+    LT: 'HH:mm',
+    LTS: 'HH:mm:ss',
+    L: 'DD/MM/YYYY',
+    LL: 'D MMMM YYYY',
+    LLL: 'D MMMM YYYY HH:mm',
+    LLLL: 'dddd, D MMMM YYYY HH:mm'
+  },
+  relativeTime: {
+    future: 'ann an %s',
+    past: 'bho chionn %s',
+    s: 'beagan diogan',
+    m: 'mionaid',
+    mm: '%d mionaidean',
+    h: 'uair',
+    hh: '%d uairean',
+    d: 'latha',
+    dd: '%d latha',
+    M: 'mìos',
+    MM: '%d mìosan',
+    y: 'bliadhna',
+    yy: '%d bliadhna'
+  }
 }
 
 dayjs.locale(locale, null, true)

--- a/src/locale/gl.js
+++ b/src/locale/gl.js
@@ -8,7 +8,15 @@ const locale = {
   weekdaysShort: 'dom._lun._mar._mér._xov._ven._sáb.'.split('_'),
   monthsShort: 'xan._feb._mar._abr._mai._xuñ._xul._ago._set._out._nov._dec.'.split('_'),
   weekdaysMin: 'do_lu_ma_mé_xo_ve_sá'.split('_'),
-  ordinal: n => n
+  ordinal: n => n,
+  formats: {
+    LT: 'H:mm',
+    LTS: 'H:mm:ss',
+    L: 'DD/MM/YYYY',
+    LL: 'D [de] MMMM [de] YYYY',
+    LLL: 'D [de] MMMM [de] YYYY H:mm',
+    LLLL: 'dddd, D [de] MMMM [de] YYYY H:mm'
+  }
 }
 
 dayjs.locale(locale, null, true)

--- a/src/locale/gom-latn.js
+++ b/src/locale/gom-latn.js
@@ -8,7 +8,16 @@ const locale = {
   weekdaysShort: 'Ait._Som._Mon._Bud._Bre._Suk._Son.'.split('_'),
   monthsShort: 'Jan._Feb._Mars_Abr._Mai_Jun_Jul._Ago._Set._Otu._Nov._Dez.'.split('_'),
   weekdaysMin: 'Ai_Sm_Mo_Bu_Br_Su_Sn'.split('_'),
-  ordinal: n => n
+  ordinal: n => n,
+  formats: {
+    LT: 'A h:mm [vazta]',
+    LTS: 'A h:mm:ss [vazta]',
+    L: 'DD-MM-YYYY',
+    LL: 'D MMMM YYYY',
+    LLL: 'D MMMM YYYY A h:mm [vazta]',
+    LLLL: 'dddd, MMMM[achea] Do, YYYY, A h:mm [vazta]',
+    llll: 'ddd, D MMM YYYY, A h:mm [vazta]'
+  }
 }
 
 dayjs.locale(locale, null, true)

--- a/src/locale/gu.js
+++ b/src/locale/gu.js
@@ -7,7 +7,30 @@ const locale = {
   weekdaysShort: 'રવિ_સોમ_મંગળ_બુધ્_ગુરુ_શુક્ર_શનિ'.split('_'),
   monthsShort: 'જાન્યુ._ફેબ્રુ._માર્ચ_એપ્રિ._મે_જૂન_જુલા._ઑગ._સપ્ટે._ઑક્ટ્._નવે._ડિસે.'.split('_'),
   weekdaysMin: 'ર_સો_મં_બુ_ગુ_શુ_શ'.split('_'),
-  ordinal: n => n
+  ordinal: n => n,
+  formats: {
+    LT: 'A h:mm વાગ્યે',
+    LTS: 'A h:mm:ss વાગ્યે',
+    L: 'DD/MM/YYYY',
+    LL: 'D MMMM YYYY',
+    LLL: 'D MMMM YYYY, A h:mm વાગ્યે',
+    LLLL: 'dddd, D MMMM YYYY, A h:mm વાગ્યે'
+  },
+  relativeTime: {
+    future: '%s મા',
+    past: '%s પેહલા',
+    s: 'અમુક પળો',
+    m: 'એક મિનિટ',
+    mm: '%d મિનિટ',
+    h: 'એક કલાક',
+    hh: '%d કલાક',
+    d: 'એક દિવસ',
+    dd: '%d દિવસ',
+    M: 'એક મહિનો',
+    MM: '%d મહિનો',
+    y: 'એક વર્ષ',
+    yy: '%d વર્ષ'
+  }
 }
 
 dayjs.locale(locale, null, true)

--- a/src/locale/he.js
+++ b/src/locale/he.js
@@ -33,9 +33,22 @@ const locale = {
     ll: 'D MMM YYYY',
     lll: 'D MMM YYYY HH:mm',
     llll: 'ddd, D MMM YYYY HH:mm'
+  },
+  formats: {
+    LT: 'HH:mm',
+    LTS: 'HH:mm:ss',
+    L: 'DD/MM/YYYY',
+    LL: 'D [ב]MMMM YYYY',
+    LLL: 'D [ב]MMMM YYYY HH:mm',
+    LLLL: 'dddd, D [ב]MMMM YYYY HH:mm',
+    l: 'D/M/YYYY',
+    ll: 'D MMM YYYY',
+    lll: 'D MMM YYYY HH:mm',
+    llll: 'ddd, D MMM YYYY HH:mm'
   }
 }
 
 dayjs.locale(locale, null, true)
 
 export default locale
+

--- a/src/locale/hi.js
+++ b/src/locale/hi.js
@@ -7,7 +7,30 @@ const locale = {
   weekdaysShort: 'रवि_सोम_मंगल_बुध_गुरू_शुक्र_शनि'.split('_'),
   monthsShort: 'जन._फ़र._मार्च_अप्रै._मई_जून_जुल._अग._सित._अक्टू._नव._दिस.'.split('_'),
   weekdaysMin: 'र_सो_मं_बु_गु_शु_श'.split('_'),
-  ordinal: n => n
+  ordinal: n => n,
+  formats: {
+    LT: 'A h:mm बजे',
+    LTS: 'A h:mm:ss बजे',
+    L: 'DD/MM/YYYY',
+    LL: 'D MMMM YYYY',
+    LLL: 'D MMMM YYYY, A h:mm बजे',
+    LLLL: 'dddd, D MMMM YYYY, A h:mm बजे'
+  },
+  relativeTime: {
+    future: '%s में',
+    past: '%s पहले',
+    s: 'कुछ ही क्षण',
+    m: 'एक मिनट',
+    mm: '%d मिनट',
+    h: 'एक घंटा',
+    hh: '%d घंटे',
+    d: 'एक दिन',
+    dd: '%d दिन',
+    M: 'एक महीने',
+    MM: '%d महीने',
+    y: 'एक वर्ष',
+    yy: '%d वर्ष'
+  }
 }
 
 dayjs.locale(locale, null, true)

--- a/src/locale/hr.js
+++ b/src/locale/hr.js
@@ -34,3 +34,4 @@ const locale = {
 dayjs.locale(locale, null, true)
 
 export default locale
+

--- a/src/locale/hu.js
+++ b/src/locale/hu.js
@@ -23,9 +23,18 @@ const locale = {
     MM: '%d hónap',
     y: 'egy éve',
     yy: '%d év'
+  },
+  formats: {
+    LT: 'H:mm',
+    LTS: 'H:mm:ss',
+    L: 'YYYY.MM.DD.',
+    LL: 'YYYY. MMMM D.',
+    LLL: 'YYYY. MMMM D. H:mm',
+    LLLL: 'YYYY. MMMM D., dddd H:mm'
   }
 }
 
 dayjs.locale(locale, null, true)
 
 export default locale
+

--- a/src/locale/hy-am.js
+++ b/src/locale/hy-am.js
@@ -8,7 +8,30 @@ const locale = {
   weekdaysShort: 'կրկ_երկ_երք_չրք_հնգ_ուրբ_շբթ'.split('_'),
   monthsShort: 'հնվ_փտր_մրտ_ապր_մյս_հնս_հլս_օգս_սպտ_հկտ_նմբ_դկտ'.split('_'),
   weekdaysMin: 'կրկ_երկ_երք_չրք_հնգ_ուրբ_շբթ'.split('_'),
-  ordinal: n => n
+  ordinal: n => n,
+  formats: {
+    LT: 'HH:mm',
+    LTS: 'HH:mm:ss',
+    L: 'DD.MM.YYYY',
+    LL: 'D MMMM YYYY թ.',
+    LLL: 'D MMMM YYYY թ., HH:mm',
+    LLLL: 'dddd, D MMMM YYYY թ., HH:mm'
+  },
+  relativeTime: {
+    future: '%s հետո',
+    past: '%s առաջ',
+    s: 'մի քանի վայրկյան',
+    m: 'րոպե',
+    mm: '%d րոպե',
+    h: 'ժամ',
+    hh: '%d ժամ',
+    d: 'օր',
+    dd: '%d օր',
+    M: 'ամիս',
+    MM: '%d ամիս',
+    y: 'տարի',
+    yy: '%d տարի'
+  }
 }
 
 dayjs.locale(locale, null, true)

--- a/src/locale/id.js
+++ b/src/locale/id.js
@@ -34,3 +34,4 @@ const locale = {
 dayjs.locale(locale, null, true)
 
 export default locale
+

--- a/src/locale/is.js
+++ b/src/locale/is.js
@@ -8,7 +8,15 @@ const locale = {
   weekdaysShort: 'sun_mán_þri_mið_fim_fös_lau'.split('_'),
   monthsShort: 'jan_feb_mar_apr_maí_jún_júl_ágú_sep_okt_nóv_des'.split('_'),
   weekdaysMin: 'Su_Má_Þr_Mi_Fi_Fö_La'.split('_'),
-  ordinal: n => n
+  ordinal: n => n,
+  formats: {
+    LT: 'H:mm',
+    LTS: 'H:mm:ss',
+    L: 'DD.MM.YYYY',
+    LL: 'D. MMMM YYYY',
+    LLL: 'D. MMMM YYYY [kl.] H:mm',
+    LLLL: 'dddd, D. MMMM YYYY [kl.] H:mm'
+  }
 }
 
 dayjs.locale(locale, null, true)

--- a/src/locale/it-ch.js
+++ b/src/locale/it-ch.js
@@ -8,7 +8,15 @@ const locale = {
   weekdaysShort: 'dom_lun_mar_mer_gio_ven_sab'.split('_'),
   monthsShort: 'gen_feb_mar_apr_mag_giu_lug_ago_set_ott_nov_dic'.split('_'),
   weekdaysMin: 'do_lu_ma_me_gi_ve_sa'.split('_'),
-  ordinal: n => n
+  ordinal: n => n,
+  formats: {
+    LT: 'HH:mm',
+    LTS: 'HH:mm:ss',
+    L: 'DD.MM.YYYY',
+    LL: 'D MMMM YYYY',
+    LLL: 'D MMMM YYYY HH:mm',
+    LLLL: 'dddd D MMMM YYYY HH:mm'
+  }
 }
 
 dayjs.locale(locale, null, true)

--- a/src/locale/it.js
+++ b/src/locale/it.js
@@ -37,3 +37,4 @@ const locale = {
 dayjs.locale(locale, null, true)
 
 export default locale
+

--- a/src/locale/ja.js
+++ b/src/locale/ja.js
@@ -39,3 +39,4 @@ const locale = {
 dayjs.locale(locale, null, true)
 
 export default locale
+

--- a/src/locale/jv.js
+++ b/src/locale/jv.js
@@ -8,7 +8,30 @@ const locale = {
   weekdaysShort: 'Min_Sen_Sel_Reb_Kem_Jem_Sep'.split('_'),
   monthsShort: 'Jan_Feb_Mar_Apr_Mei_Jun_Jul_Ags_Sep_Okt_Nop_Des'.split('_'),
   weekdaysMin: 'Mg_Sn_Sl_Rb_Km_Jm_Sp'.split('_'),
-  ordinal: n => n
+  ordinal: n => n,
+  formats: {
+    LT: 'HH.mm',
+    LTS: 'HH.mm.ss',
+    L: 'DD/MM/YYYY',
+    LL: 'D MMMM YYYY',
+    LLL: 'D MMMM YYYY [pukul] HH.mm',
+    LLLL: 'dddd, D MMMM YYYY [pukul] HH.mm'
+  },
+  relativeTime: {
+    future: 'wonten ing %s',
+    past: '%s ingkang kepengker',
+    s: 'sawetawis detik',
+    m: 'setunggal menit',
+    mm: '%d menit',
+    h: 'setunggal jam',
+    hh: '%d jam',
+    d: 'sedinten',
+    dd: '%d dinten',
+    M: 'sewulan',
+    MM: '%d wulan',
+    y: 'setaun',
+    yy: '%d taun'
+  }
 }
 
 dayjs.locale(locale, null, true)

--- a/src/locale/ka.js
+++ b/src/locale/ka.js
@@ -34,3 +34,4 @@ const locale = {
 dayjs.locale(locale, null, true)
 
 export default locale
+

--- a/src/locale/kk.js
+++ b/src/locale/kk.js
@@ -23,9 +23,18 @@ const locale = {
     y: 'бір жыл',
     yy: '%d жыл'
   },
-  ordinal: n => n
+  ordinal: n => n,
+  formats: {
+    LT: 'HH:mm',
+    LTS: 'HH:mm:ss',
+    L: 'DD.MM.YYYY',
+    LL: 'D MMMM YYYY',
+    LLL: 'D MMMM YYYY HH:mm',
+    LLLL: 'dddd, D MMMM YYYY HH:mm'
+  }
 }
 
 dayjs.locale(locale, null, true)
 
 export default locale
+

--- a/src/locale/km.js
+++ b/src/locale/km.js
@@ -8,7 +8,30 @@ const locale = {
   weekdaysShort: 'អា_ច_អ_ព_ព្រ_សុ_ស'.split('_'),
   monthsShort: 'មករា_កុម្ភៈ_មីនា_មេសា_ឧសភា_មិថុនា_កក្កដា_សីហា_កញ្ញា_តុលា_វិច្ឆិកា_ធ្នូ'.split('_'),
   weekdaysMin: 'អា_ច_អ_ព_ព្រ_សុ_ស'.split('_'),
-  ordinal: n => n
+  ordinal: n => n,
+  formats: {
+    LT: 'HH:mm',
+    LTS: 'HH:mm:ss',
+    L: 'DD/MM/YYYY',
+    LL: 'D MMMM YYYY',
+    LLL: 'D MMMM YYYY HH:mm',
+    LLLL: 'dddd, D MMMM YYYY HH:mm'
+  },
+  relativeTime: {
+    future: '%sទៀត',
+    past: '%sមុន',
+    s: 'ប៉ុន្មានវិនាទី',
+    m: 'មួយនាទី',
+    mm: '%d នាទី',
+    h: 'មួយម៉ោង',
+    hh: '%d ម៉ោង',
+    d: 'មួយថ្ងៃ',
+    dd: '%d ថ្ងៃ',
+    M: 'មួយខែ',
+    MM: '%d ខែ',
+    y: 'មួយឆ្នាំ',
+    yy: '%d ឆ្នាំ'
+  }
 }
 
 dayjs.locale(locale, null, true)

--- a/src/locale/kn.js
+++ b/src/locale/kn.js
@@ -7,7 +7,30 @@ const locale = {
   weekdaysShort: 'ಭಾನು_ಸೋಮ_ಮಂಗಳ_ಬುಧ_ಗುರು_ಶುಕ್ರ_ಶನಿ'.split('_'),
   monthsShort: 'ಜನ_ಫೆಬ್ರ_ಮಾರ್ಚ್_ಏಪ್ರಿಲ್_ಮೇ_ಜೂನ್_ಜುಲೈ_ಆಗಸ್ಟ್_ಸೆಪ್ಟೆಂ_ಅಕ್ಟೋ_ನವೆಂ_ಡಿಸೆಂ'.split('_'),
   weekdaysMin: 'ಭಾ_ಸೋ_ಮಂ_ಬು_ಗು_ಶು_ಶ'.split('_'),
-  ordinal: n => n
+  ordinal: n => n,
+  formats: {
+    LT: 'A h:mm',
+    LTS: 'A h:mm:ss',
+    L: 'DD/MM/YYYY',
+    LL: 'D MMMM YYYY',
+    LLL: 'D MMMM YYYY, A h:mm',
+    LLLL: 'dddd, D MMMM YYYY, A h:mm'
+  },
+  relativeTime: {
+    future: '%s ನಂತರ',
+    past: '%s ಹಿಂದೆ',
+    s: 'ಕೆಲವು ಕ್ಷಣಗಳು',
+    m: 'ಒಂದು ನಿಮಿಷ',
+    mm: '%d ನಿಮಿಷ',
+    h: 'ಒಂದು ಗಂಟೆ',
+    hh: '%d ಗಂಟೆ',
+    d: 'ಒಂದು ದಿನ',
+    dd: '%d ದಿನ',
+    M: 'ಒಂದು ತಿಂಗಳು',
+    MM: '%d ತಿಂಗಳು',
+    y: 'ಒಂದು ವರ್ಷ',
+    yy: '%d ವರ್ಷ'
+  }
 }
 
 dayjs.locale(locale, null, true)

--- a/src/locale/ko.js
+++ b/src/locale/ko.js
@@ -38,3 +38,4 @@ const locale = {
 dayjs.locale(locale, null, true)
 
 export default locale
+

--- a/src/locale/ku.js
+++ b/src/locale/ku.js
@@ -8,7 +8,30 @@ const locale = {
   weekdaysShort: 'یه‌كشه‌م_دووشه‌م_سێشه‌م_چوارشه‌م_پێنجشه‌م_هه‌ینی_شه‌ممه‌'.split('_'),
   monthsShort: 'کانونی دووەم_شوبات_ئازار_نیسان_ئایار_حوزەیران_تەمموز_ئاب_ئەیلوول_تشرینی یەكەم_تشرینی دووەم_كانونی یەکەم'.split('_'),
   weekdaysMin: 'ی_د_س_چ_پ_ه_ش'.split('_'),
-  ordinal: n => n
+  ordinal: n => n,
+  formats: {
+    LT: 'HH:mm',
+    LTS: 'HH:mm:ss',
+    L: 'DD/MM/YYYY',
+    LL: 'D MMMM YYYY',
+    LLL: 'D MMMM YYYY HH:mm',
+    LLLL: 'dddd, D MMMM YYYY HH:mm'
+  },
+  relativeTime: {
+    future: 'له‌ %s',
+    past: '%s',
+    s: 'چه‌ند چركه‌یه‌ك',
+    m: 'یه‌ك خوله‌ك',
+    mm: '%d خوله‌ك',
+    h: 'یه‌ك كاتژمێر',
+    hh: '%d كاتژمێر',
+    d: 'یه‌ك ڕۆژ',
+    dd: '%d ڕۆژ',
+    M: 'یه‌ك مانگ',
+    MM: '%d مانگ',
+    y: 'یه‌ك ساڵ',
+    yy: '%d ساڵ'
+  }
 }
 
 dayjs.locale(locale, null, true)

--- a/src/locale/ky.js
+++ b/src/locale/ky.js
@@ -8,7 +8,30 @@ const locale = {
   weekdaysShort: 'Жек_Дүй_Шей_Шар_Бей_Жум_Ише'.split('_'),
   monthsShort: 'янв_фев_март_апр_май_июнь_июль_авг_сен_окт_ноя_дек'.split('_'),
   weekdaysMin: 'Жк_Дй_Шй_Шр_Бй_Жм_Иш'.split('_'),
-  ordinal: n => n
+  ordinal: n => n,
+  formats: {
+    LT: 'HH:mm',
+    LTS: 'HH:mm:ss',
+    L: 'DD.MM.YYYY',
+    LL: 'D MMMM YYYY',
+    LLL: 'D MMMM YYYY HH:mm',
+    LLLL: 'dddd, D MMMM YYYY HH:mm'
+  },
+  relativeTime: {
+    future: '%s ичинде',
+    past: '%s мурун',
+    s: 'бирнече секунд',
+    m: 'бир мүнөт',
+    mm: '%d мүнөт',
+    h: 'бир саат',
+    hh: '%d саат',
+    d: 'бир күн',
+    dd: '%d күн',
+    M: 'бир ай',
+    MM: '%d ай',
+    y: 'бир жыл',
+    yy: '%d жыл'
+  }
 }
 
 dayjs.locale(locale, null, true)

--- a/src/locale/lb.js
+++ b/src/locale/lb.js
@@ -8,7 +8,15 @@ const locale = {
   weekdaysShort: 'So._Mé._Dë._Më._Do._Fr._Sa.'.split('_'),
   monthsShort: 'Jan._Febr._Mrz._Abr._Mee_Jun._Jul._Aug._Sept._Okt._Nov._Dez.'.split('_'),
   weekdaysMin: 'So_Mé_Dë_Më_Do_Fr_Sa'.split('_'),
-  ordinal: n => n
+  ordinal: n => n,
+  formats: {
+    LT: 'H:mm [Auer]',
+    LTS: 'H:mm:ss [Auer]',
+    L: 'DD.MM.YYYY',
+    LL: 'D. MMMM YYYY',
+    LLL: 'D. MMMM YYYY H:mm [Auer]',
+    LLLL: 'dddd, D. MMMM YYYY H:mm [Auer]'
+  }
 }
 
 dayjs.locale(locale, null, true)

--- a/src/locale/lo.js
+++ b/src/locale/lo.js
@@ -7,7 +7,30 @@ const locale = {
   weekdaysShort: 'ທິດ_ຈັນ_ອັງຄານ_ພຸດ_ພະຫັດ_ສຸກ_ເສົາ'.split('_'),
   monthsShort: 'ມັງກອນ_ກຸມພາ_ມີນາ_ເມສາ_ພຶດສະພາ_ມິຖຸນາ_ກໍລະກົດ_ສິງຫາ_ກັນຍາ_ຕຸລາ_ພະຈິກ_ທັນວາ'.split('_'),
   weekdaysMin: 'ທ_ຈ_ອຄ_ພ_ພຫ_ສກ_ສ'.split('_'),
-  ordinal: n => n
+  ordinal: n => n,
+  formats: {
+    LT: 'HH:mm',
+    LTS: 'HH:mm:ss',
+    L: 'DD/MM/YYYY',
+    LL: 'D MMMM YYYY',
+    LLL: 'D MMMM YYYY HH:mm',
+    LLLL: 'ວັນdddd D MMMM YYYY HH:mm'
+  },
+  relativeTime: {
+    future: 'ອີກ %s',
+    past: '%sຜ່ານມາ',
+    s: 'ບໍ່ເທົ່າໃດວິນາທີ',
+    m: '1 ນາທີ',
+    mm: '%d ນາທີ',
+    h: '1 ຊົ່ວໂມງ',
+    hh: '%d ຊົ່ວໂມງ',
+    d: '1 ມື້',
+    dd: '%d ມື້',
+    M: '1 ເດືອນ',
+    MM: '%d ເດືອນ',
+    y: '1 ປີ',
+    yy: '%d ປີ'
+  }
 }
 
 dayjs.locale(locale, null, true)

--- a/src/locale/lt.js
+++ b/src/locale/lt.js
@@ -32,9 +32,22 @@ const locale = {
     ll: 'YYYY [m.] MMMM D [d.]',
     lll: 'YYYY [m.] MMMM D [d.], HH:mm [val.]',
     llll: 'YYYY [m.] MMMM D [d.], ddd, HH:mm [val.]'
+  },
+  formats: {
+    LT: 'HH:mm',
+    LTS: 'HH:mm:ss',
+    L: 'YYYY-MM-DD',
+    LL: 'YYYY [m.] MMMM D [d.]',
+    LLL: 'YYYY [m.] MMMM D [d.], HH:mm [val.]',
+    LLLL: 'YYYY [m.] MMMM D [d.], dddd, HH:mm [val.]',
+    l: 'YYYY-MM-DD',
+    ll: 'YYYY [m.] MMMM D [d.]',
+    lll: 'YYYY [m.] MMMM D [d.], HH:mm [val.]',
+    llll: 'YYYY [m.] MMMM D [d.], ddd, HH:mm [val.]'
   }
 }
 
 dayjs.locale(locale, null, true)
 
 export default locale
+

--- a/src/locale/lv.js
+++ b/src/locale/lv.js
@@ -8,7 +8,15 @@ const locale = {
   weekdaysShort: 'Sv_P_O_T_C_Pk_S'.split('_'),
   monthsShort: 'jan_feb_mar_apr_mai_jūn_jūl_aug_sep_okt_nov_dec'.split('_'),
   weekdaysMin: 'Sv_P_O_T_C_Pk_S'.split('_'),
-  ordinal: n => n
+  ordinal: n => n,
+  formats: {
+    LT: 'HH:mm',
+    LTS: 'HH:mm:ss',
+    L: 'DD.MM.YYYY.',
+    LL: 'YYYY. [gada] D. MMMM',
+    LLL: 'YYYY. [gada] D. MMMM, HH:mm',
+    LLLL: 'YYYY. [gada] D. MMMM, dddd, HH:mm'
+  }
 }
 
 dayjs.locale(locale, null, true)

--- a/src/locale/me.js
+++ b/src/locale/me.js
@@ -8,7 +8,15 @@ const locale = {
   weekdaysShort: 'ned._pon._uto._sri._čet._pet._sub.'.split('_'),
   monthsShort: 'jan._feb._mar._apr._maj_jun_jul_avg._sep._okt._nov._dec.'.split('_'),
   weekdaysMin: 'ne_po_ut_sr_če_pe_su'.split('_'),
-  ordinal: n => n
+  ordinal: n => n,
+  formats: {
+    LT: 'H:mm',
+    LTS: 'H:mm:ss',
+    L: 'DD.MM.YYYY',
+    LL: 'D. MMMM YYYY',
+    LLL: 'D. MMMM YYYY H:mm',
+    LLLL: 'dddd, D. MMMM YYYY H:mm'
+  }
 }
 
 dayjs.locale(locale, null, true)

--- a/src/locale/mi.js
+++ b/src/locale/mi.js
@@ -8,7 +8,30 @@ const locale = {
   weekdaysShort: 'Ta_Ma_Tū_We_Tāi_Pa_Hā'.split('_'),
   monthsShort: 'Kohi_Hui_Pou_Pae_Hara_Pipi_Hōngoi_Here_Mahu_Whi-nu_Whi-ra_Haki'.split('_'),
   weekdaysMin: 'Ta_Ma_Tū_We_Tāi_Pa_Hā'.split('_'),
-  ordinal: n => n
+  ordinal: n => n,
+  formats: {
+    LT: 'HH:mm',
+    LTS: 'HH:mm:ss',
+    L: 'DD/MM/YYYY',
+    LL: 'D MMMM YYYY',
+    LLL: 'D MMMM YYYY [i] HH:mm',
+    LLLL: 'dddd, D MMMM YYYY [i] HH:mm'
+  },
+  relativeTime: {
+    future: 'i roto i %s',
+    past: '%s i mua',
+    s: 'te hēkona ruarua',
+    m: 'he meneti',
+    mm: '%d meneti',
+    h: 'te haora',
+    hh: '%d haora',
+    d: 'he ra',
+    dd: '%d ra',
+    M: 'he marama',
+    MM: '%d marama',
+    y: 'he tau',
+    yy: '%d tau'
+  }
 }
 
 dayjs.locale(locale, null, true)

--- a/src/locale/mk.js
+++ b/src/locale/mk.js
@@ -8,7 +8,30 @@ const locale = {
   weekdaysShort: 'нед_пон_вто_сре_чет_пет_саб'.split('_'),
   monthsShort: 'јан_фев_мар_апр_мај_јун_јул_авг_сеп_окт_ное_дек'.split('_'),
   weekdaysMin: 'нe_пo_вт_ср_че_пе_сa'.split('_'),
-  ordinal: n => n
+  ordinal: n => n,
+  formats: {
+    LT: 'H:mm',
+    LTS: 'H:mm:ss',
+    L: 'D.MM.YYYY',
+    LL: 'D MMMM YYYY',
+    LLL: 'D MMMM YYYY H:mm',
+    LLLL: 'dddd, D MMMM YYYY H:mm'
+  },
+  relativeTime: {
+    future: 'после %s',
+    past: 'пред %s',
+    s: 'неколку секунди',
+    m: 'минута',
+    mm: '%d минути',
+    h: 'час',
+    hh: '%d часа',
+    d: 'ден',
+    dd: '%d дена',
+    M: 'месец',
+    MM: '%d месеци',
+    y: 'година',
+    yy: '%d години'
+  }
 }
 
 dayjs.locale(locale, null, true)

--- a/src/locale/ml.js
+++ b/src/locale/ml.js
@@ -7,7 +7,30 @@ const locale = {
   weekdaysShort: 'ഞായർ_തിങ്കൾ_ചൊവ്വ_ബുധൻ_വ്യാഴം_വെള്ളി_ശനി'.split('_'),
   monthsShort: 'ജനു._ഫെബ്രു._മാർ._ഏപ്രി._മേയ്_ജൂൺ_ജൂലൈ._ഓഗ._സെപ്റ്റ._ഒക്ടോ._നവം._ഡിസം.'.split('_'),
   weekdaysMin: 'ഞാ_തി_ചൊ_ബു_വ്യാ_വെ_ശ'.split('_'),
-  ordinal: n => n
+  ordinal: n => n,
+  formats: {
+    LT: 'A h:mm -നു',
+    LTS: 'A h:mm:ss -നു',
+    L: 'DD/MM/YYYY',
+    LL: 'D MMMM YYYY',
+    LLL: 'D MMMM YYYY, A h:mm -നു',
+    LLLL: 'dddd, D MMMM YYYY, A h:mm -നു'
+  },
+  relativeTime: {
+    future: '%s കഴിഞ്ഞ്',
+    past: '%s മുൻപ്',
+    s: 'അൽപ നിമിഷങ്ങൾ',
+    m: 'ഒരു മിനിറ്റ്',
+    mm: '%d മിനിറ്റ്',
+    h: 'ഒരു മണിക്കൂർ',
+    hh: '%d മണിക്കൂർ',
+    d: 'ഒരു ദിവസം',
+    dd: '%d ദിവസം',
+    M: 'ഒരു മാസം',
+    MM: '%d മാസം',
+    y: 'ഒരു വർഷം',
+    yy: '%d വർഷം'
+  }
 }
 
 dayjs.locale(locale, null, true)

--- a/src/locale/mn.js
+++ b/src/locale/mn.js
@@ -7,7 +7,15 @@ const locale = {
   weekdaysShort: 'Ням_Дав_Мяг_Лха_Пүр_Баа_Бям'.split('_'),
   monthsShort: '1 сар_2 сар_3 сар_4 сар_5 сар_6 сар_7 сар_8 сар_9 сар_10 сар_11 сар_12 сар'.split('_'),
   weekdaysMin: 'Ня_Да_Мя_Лх_Пү_Ба_Бя'.split('_'),
-  ordinal: n => n
+  ordinal: n => n,
+  formats: {
+    LT: 'HH:mm',
+    LTS: 'HH:mm:ss',
+    L: 'YYYY-MM-DD',
+    LL: 'YYYY оны MMMMын D',
+    LLL: 'YYYY оны MMMMын D HH:mm',
+    LLLL: 'dddd, YYYY оны MMMMын D HH:mm'
+  }
 }
 
 dayjs.locale(locale, null, true)

--- a/src/locale/mr.js
+++ b/src/locale/mr.js
@@ -7,7 +7,15 @@ const locale = {
   weekdaysShort: 'रवि_सोम_मंगळ_बुध_गुरू_शुक्र_शनि'.split('_'),
   monthsShort: 'जाने._फेब्रु._मार्च._एप्रि._मे._जून._जुलै._ऑग._सप्टें._ऑक्टो._नोव्हें._डिसें.'.split('_'),
   weekdaysMin: 'र_सो_मं_बु_गु_शु_श'.split('_'),
-  ordinal: n => n
+  ordinal: n => n,
+  formats: {
+    LT: 'A h:mm वाजता',
+    LTS: 'A h:mm:ss वाजता',
+    L: 'DD/MM/YYYY',
+    LL: 'D MMMM YYYY',
+    LLL: 'D MMMM YYYY, A h:mm वाजता',
+    LLLL: 'dddd, D MMMM YYYY, A h:mm वाजता'
+  }
 }
 
 dayjs.locale(locale, null, true)

--- a/src/locale/ms-my.js
+++ b/src/locale/ms-my.js
@@ -8,7 +8,30 @@ const locale = {
   weekdaysShort: 'Ahd_Isn_Sel_Rab_Kha_Jum_Sab'.split('_'),
   monthsShort: 'Jan_Feb_Mac_Apr_Mei_Jun_Jul_Ogs_Sep_Okt_Nov_Dis'.split('_'),
   weekdaysMin: 'Ah_Is_Sl_Rb_Km_Jm_Sb'.split('_'),
-  ordinal: n => n
+  ordinal: n => n,
+  formats: {
+    LT: 'HH.mm',
+    LTS: 'HH.mm.ss',
+    L: 'DD/MM/YYYY',
+    LL: 'D MMMM YYYY',
+    LLL: 'D MMMM YYYY [pukul] HH.mm',
+    LLLL: 'dddd, D MMMM YYYY [pukul] HH.mm'
+  },
+  relativeTime: {
+    future: 'dalam %s',
+    past: '%s yang lepas',
+    s: 'beberapa saat',
+    m: 'seminit',
+    mm: '%d minit',
+    h: 'sejam',
+    hh: '%d jam',
+    d: 'sehari',
+    dd: '%d hari',
+    M: 'sebulan',
+    MM: '%d bulan',
+    y: 'setahun',
+    yy: '%d tahun'
+  }
 }
 
 dayjs.locale(locale, null, true)

--- a/src/locale/ms.js
+++ b/src/locale/ms.js
@@ -34,3 +34,4 @@ const locale = {
 dayjs.locale(locale, null, true)
 
 export default locale
+

--- a/src/locale/mt.js
+++ b/src/locale/mt.js
@@ -8,7 +8,30 @@ const locale = {
   weekdaysShort: 'Ħad_Tne_Tli_Erb_Ħam_Ġim_Sib'.split('_'),
   monthsShort: 'Jan_Fra_Mar_Apr_Mej_Ġun_Lul_Aww_Set_Ott_Nov_Diċ'.split('_'),
   weekdaysMin: 'Ħa_Tn_Tl_Er_Ħa_Ġi_Si'.split('_'),
-  ordinal: n => n
+  ordinal: n => n,
+  formats: {
+    LT: 'HH:mm',
+    LTS: 'HH:mm:ss',
+    L: 'DD/MM/YYYY',
+    LL: 'D MMMM YYYY',
+    LLL: 'D MMMM YYYY HH:mm',
+    LLLL: 'dddd, D MMMM YYYY HH:mm'
+  },
+  relativeTime: {
+    future: 'f’ %s',
+    past: '%s ilu',
+    s: 'ftit sekondi',
+    m: 'minuta',
+    mm: '%d minuti',
+    h: 'siegħa',
+    hh: '%d siegħat',
+    d: 'ġurnata',
+    dd: '%d ġranet',
+    M: 'xahar',
+    MM: '%d xhur',
+    y: 'sena',
+    yy: '%d sni'
+  }
 }
 
 dayjs.locale(locale, null, true)

--- a/src/locale/my.js
+++ b/src/locale/my.js
@@ -8,7 +8,30 @@ const locale = {
   weekdaysShort: 'နွေ_လာ_ဂါ_ဟူး_ကြာ_သော_နေ'.split('_'),
   monthsShort: 'ဇန်_ဖေ_မတ်_ပြီ_မေ_ဇွန်_လိုင်_သြ_စက်_အောက်_နို_ဒီ'.split('_'),
   weekdaysMin: 'နွေ_လာ_ဂါ_ဟူး_ကြာ_သော_နေ'.split('_'),
-  ordinal: n => n
+  ordinal: n => n,
+  formats: {
+    LT: 'HH:mm',
+    LTS: 'HH:mm:ss',
+    L: 'DD/MM/YYYY',
+    LL: 'D MMMM YYYY',
+    LLL: 'D MMMM YYYY HH:mm',
+    LLLL: 'dddd D MMMM YYYY HH:mm'
+  },
+  relativeTime: {
+    future: 'လာမည့် %s မှာ',
+    past: 'လွန်ခဲ့သော %s က',
+    s: 'စက္ကန်.အနည်းငယ်',
+    m: 'တစ်မိနစ်',
+    mm: '%d မိနစ်',
+    h: 'တစ်နာရီ',
+    hh: '%d နာရီ',
+    d: 'တစ်ရက်',
+    dd: '%d ရက်',
+    M: 'တစ်လ',
+    MM: '%d လ',
+    y: 'တစ်နှစ်',
+    yy: '%d နှစ်'
+  }
 }
 
 dayjs.locale(locale, null, true)

--- a/src/locale/nb.js
+++ b/src/locale/nb.js
@@ -34,3 +34,4 @@ const locale = {
 dayjs.locale(locale, null, true)
 
 export default locale
+

--- a/src/locale/ne.js
+++ b/src/locale/ne.js
@@ -19,9 +19,18 @@ const locale = {
     y: 'एक वर्ष',
     yy: '%d वर्ष'
   },
-  ordinal: n => `${n}`.replace(/\d/g, i => '०१२३४५६७८९'[i])
+  ordinal: n => `${n}`.replace(/\d/g, i => '०१२३४५६७८९'[i]),
+  formats: {
+    LT: 'Aको h:mm बजे',
+    LTS: 'Aको h:mm:ss बजे',
+    L: 'DD/MM/YYYY',
+    LL: 'D MMMM YYYY',
+    LLL: 'D MMMM YYYY, Aको h:mm बजे',
+    LLLL: 'dddd, D MMMM YYYY, Aको h:mm बजे'
+  }
 }
 
 dayjs.locale(locale, null, true)
 
 export default locale
+

--- a/src/locale/nl-be.js
+++ b/src/locale/nl-be.js
@@ -7,7 +7,30 @@ const locale = {
   weekStart: 1,
   weekdaysShort: 'zo._ma._di._wo._do._vr._za.'.split('_'),
   weekdaysMin: 'zo_ma_di_wo_do_vr_za'.split('_'),
-  ordinal: n => n
+  ordinal: n => n,
+  formats: {
+    LT: 'HH:mm',
+    LTS: 'HH:mm:ss',
+    L: 'DD/MM/YYYY',
+    LL: 'D MMMM YYYY',
+    LLL: 'D MMMM YYYY HH:mm',
+    LLLL: 'dddd D MMMM YYYY HH:mm'
+  },
+  relativeTime: {
+    future: 'over %s',
+    past: '%s geleden',
+    s: 'een paar seconden',
+    m: 'één minuut',
+    mm: '%d minuten',
+    h: 'één uur',
+    hh: '%d uur',
+    d: 'één dag',
+    dd: '%d dagen',
+    M: 'één maand',
+    MM: '%d maanden',
+    y: 'één jaar',
+    yy: '%d jaar'
+  }
 }
 
 dayjs.locale(locale, null, true)

--- a/src/locale/nl.js
+++ b/src/locale/nl.js
@@ -34,3 +34,4 @@ const locale = {
 dayjs.locale(locale, null, true)
 
 export default locale
+

--- a/src/locale/nn.js
+++ b/src/locale/nn.js
@@ -23,9 +23,18 @@ const locale = {
     MM: '%d månadar',
     y: 'eitt år',
     yy: '%d år'
+  },
+  formats: {
+    LT: 'HH:mm',
+    LTS: 'HH:mm:ss',
+    L: 'DD.MM.YYYY',
+    LL: 'D. MMMM YYYY',
+    LLL: 'D. MMMM YYYY [kl.] H:mm',
+    LLLL: 'dddd D. MMMM YYYY [kl.] HH:mm'
   }
 }
 
 dayjs.locale(locale, null, true)
 
 export default locale
+

--- a/src/locale/pa-in.js
+++ b/src/locale/pa-in.js
@@ -7,7 +7,30 @@ const locale = {
   weekdaysShort: 'ਐਤ_ਸੋਮ_ਮੰਗਲ_ਬੁਧ_ਵੀਰ_ਸ਼ੁਕਰ_ਸ਼ਨੀ'.split('_'),
   monthsShort: 'ਜਨਵਰੀ_ਫ਼ਰਵਰੀ_ਮਾਰਚ_ਅਪ੍ਰੈਲ_ਮਈ_ਜੂਨ_ਜੁਲਾਈ_ਅਗਸਤ_ਸਤੰਬਰ_ਅਕਤੂਬਰ_ਨਵੰਬਰ_ਦਸੰਬਰ'.split('_'),
   weekdaysMin: 'ਐਤ_ਸੋਮ_ਮੰਗਲ_ਬੁਧ_ਵੀਰ_ਸ਼ੁਕਰ_ਸ਼ਨੀ'.split('_'),
-  ordinal: n => n
+  ordinal: n => n,
+  formats: {
+    LT: 'A h:mm ਵਜੇ',
+    LTS: 'A h:mm:ss ਵਜੇ',
+    L: 'DD/MM/YYYY',
+    LL: 'D MMMM YYYY',
+    LLL: 'D MMMM YYYY, A h:mm ਵਜੇ',
+    LLLL: 'dddd, D MMMM YYYY, A h:mm ਵਜੇ'
+  },
+  relativeTime: {
+    future: '%s ਵਿੱਚ',
+    past: '%s ਪਿਛਲੇ',
+    s: 'ਕੁਝ ਸਕਿੰਟ',
+    m: 'ਇਕ ਮਿੰਟ',
+    mm: '%d ਮਿੰਟ',
+    h: 'ਇੱਕ ਘੰਟਾ',
+    hh: '%d ਘੰਟੇ',
+    d: 'ਇੱਕ ਦਿਨ',
+    dd: '%d ਦਿਨ',
+    M: 'ਇੱਕ ਮਹੀਨਾ',
+    MM: '%d ਮਹੀਨੇ',
+    y: 'ਇੱਕ ਸਾਲ',
+    yy: '%d ਸਾਲ'
+  }
 }
 
 dayjs.locale(locale, null, true)

--- a/src/locale/pl.js
+++ b/src/locale/pl.js
@@ -22,9 +22,18 @@ const locale = {
     MM: '%d miesięcy',
     y: 'rok',
     yy: '%d lat'
+  },
+  formats: {
+    LT: 'HH:mm',
+    LTS: 'HH:mm:ss',
+    L: 'DD.MM.YYYY',
+    LL: 'D MMMM YYYY',
+    LLL: 'D MMMM YYYY HH:mm',
+    LLLL: 'dddd, D MMMM YYYY HH:mm'
   }
 }
 
 dayjs.locale(locale, null, true)
 
 export default locale
+

--- a/src/locale/pt-br.js
+++ b/src/locale/pt-br.js
@@ -33,3 +33,4 @@ const locale = {
 dayjs.locale(locale, null, true)
 
 export default locale
+

--- a/src/locale/pt.js
+++ b/src/locale/pt.js
@@ -36,3 +36,4 @@ const locale = {
 dayjs.locale(locale, null, true)
 
 export default locale
+

--- a/src/locale/ro.js
+++ b/src/locale/ro.js
@@ -34,3 +34,4 @@ const locale = {
 dayjs.locale(locale, null, true)
 
 export default locale
+

--- a/src/locale/ru.js
+++ b/src/locale/ru.js
@@ -37,3 +37,4 @@ const locale = {
 dayjs.locale(locale, null, true)
 
 export default locale
+

--- a/src/locale/sd.js
+++ b/src/locale/sd.js
@@ -8,7 +8,30 @@ const locale = {
   weekdaysShort: 'آچر_سومر_اڱارو_اربع_خميس_جمع_ڇنڇر'.split('_'),
   monthsShort: 'جنوري_فيبروري_مارچ_اپريل_مئي_جون_جولاءِ_آگسٽ_سيپٽمبر_آڪٽوبر_نومبر_ڊسمبر'.split('_'),
   weekdaysMin: 'آچر_سومر_اڱارو_اربع_خميس_جمع_ڇنڇر'.split('_'),
-  ordinal: n => n
+  ordinal: n => n,
+  formats: {
+    LT: 'HH:mm',
+    LTS: 'HH:mm:ss',
+    L: 'DD/MM/YYYY',
+    LL: 'D MMMM YYYY',
+    LLL: 'D MMMM YYYY HH:mm',
+    LLLL: 'dddd، D MMMM YYYY HH:mm'
+  },
+  relativeTime: {
+    future: '%s پوء',
+    past: '%s اڳ',
+    s: 'چند سيڪنڊ',
+    m: 'هڪ منٽ',
+    mm: '%d منٽ',
+    h: 'هڪ ڪلاڪ',
+    hh: '%d ڪلاڪ',
+    d: 'هڪ ڏينهن',
+    dd: '%d ڏينهن',
+    M: 'هڪ مهينو',
+    MM: '%d مهينا',
+    y: 'هڪ سال',
+    yy: '%d سال'
+  }
 }
 
 dayjs.locale(locale, null, true)

--- a/src/locale/se.js
+++ b/src/locale/se.js
@@ -8,7 +8,30 @@ const locale = {
   weekdaysShort: 'sotn_vuos_maŋ_gask_duor_bear_láv'.split('_'),
   monthsShort: 'ođđj_guov_njuk_cuo_mies_geas_suoi_borg_čakč_golg_skáb_juov'.split('_'),
   weekdaysMin: 's_v_m_g_d_b_L'.split('_'),
-  ordinal: n => n
+  ordinal: n => n,
+  formats: {
+    LT: 'HH:mm',
+    LTS: 'HH:mm:ss',
+    L: 'DD.MM.YYYY',
+    LL: 'MMMM D. [b.] YYYY',
+    LLL: 'MMMM D. [b.] YYYY [ti.] HH:mm',
+    LLLL: 'dddd, MMMM D. [b.] YYYY [ti.] HH:mm'
+  },
+  relativeTime: {
+    future: '%s geažes',
+    past: 'maŋit %s',
+    s: 'moadde sekunddat',
+    m: 'okta minuhta',
+    mm: '%d minuhtat',
+    h: 'okta diimmu',
+    hh: '%d diimmut',
+    d: 'okta beaivi',
+    dd: '%d beaivvit',
+    M: 'okta mánnu',
+    MM: '%d mánut',
+    y: 'okta jahki',
+    yy: '%d jagit'
+  }
 }
 
 dayjs.locale(locale, null, true)

--- a/src/locale/si.js
+++ b/src/locale/si.js
@@ -7,7 +7,30 @@ const locale = {
   weekdaysShort: 'ඉරි_සඳු_අඟ_බදා_බ්‍රහ_සිකු_සෙන'.split('_'),
   monthsShort: 'ජන_පෙබ_මාර්_අප්_මැයි_ජූනි_ජූලි_අගෝ_සැප්_ඔක්_නොවැ_දෙසැ'.split('_'),
   weekdaysMin: 'ඉ_ස_අ_බ_බ්‍ර_සි_සෙ'.split('_'),
-  ordinal: n => n
+  ordinal: n => n,
+  formats: {
+    LT: 'a h:mm',
+    LTS: 'a h:mm:ss',
+    L: 'YYYY/MM/DD',
+    LL: 'YYYY MMMM D',
+    LLL: 'YYYY MMMM D, a h:mm',
+    LLLL: 'YYYY MMMM D [වැනි] dddd, a h:mm:ss'
+  },
+  relativeTime: {
+    future: '%sකින්',
+    past: '%sකට පෙර',
+    s: 'තත්පර කිහිපය',
+    m: 'මිනිත්තුව',
+    mm: 'මිනිත්තු %d',
+    h: 'පැය',
+    hh: 'පැය %d',
+    d: 'දිනය',
+    dd: 'දින %d',
+    M: 'මාසය',
+    MM: 'මාස %d',
+    y: 'වසර',
+    yy: 'වසර %d'
+  }
 }
 
 dayjs.locale(locale, null, true)

--- a/src/locale/sk.js
+++ b/src/locale/sk.js
@@ -20,9 +20,18 @@ const locale = {
     y: 'rok',
     yy: '%d rokov'
   },
-  ordinal: n => `${n}º`
+  ordinal: n => `${n}º`,
+  formats: {
+    LT: 'H:mm',
+    LTS: 'H:mm:ss',
+    L: 'DD.MM.YYYY',
+    LL: 'D. MMMM YYYY',
+    LLL: 'D. MMMM YYYY H:mm',
+    LLLL: 'dddd D. MMMM YYYY H:mm'
+  }
 }
 
 dayjs.locale(locale, null, true)
 
 export default locale
+

--- a/src/locale/sl.js
+++ b/src/locale/sl.js
@@ -8,7 +8,15 @@ const locale = {
   weekdaysShort: 'ned._pon._tor._sre._čet._pet._sob.'.split('_'),
   monthsShort: 'jan._feb._mar._apr._maj._jun._jul._avg._sep._okt._nov._dec.'.split('_'),
   weekdaysMin: 'ne_po_to_sr_če_pe_so'.split('_'),
-  ordinal: n => n
+  ordinal: n => n,
+  formats: {
+    LT: 'H:mm',
+    LTS: 'H:mm:ss',
+    L: 'DD.MM.YYYY',
+    LL: 'D. MMMM YYYY',
+    LLL: 'D. MMMM YYYY H:mm',
+    LLLL: 'dddd, D. MMMM YYYY H:mm'
+  }
 }
 
 dayjs.locale(locale, null, true)

--- a/src/locale/sq.js
+++ b/src/locale/sq.js
@@ -8,7 +8,30 @@ const locale = {
   weekdaysShort: 'Die_Hën_Mar_Mër_Enj_Pre_Sht'.split('_'),
   monthsShort: 'Jan_Shk_Mar_Pri_Maj_Qer_Kor_Gus_Sht_Tet_Nën_Dhj'.split('_'),
   weekdaysMin: 'D_H_Ma_Më_E_P_Sh'.split('_'),
-  ordinal: n => n
+  ordinal: n => n,
+  formats: {
+    LT: 'HH:mm',
+    LTS: 'HH:mm:ss',
+    L: 'DD/MM/YYYY',
+    LL: 'D MMMM YYYY',
+    LLL: 'D MMMM YYYY HH:mm',
+    LLLL: 'dddd, D MMMM YYYY HH:mm'
+  },
+  relativeTime: {
+    future: 'në %s',
+    past: '%s më parë',
+    s: 'disa sekonda',
+    m: 'një minutë',
+    mm: '%d minuta',
+    h: 'një orë',
+    hh: '%d orë',
+    d: 'një ditë',
+    dd: '%d ditë',
+    M: 'një muaj',
+    MM: '%d muaj',
+    y: 'një vit',
+    yy: '%d vite'
+  }
 }
 
 dayjs.locale(locale, null, true)

--- a/src/locale/sr-cyrl.js
+++ b/src/locale/sr-cyrl.js
@@ -20,9 +20,18 @@ const locale = {
     y: 'година',
     yy: '%d године'
   },
-  ordinal: n => `${n}.`
+  ordinal: n => `${n}.`,
+  formats: {
+    LT: 'H:mm',
+    LTS: 'H:mm:ss',
+    L: 'DD.MM.YYYY',
+    LL: 'D. MMMM YYYY',
+    LLL: 'D. MMMM YYYY H:mm',
+    LLLL: 'dddd, D. MMMM YYYY H:mm'
+  }
 }
 
 dayjs.locale(locale, null, true)
 
 export default locale
+

--- a/src/locale/sr.js
+++ b/src/locale/sr.js
@@ -20,9 +20,18 @@ const locale = {
     y: 'godina',
     yy: '%d godine'
   },
-  ordinal: n => `${n}.`
+  ordinal: n => `${n}.`,
+  formats: {
+    LT: 'H:mm',
+    LTS: 'H:mm:ss',
+    L: 'DD.MM.YYYY',
+    LL: 'D. MMMM YYYY',
+    LLL: 'D. MMMM YYYY H:mm',
+    LLLL: 'dddd, D. MMMM YYYY H:mm'
+  }
 }
 
 dayjs.locale(locale, null, true)
 
 export default locale
+

--- a/src/locale/ss.js
+++ b/src/locale/ss.js
@@ -8,7 +8,30 @@ const locale = {
   weekdaysShort: 'Lis_Umb_Lsb_Les_Lsi_Lsh_Umg'.split('_'),
   monthsShort: 'Bhi_Ina_Inu_Mab_Ink_Inh_Kho_Igc_Iny_Imp_Lwe_Igo'.split('_'),
   weekdaysMin: 'Li_Us_Lb_Lt_Ls_Lh_Ug'.split('_'),
-  ordinal: n => n
+  ordinal: n => n,
+  formats: {
+    LT: 'h:mm A',
+    LTS: 'h:mm:ss A',
+    L: 'DD/MM/YYYY',
+    LL: 'D MMMM YYYY',
+    LLL: 'D MMMM YYYY h:mm A',
+    LLLL: 'dddd, D MMMM YYYY h:mm A'
+  },
+  relativeTime: {
+    future: 'nga %s',
+    past: 'wenteka nga %s',
+    s: 'emizuzwana lomcane',
+    m: 'umzuzu',
+    mm: '%d emizuzu',
+    h: 'lihora',
+    hh: '%d emahora',
+    d: 'lilanga',
+    dd: '%d emalanga',
+    M: 'inyanga',
+    MM: '%d tinyanga',
+    y: 'umnyaka',
+    yy: '%d iminyaka'
+  }
 }
 
 dayjs.locale(locale, null, true)

--- a/src/locale/sv.js
+++ b/src/locale/sv.js
@@ -43,3 +43,4 @@ const locale = {
 dayjs.locale(locale, null, true)
 
 export default locale
+

--- a/src/locale/sw.js
+++ b/src/locale/sw.js
@@ -37,3 +37,4 @@ const locale = {
 dayjs.locale(locale, null, true)
 
 export default locale
+

--- a/src/locale/ta.js
+++ b/src/locale/ta.js
@@ -7,7 +7,30 @@ const locale = {
   weekdaysShort: 'ஞாயிறு_திங்கள்_செவ்வாய்_புதன்_வியாழன்_வெள்ளி_சனி'.split('_'),
   monthsShort: 'ஜனவரி_பிப்ரவரி_மார்ச்_ஏப்ரல்_மே_ஜூன்_ஜூலை_ஆகஸ்ட்_செப்டெம்பர்_அக்டோபர்_நவம்பர்_டிசம்பர்'.split('_'),
   weekdaysMin: 'ஞா_தி_செ_பு_வி_வெ_ச'.split('_'),
-  ordinal: n => n
+  ordinal: n => n,
+  formats: {
+    LT: 'HH:mm',
+    LTS: 'HH:mm:ss',
+    L: 'DD/MM/YYYY',
+    LL: 'D MMMM YYYY',
+    LLL: 'D MMMM YYYY, HH:mm',
+    LLLL: 'dddd, D MMMM YYYY, HH:mm'
+  },
+  relativeTime: {
+    future: '%s இல்',
+    past: '%s முன்',
+    s: 'ஒரு சில விநாடிகள்',
+    m: 'ஒரு நிமிடம்',
+    mm: '%d நிமிடங்கள்',
+    h: 'ஒரு மணி நேரம்',
+    hh: '%d மணி நேரம்',
+    d: 'ஒரு நாள்',
+    dd: '%d நாட்கள்',
+    M: 'ஒரு மாதம்',
+    MM: '%d மாதங்கள்',
+    y: 'ஒரு வருடம்',
+    yy: '%d ஆண்டுகள்'
+  }
 }
 
 dayjs.locale(locale, null, true)

--- a/src/locale/te.js
+++ b/src/locale/te.js
@@ -7,7 +7,30 @@ const locale = {
   weekdaysShort: 'ఆది_సోమ_మంగళ_బుధ_గురు_శుక్ర_శని'.split('_'),
   monthsShort: 'జన._ఫిబ్ర._మార్చి_ఏప్రి._మే_జూన్_జులై_ఆగ._సెప్._అక్టో._నవ._డిసె.'.split('_'),
   weekdaysMin: 'ఆ_సో_మం_బు_గు_శు_శ'.split('_'),
-  ordinal: n => n
+  ordinal: n => n,
+  formats: {
+    LT: 'A h:mm',
+    LTS: 'A h:mm:ss',
+    L: 'DD/MM/YYYY',
+    LL: 'D MMMM YYYY',
+    LLL: 'D MMMM YYYY, A h:mm',
+    LLLL: 'dddd, D MMMM YYYY, A h:mm'
+  },
+  relativeTime: {
+    future: '%s లో',
+    past: '%s క్రితం',
+    s: 'కొన్ని క్షణాలు',
+    m: 'ఒక నిమిషం',
+    mm: '%d నిమిషాలు',
+    h: 'ఒక గంట',
+    hh: '%d గంటలు',
+    d: 'ఒక రోజు',
+    dd: '%d రోజులు',
+    M: 'ఒక నెల',
+    MM: '%d నెలలు',
+    y: 'ఒక సంవత్సరం',
+    yy: '%d సంవత్సరాలు'
+  }
 }
 
 dayjs.locale(locale, null, true)

--- a/src/locale/tet.js
+++ b/src/locale/tet.js
@@ -8,7 +8,30 @@ const locale = {
   weekdaysShort: 'Dom_Seg_Ters_Kua_Kint_Sest_Sab'.split('_'),
   monthsShort: 'Jan_Fev_Mar_Abr_Mai_Jun_Jul_Ago_Set_Out_Nov_Dez'.split('_'),
   weekdaysMin: 'Do_Seg_Te_Ku_Ki_Ses_Sa'.split('_'),
-  ordinal: n => n
+  ordinal: n => n,
+  formats: {
+    LT: 'HH:mm',
+    LTS: 'HH:mm:ss',
+    L: 'DD/MM/YYYY',
+    LL: 'D MMMM YYYY',
+    LLL: 'D MMMM YYYY HH:mm',
+    LLLL: 'dddd, D MMMM YYYY HH:mm'
+  },
+  relativeTime: {
+    future: 'iha %s',
+    past: '%s liuba',
+    s: 'minutu balun',
+    m: 'minutu ida',
+    mm: 'minutu %d',
+    h: 'oras ida',
+    hh: 'oras %d',
+    d: 'loron ida',
+    dd: 'loron %d',
+    M: 'fulan ida',
+    MM: 'fulan %d',
+    y: 'tinan ida',
+    yy: 'tinan %d'
+  }
 }
 
 dayjs.locale(locale, null, true)

--- a/src/locale/tg.js
+++ b/src/locale/tg.js
@@ -8,7 +8,30 @@ const locale = {
   weekdaysShort: 'яшб_дшб_сшб_чшб_пшб_ҷум_шнб'.split('_'),
   monthsShort: 'янв_фев_мар_апр_май_июн_июл_авг_сен_окт_ноя_дек'.split('_'),
   weekdaysMin: 'яш_дш_сш_чш_пш_ҷм_шб'.split('_'),
-  ordinal: n => n
+  ordinal: n => n,
+  formats: {
+    LT: 'HH:mm',
+    LTS: 'HH:mm:ss',
+    L: 'DD/MM/YYYY',
+    LL: 'D MMMM YYYY',
+    LLL: 'D MMMM YYYY HH:mm',
+    LLLL: 'dddd, D MMMM YYYY HH:mm'
+  },
+  relativeTime: {
+    future: 'баъди %s',
+    past: '%s пеш',
+    s: 'якчанд сония',
+    m: 'як дақиқа',
+    mm: '%d дақиқа',
+    h: 'як соат',
+    hh: '%d соат',
+    d: 'як рӯз',
+    dd: '%d рӯз',
+    M: 'як моҳ',
+    MM: '%d моҳ',
+    y: 'як сол',
+    yy: '%d сол'
+  }
 }
 
 dayjs.locale(locale, null, true)

--- a/src/locale/th.js
+++ b/src/locale/th.js
@@ -36,3 +36,4 @@ const locale = {
 dayjs.locale(locale, null, true)
 
 export default locale
+

--- a/src/locale/tl-ph.js
+++ b/src/locale/tl-ph.js
@@ -8,7 +8,30 @@ const locale = {
   weekdaysShort: 'Lin_Lun_Mar_Miy_Huw_Biy_Sab'.split('_'),
   monthsShort: 'Ene_Peb_Mar_Abr_May_Hun_Hul_Ago_Set_Okt_Nob_Dis'.split('_'),
   weekdaysMin: 'Li_Lu_Ma_Mi_Hu_Bi_Sab'.split('_'),
-  ordinal: n => n
+  ordinal: n => n,
+  formats: {
+    LT: 'HH:mm',
+    LTS: 'HH:mm:ss',
+    L: 'MM/D/YYYY',
+    LL: 'MMMM D, YYYY',
+    LLL: 'MMMM D, YYYY HH:mm',
+    LLLL: 'dddd, MMMM DD, YYYY HH:mm'
+  },
+  relativeTime: {
+    future: 'sa loob ng %s',
+    past: '%s ang nakalipas',
+    s: 'ilang segundo',
+    m: 'isang minuto',
+    mm: '%d minuto',
+    h: 'isang oras',
+    hh: '%d oras',
+    d: 'isang araw',
+    dd: '%d araw',
+    M: 'isang buwan',
+    MM: '%d buwan',
+    y: 'isang taon',
+    yy: '%d taon'
+  }
 }
 
 dayjs.locale(locale, null, true)

--- a/src/locale/tlh.js
+++ b/src/locale/tlh.js
@@ -8,7 +8,15 @@ const locale = {
   weekdaysShort: 'lojmItjaj_DaSjaj_povjaj_ghItlhjaj_loghjaj_buqjaj_ghInjaj'.split('_'),
   monthsShort: 'jar wa’_jar cha’_jar wej_jar loS_jar vagh_jar jav_jar Soch_jar chorgh_jar Hut_jar wa’maH_jar wa’maH wa’_jar wa’maH cha’'.split('_'),
   weekdaysMin: 'lojmItjaj_DaSjaj_povjaj_ghItlhjaj_loghjaj_buqjaj_ghInjaj'.split('_'),
-  ordinal: n => n
+  ordinal: n => n,
+  formats: {
+    LT: 'HH:mm',
+    LTS: 'HH:mm:ss',
+    L: 'DD.MM.YYYY',
+    LL: 'D MMMM YYYY',
+    LLL: 'D MMMM YYYY HH:mm',
+    LLLL: 'dddd, D MMMM YYYY HH:mm'
+  }
 }
 
 dayjs.locale(locale, null, true)

--- a/src/locale/tr.js
+++ b/src/locale/tr.js
@@ -34,3 +34,4 @@ const locale = {
 dayjs.locale(locale, null, true)
 
 export default locale
+

--- a/src/locale/tzl.js
+++ b/src/locale/tzl.js
@@ -8,7 +8,15 @@ const locale = {
   weekdaysShort: 'Súl_Lún_Mai_Már_Xhú_Vié_Sát'.split('_'),
   monthsShort: 'Jan_Fev_Mar_Avr_Mai_Gün_Jul_Gus_Set_Lis_Noe_Zec'.split('_'),
   weekdaysMin: 'Sú_Lú_Ma_Má_Xh_Vi_Sá'.split('_'),
-  ordinal: n => n
+  ordinal: n => n,
+  formats: {
+    LT: 'HH.mm',
+    LTS: 'HH.mm.ss',
+    L: 'DD.MM.YYYY',
+    LL: 'D. MMMM [dallas] YYYY',
+    LLL: 'D. MMMM [dallas] YYYY HH.mm',
+    LLLL: 'dddd, [li] D. MMMM [dallas] YYYY HH.mm'
+  }
 }
 
 dayjs.locale(locale, null, true)

--- a/src/locale/tzm-latn.js
+++ b/src/locale/tzm-latn.js
@@ -8,7 +8,30 @@ const locale = {
   weekdaysShort: 'asamas_aynas_asinas_akras_akwas_asimwas_asiḍyas'.split('_'),
   monthsShort: 'innayr_brˤayrˤ_marˤsˤ_ibrir_mayyw_ywnyw_ywlywz_ɣwšt_šwtanbir_ktˤwbrˤ_nwwanbir_dwjnbir'.split('_'),
   weekdaysMin: 'asamas_aynas_asinas_akras_akwas_asimwas_asiḍyas'.split('_'),
-  ordinal: n => n
+  ordinal: n => n,
+  formats: {
+    LT: 'HH:mm',
+    LTS: 'HH:mm:ss',
+    L: 'DD/MM/YYYY',
+    LL: 'D MMMM YYYY',
+    LLL: 'D MMMM YYYY HH:mm',
+    LLLL: 'dddd D MMMM YYYY HH:mm'
+  },
+  relativeTime: {
+    future: 'dadkh s yan %s',
+    past: 'yan %s',
+    s: 'imik',
+    m: 'minuḍ',
+    mm: '%d minuḍ',
+    h: 'saɛa',
+    hh: '%d tassaɛin',
+    d: 'ass',
+    dd: '%d ossan',
+    M: 'ayowr',
+    MM: '%d iyyirn',
+    y: 'asgas',
+    yy: '%d isgasn'
+  }
 }
 
 dayjs.locale(locale, null, true)

--- a/src/locale/tzm.js
+++ b/src/locale/tzm.js
@@ -8,7 +8,30 @@ const locale = {
   weekdaysShort: 'ⴰⵙⴰⵎⴰⵙ_ⴰⵢⵏⴰⵙ_ⴰⵙⵉⵏⴰⵙ_ⴰⴽⵔⴰⵙ_ⴰⴽⵡⴰⵙ_ⴰⵙⵉⵎⵡⴰⵙ_ⴰⵙⵉⴹⵢⴰⵙ'.split('_'),
   monthsShort: 'ⵉⵏⵏⴰⵢⵔ_ⴱⵕⴰⵢⵕ_ⵎⴰⵕⵚ_ⵉⴱⵔⵉⵔ_ⵎⴰⵢⵢⵓ_ⵢⵓⵏⵢⵓ_ⵢⵓⵍⵢⵓⵣ_ⵖⵓⵛⵜ_ⵛⵓⵜⴰⵏⴱⵉⵔ_ⴽⵟⵓⴱⵕ_ⵏⵓⵡⴰⵏⴱⵉⵔ_ⴷⵓⵊⵏⴱⵉⵔ'.split('_'),
   weekdaysMin: 'ⴰⵙⴰⵎⴰⵙ_ⴰⵢⵏⴰⵙ_ⴰⵙⵉⵏⴰⵙ_ⴰⴽⵔⴰⵙ_ⴰⴽⵡⴰⵙ_ⴰⵙⵉⵎⵡⴰⵙ_ⴰⵙⵉⴹⵢⴰⵙ'.split('_'),
-  ordinal: n => n
+  ordinal: n => n,
+  formats: {
+    LT: 'HH:mm',
+    LTS: 'HH:mm:ss',
+    L: 'DD/MM/YYYY',
+    LL: 'D MMMM YYYY',
+    LLL: 'D MMMM YYYY HH:mm',
+    LLLL: 'dddd D MMMM YYYY HH:mm'
+  },
+  relativeTime: {
+    future: 'ⴷⴰⴷⵅ ⵙ ⵢⴰⵏ %s',
+    past: 'ⵢⴰⵏ %s',
+    s: 'ⵉⵎⵉⴽ',
+    m: 'ⵎⵉⵏⵓⴺ',
+    mm: '%d ⵎⵉⵏⵓⴺ',
+    h: 'ⵙⴰⵄⴰ',
+    hh: '%d ⵜⴰⵙⵙⴰⵄⵉⵏ',
+    d: 'ⴰⵙⵙ',
+    dd: '%d oⵙⵙⴰⵏ',
+    M: 'ⴰⵢoⵓⵔ',
+    MM: '%d ⵉⵢⵢⵉⵔⵏ',
+    y: 'ⴰⵙⴳⴰⵙ',
+    yy: '%d ⵉⵙⴳⴰⵙⵏ'
+  }
 }
 
 dayjs.locale(locale, null, true)

--- a/src/locale/ug-cn.js
+++ b/src/locale/ug-cn.js
@@ -8,7 +8,30 @@ const locale = {
   weekdaysShort: 'يە_دۈ_سە_چا_پە_جۈ_شە'.split('_'),
   monthsShort: 'يانۋار_فېۋرال_مارت_ئاپرېل_ماي_ئىيۇن_ئىيۇل_ئاۋغۇست_سېنتەبىر_ئۆكتەبىر_نويابىر_دېكابىر'.split('_'),
   weekdaysMin: 'يە_دۈ_سە_چا_پە_جۈ_شە'.split('_'),
-  ordinal: n => n
+  ordinal: n => n,
+  formats: {
+    LT: 'HH:mm',
+    LTS: 'HH:mm:ss',
+    L: 'YYYY-MM-DD',
+    LL: 'YYYY-يىلىM-ئاينىڭD-كۈنى',
+    LLL: 'YYYY-يىلىM-ئاينىڭD-كۈنى، HH:mm',
+    LLLL: 'dddd، YYYY-يىلىM-ئاينىڭD-كۈنى، HH:mm'
+  },
+  relativeTime: {
+    future: '%s كېيىن',
+    past: '%s بۇرۇن',
+    s: 'نەچچە سېكونت',
+    m: 'بىر مىنۇت',
+    mm: '%d مىنۇت',
+    h: 'بىر سائەت',
+    hh: '%d سائەت',
+    d: 'بىر كۈن',
+    dd: '%d كۈن',
+    M: 'بىر ئاي',
+    MM: '%d ئاي',
+    y: 'بىر يىل',
+    yy: '%d يىل'
+  }
 }
 
 dayjs.locale(locale, null, true)

--- a/src/locale/uk.js
+++ b/src/locale/uk.js
@@ -23,9 +23,18 @@ const locale = {
     y: 'рік',
     yy: '%d роки'
   },
-  ordinal: n => n
+  ordinal: n => n,
+  formats: {
+    LT: 'HH:mm',
+    LTS: 'HH:mm:ss',
+    L: 'DD.MM.YYYY',
+    LL: 'D MMMM YYYY р.',
+    LLL: 'D MMMM YYYY р., HH:mm',
+    LLLL: 'dddd, D MMMM YYYY р., HH:mm'
+  }
 }
 
 dayjs.locale(locale, null, true)
 
 export default locale
+

--- a/src/locale/ur.js
+++ b/src/locale/ur.js
@@ -8,7 +8,30 @@ const locale = {
   weekdaysShort: 'اتوار_پیر_منگل_بدھ_جمعرات_جمعہ_ہفتہ'.split('_'),
   monthsShort: 'جنوری_فروری_مارچ_اپریل_مئی_جون_جولائی_اگست_ستمبر_اکتوبر_نومبر_دسمبر'.split('_'),
   weekdaysMin: 'اتوار_پیر_منگل_بدھ_جمعرات_جمعہ_ہفتہ'.split('_'),
-  ordinal: n => n
+  ordinal: n => n,
+  formats: {
+    LT: 'HH:mm',
+    LTS: 'HH:mm:ss',
+    L: 'DD/MM/YYYY',
+    LL: 'D MMMM YYYY',
+    LLL: 'D MMMM YYYY HH:mm',
+    LLLL: 'dddd، D MMMM YYYY HH:mm'
+  },
+  relativeTime: {
+    future: '%s بعد',
+    past: '%s قبل',
+    s: 'چند سیکنڈ',
+    m: 'ایک منٹ',
+    mm: '%d منٹ',
+    h: 'ایک گھنٹہ',
+    hh: '%d گھنٹے',
+    d: 'ایک دن',
+    dd: '%d دن',
+    M: 'ایک ماہ',
+    MM: '%d ماہ',
+    y: 'ایک سال',
+    yy: '%d سال'
+  }
 }
 
 dayjs.locale(locale, null, true)

--- a/src/locale/uz-latn.js
+++ b/src/locale/uz-latn.js
@@ -8,7 +8,30 @@ const locale = {
   weekdaysShort: 'Yak_Dush_Sesh_Chor_Pay_Jum_Shan'.split('_'),
   monthsShort: 'Yan_Fev_Mar_Apr_May_Iyun_Iyul_Avg_Sen_Okt_Noy_Dek'.split('_'),
   weekdaysMin: 'Ya_Du_Se_Cho_Pa_Ju_Sha'.split('_'),
-  ordinal: n => n
+  ordinal: n => n,
+  formats: {
+    LT: 'HH:mm',
+    LTS: 'HH:mm:ss',
+    L: 'DD/MM/YYYY',
+    LL: 'D MMMM YYYY',
+    LLL: 'D MMMM YYYY HH:mm',
+    LLLL: 'D MMMM YYYY, dddd HH:mm'
+  },
+  relativeTime: {
+    future: 'Yaqin %s ichida',
+    past: 'Bir necha %s oldin',
+    s: 'soniya',
+    m: 'bir daqiqa',
+    mm: '%d daqiqa',
+    h: 'bir soat',
+    hh: '%d soat',
+    d: 'bir kun',
+    dd: '%d kun',
+    M: 'bir oy',
+    MM: '%d oy',
+    y: 'bir yil',
+    yy: '%d yil'
+  }
 }
 
 dayjs.locale(locale, null, true)

--- a/src/locale/uz.js
+++ b/src/locale/uz.js
@@ -8,7 +8,30 @@ const locale = {
   weekdaysShort: 'Якш_Душ_Сеш_Чор_Пай_Жум_Шан'.split('_'),
   monthsShort: 'янв_фев_мар_апр_май_июн_июл_авг_сен_окт_ноя_дек'.split('_'),
   weekdaysMin: 'Як_Ду_Се_Чо_Па_Жу_Ша'.split('_'),
-  ordinal: n => n
+  ordinal: n => n,
+  formats: {
+    LT: 'HH:mm',
+    LTS: 'HH:mm:ss',
+    L: 'DD/MM/YYYY',
+    LL: 'D MMMM YYYY',
+    LLL: 'D MMMM YYYY HH:mm',
+    LLLL: 'D MMMM YYYY, dddd HH:mm'
+  },
+  relativeTime: {
+    future: 'Якин %s ичида',
+    past: 'Бир неча %s олдин',
+    s: 'фурсат',
+    m: 'бир дакика',
+    mm: '%d дакика',
+    h: 'бир соат',
+    hh: '%d соат',
+    d: 'бир кун',
+    dd: '%d кун',
+    M: 'бир ой',
+    MM: '%d ой',
+    y: 'бир йил',
+    yy: '%d йил'
+  }
 }
 
 dayjs.locale(locale, null, true)

--- a/src/locale/vi.js
+++ b/src/locale/vi.js
@@ -8,7 +8,34 @@ const locale = {
   weekdaysShort: 'CN_T2_T3_T4_T5_T6_T7'.split('_'),
   monthsShort: 'Th01_Th02_Th03_Th04_Th05_Th06_Th07_Th08_Th09_Th10_Th11_Th12'.split('_'),
   weekdaysMin: 'CN_T2_T3_T4_T5_T6_T7'.split('_'),
-  ordinal: n => n
+  ordinal: n => n,
+  formats: {
+    LT: 'HH:mm',
+    LTS: 'HH:mm:ss',
+    L: 'DD/MM/YYYY',
+    LL: 'D MMMM [năm] YYYY',
+    LLL: 'D MMMM [năm] YYYY HH:mm',
+    LLLL: 'dddd, D MMMM [năm] YYYY HH:mm',
+    l: 'DD/M/YYYY',
+    ll: 'D MMM YYYY',
+    lll: 'D MMM YYYY HH:mm',
+    llll: 'ddd, D MMM YYYY HH:mm'
+  },
+  relativeTime: {
+    future: '%s tới',
+    past: '%s trước',
+    s: 'vài giây',
+    m: 'một phút',
+    mm: '%d phút',
+    h: 'một giờ',
+    hh: '%d giờ',
+    d: 'một ngày',
+    dd: '%d ngày',
+    M: 'một tháng',
+    MM: '%d tháng',
+    y: 'một năm',
+    yy: '%d năm'
+  }
 }
 
 dayjs.locale(locale, null, true)

--- a/src/locale/x-pseudo.js
+++ b/src/locale/x-pseudo.js
@@ -8,7 +8,29 @@ const locale = {
   weekdaysShort: 'S~úñ_~Móñ_~Túé_~Wéd_~Thú_~Frí_~Sát'.split('_'),
   monthsShort: 'J~áñ_~Féb_~Már_~Ápr_~Máý_~Júñ_~Júl_~Áúg_~Sép_~Óct_~Ñóv_~Déc'.split('_'),
   weekdaysMin: 'S~ú_Mó~_Tú_~Wé_T~h_Fr~_Sá'.split('_'),
-  ordinal: n => n
+  ordinal: n => n,
+  formats: {
+    LT: 'HH:mm',
+    L: 'DD/MM/YYYY',
+    LL: 'D MMMM YYYY',
+    LLL: 'D MMMM YYYY HH:mm',
+    LLLL: 'dddd, D MMMM YYYY HH:mm'
+  },
+  relativeTime: {
+    future: 'í~ñ %s',
+    past: '%s á~gó',
+    s: 'á ~féw ~sécó~ñds',
+    m: 'á ~míñ~úté',
+    mm: '%d m~íñú~tés',
+    h: 'á~ñ hó~úr',
+    hh: '%d h~óúrs',
+    d: 'á ~dáý',
+    dd: '%d d~áýs',
+    M: 'á ~móñ~th',
+    MM: '%d m~óñt~hs',
+    y: 'á ~ýéár',
+    yy: '%d ý~éárs'
+  }
 }
 
 dayjs.locale(locale, null, true)

--- a/src/locale/x-pseudo.js
+++ b/src/locale/x-pseudo.js
@@ -11,6 +11,7 @@ const locale = {
   ordinal: n => n,
   formats: {
     LT: 'HH:mm',
+    LTS: 'HH:mm:ss',
     L: 'DD/MM/YYYY',
     LL: 'D MMMM YYYY',
     LLL: 'D MMMM YYYY HH:mm',

--- a/src/locale/yo.js
+++ b/src/locale/yo.js
@@ -8,7 +8,30 @@ const locale = {
   weekdaysShort: 'Àìk_Ajé_Ìsẹ́_Ọjr_Ọjb_Ẹtì_Àbá'.split('_'),
   monthsShort: 'Sẹ́r_Èrl_Ẹrn_Ìgb_Èbi_Òkù_Agẹ_Ògú_Owe_Ọ̀wà_Bél_Ọ̀pẹ̀̀'.split('_'),
   weekdaysMin: 'Àì_Aj_Ìs_Ọr_Ọb_Ẹt_Àb'.split('_'),
-  ordinal: n => n
+  ordinal: n => n,
+  formats: {
+    LT: 'h:mm A',
+    LTS: 'h:mm:ss A',
+    L: 'DD/MM/YYYY',
+    LL: 'D MMMM YYYY',
+    LLL: 'D MMMM YYYY h:mm A',
+    LLLL: 'dddd, D MMMM YYYY h:mm A'
+  },
+  relativeTime: {
+    future: 'ní %s',
+    past: '%s kọjá',
+    s: 'ìsẹjú aayá die',
+    m: 'ìsẹjú kan',
+    mm: 'ìsẹjú %d',
+    h: 'wákati kan',
+    hh: 'wákati %d',
+    d: 'ọjọ́ kan',
+    dd: 'ọjọ́ %d',
+    M: 'osù kan',
+    MM: 'osù %d',
+    y: 'ọdún kan',
+    yy: 'ọdún %d'
+  }
 }
 
 dayjs.locale(locale, null, true)

--- a/src/locale/zh-cn.js
+++ b/src/locale/zh-cn.js
@@ -48,3 +48,4 @@ const locale = {
 dayjs.locale(locale, null, true)
 
 export default locale
+

--- a/src/locale/zh-hk.js
+++ b/src/locale/zh-hk.js
@@ -36,3 +36,4 @@ const locale = {
 dayjs.locale(locale, null, true)
 
 export default locale
+

--- a/src/locale/zh-tw.js
+++ b/src/locale/zh-tw.js
@@ -40,3 +40,4 @@ const locale = {
 dayjs.locale(locale, null, true)
 
 export default locale
+

--- a/test/locale/keys.test.js
+++ b/test/locale/keys.test.js
@@ -15,8 +15,9 @@ fs.readdirSync(path.join(__dirname, localeDir))
     })
   })
 
-it('Locale keys', () => {
-  Locale.forEach((locale) => {
+const noRelTime = []
+Locale.forEach((locale) => {
+  it(`Locale keys for ${locale.content.name}`, () => {
     const {
       name,
       ordinal,
@@ -76,9 +77,18 @@ it('Locale keys', () => {
       if (llll) expect(llll).toEqual(expect.any(String))
     }
     if (relativeTime) {
-      expect(Object.keys(relativeTime).sort()).toEqual(['d', 'dd', 'future', 'h', 'hh', 'm', 'mm', 'M', 'MM',
-        'past', 's', 'y', 'yy']
-        .sort())
+      try {
+        expect(Object.keys(relativeTime).sort()).toEqual(['d', 'dd', 'future', 'h', 'hh', 'm', 'mm', 'M', 'MM',
+          'past', 's', 'y', 'yy']
+          .sort())
+      } catch (e) {
+        noRelTime.push(locale.content.name)
+      }
     }
   })
 })
+
+afterAll(() => {
+  console.log(noRelTime)
+})
+

--- a/test/locale/keys.test.js
+++ b/test/locale/keys.test.js
@@ -15,7 +15,6 @@ fs.readdirSync(path.join(__dirname, localeDir))
     })
   })
 
-const noRelTime = []
 Locale.forEach((locale) => {
   it(`Locale keys for ${locale.content.name}`, () => {
     const {
@@ -77,18 +76,9 @@ Locale.forEach((locale) => {
       if (llll) expect(llll).toEqual(expect.any(String))
     }
     if (relativeTime) {
-      try {
-        expect(Object.keys(relativeTime).sort()).toEqual(['d', 'dd', 'future', 'h', 'hh', 'm', 'mm', 'M', 'MM',
-          'past', 's', 'y', 'yy']
-          .sort())
-      } catch (e) {
-        noRelTime.push(locale.content.name)
-      }
+      expect(Object.keys(relativeTime).sort()).toEqual(['d', 'dd', 'future', 'h', 'hh', 'm', 'mm', 'M', 'MM',
+        'past', 's', 'y', 'yy']
+        .sort())
     }
   })
 })
-
-afterAll(() => {
-  console.log(noRelTime)
-})
-

--- a/test/plugin/localizableFormat.test.js
+++ b/test/plugin/localizableFormat.test.js
@@ -53,7 +53,10 @@ it('Uses English formats in other locales as default', () => {
   const actualDate = dayjs(date)
   const expectedDate = moment(date)
   // todo: ar here isn't a good fix here
+  const arOldFormats = ar.formats
+  ar.formats = {}
   expect(actualDate.locale(ar).format('L')).toBe(expectedDate.format('L'))
+  ar.formats = arOldFormats
 })
 
 it('Leaves the default format intact', () => {


### PR DESCRIPTION
Inspired from https://github.com/iamkun/dayjs/pull/541

#### This PR imports `relativeTime` and `formats` from momentjs locales.

I have skipped the ones that uses function like https://github.com/moment/moment/blob/d0f0dd8f40be987593767a3dc5e27c45c6a3fa49/locale/he.js#L45-L50 to keep it simple

```js
             hh : function (number) {
                if (number === 2) {
                    return 'שעתיים';
                }
                return number + ' שעות';
            }
```

#### I have also made locale tests independent, so that it tests all locales even when one of them fails, let me know if I need to revert that.

#### Locales with missing keys

```js
[ 
  'ar-ly',
  'be',
  'br',
  'bs',
  'cv',
  'de-ch',
  'gl',
  'gom-latn',
  'is',
  'it-ch',
  'lb',
  'lv',
  'me',
  'mn',
  'mr',
  'sl',
  'tlh',
  'tzl'
]
```