### PR TITLE
Typo fix in API-reference.md

### DIFF
--- a/docs/en/API-reference.md
+++ b/docs/en/API-reference.md
@@ -270,7 +270,7 @@ Returns a `string` with the `Dayjs`'s formatted date.
 To escape characters, wrap them in square brackets (e.g. `[A] [MM]`).
 
 ```js
-dayjs().format() // current date in ISO6801, without fraction seconds e.g. '2020-04-02T08:02:17-05:00'
+dayjs().format() // current date in ISO8601, without fraction seconds e.g. '2020-04-02T08:02:17-05:00'
 
 dayjs('2019-01-25').format('[YYYY] YYYY-MM-DDTHH:mm:ssZ[Z]') // 'YYYY 2019-01-25T00:00:00-02:00Z'
 

--- a/docs/es-es/API-reference.md
+++ b/docs/es-es/API-reference.md
@@ -270,7 +270,7 @@ Devuelve un dato de tipo `string` con la fecha del objeto `Dayjs` formateada.
 Para escapar caracteres, estos se han de encerrar entre corchetes (p.ej.: `[A] [MM]`).
 
 ```js
-dayjs().format() // fecha actual en ISO6801, sin fracciones de segundo p.ej. '2020-04-02T08:02:17-05:00'
+dayjs().format() // fecha actual en ISO8601, sin fracciones de segundo p.ej. '2020-04-02T08:02:17-05:00'
 
 dayjs('2019-01-25').format('[YYYY] YYYY-MM-DDTHH:mm:ssZ[Z]') // 'YYYY 2019-01-25T00:00:00-02:00Z'
 

--- a/docs/pt-br/API-reference.md
+++ b/docs/pt-br/API-reference.md
@@ -268,7 +268,7 @@ Retorna uma `string` com um objeto `Dayjs` contendo a data formatada.
 Para escapar caracteres, envolva-os entre colchetes (por exemplo: `[A] [MM]`).
 
 ```js
-dayjs().format() // current date in ISO6801, without fraction seconds e.g. '2020-04-02T08:02:17-05:00'
+dayjs().format() // current date in ISO8601, without fraction seconds e.g. '2020-04-02T08:02:17-05:00'
 
 dayjs('2019-01-25').format('[YYYY] YYYY-MM-DDTHH:mm:ssZ[Z]') // 'YYYY 2019-01-25T00:00:00-02:00Z'
 


### PR DESCRIPTION
Just noticed this tiny typo in your docs!