### PR TITLE
fix: add calendar locales for nl

### DIFF
--- a/src/locale/nl.js
+++ b/src/locale/nl.js
@@ -1,5 +1,8 @@
 import dayjs from 'dayjs'
 
+const LT = 'HH:mm';
+const L = 'DD-MM-YYYY';
+
 const locale = {
   name: 'nl',
   weekdays: 'zondag_maandag_dinsdag_woensdag_donderdag_vrijdag_zaterdag'.split('_'),
@@ -7,20 +10,20 @@ const locale = {
   ordinal: n => `${n}.`,
   weekStart: 1,
   formats: {
-    LT: 'HH:mm',
+    L,
+    LT,
     LTS: 'HH:mm:ss',
-    L: 'DD-MM-YYYY',
     LL: 'D MMMM YYYY',
     LLL: 'D MMMM YYYY HH:mm',
     LLLL: 'dddd D MMMM YYYY HH:mm'
   },
   calendar: {
-    lastDay: `[Gisteren om] LT`,
-    sameDay: `[Vandaag om] LT`,
-    nextDay: `[Morgen om] LT`,
-    nextWeek: `dddd [om] LT`,
-    lastWeek: `[Afgelopen] dddd [om] LT`,
-    sameElse: 'L'
+    lastDay: '[Gisteren om] ' + LT,
+    sameDay: '[Vandaag om] ' + LT,
+    nextDay: '[Morgen om] ' + LT,
+    nextWeek: 'dddd [om] ' + LT,
+    lastWeek: '[Afgelopen] dddd [om] ' + LT,
+    sameElse: L
   },
   relativeTime: {
     future: 'over %s',

--- a/src/locale/nl.js
+++ b/src/locale/nl.js
@@ -1,7 +1,7 @@
 import dayjs from 'dayjs'
 
-const LT = 'HH:mm';
-const L = 'DD-MM-YYYY';
+const LT = 'HH:mm'
+const L = 'DD-MM-YYYY'
 
 const locale = {
   name: 'nl',
@@ -18,11 +18,11 @@ const locale = {
     LLLL: 'dddd D MMMM YYYY HH:mm'
   },
   calendar: {
-    lastDay: '[Gisteren om] ' + LT,
-    sameDay: '[Vandaag om] ' + LT,
-    nextDay: '[Morgen om] ' + LT,
-    nextWeek: 'dddd [om] ' + LT,
-    lastWeek: '[Afgelopen] dddd [om] ' + LT,
+    lastDay: `[Gisteren om] ${LT}`,
+    sameDay: `[Vandaag om] ${LT}`,
+    nextDay: `[Morgen om] ${LT}`,
+    nextWeek: `dddd [om] ${LT}`,
+    lastWeek: `[Afgelopen] dddd [om] ${LT}`,
     sameElse: L
   },
   relativeTime: {

--- a/src/locale/nl.js
+++ b/src/locale/nl.js
@@ -14,6 +14,14 @@ const locale = {
     LLL: 'D MMMM YYYY HH:mm',
     LLLL: 'dddd D MMMM YYYY HH:mm'
   },
+  calendar: {
+    lastDay: `[Gisteren om] LT`,
+    sameDay: `[Vandaag om] LT`,
+    nextDay: `[Morgen om] LT`,
+    nextWeek: `dddd [om] LT`,
+    lastWeek: `[Afgelopen] dddd [om] LT`,
+    sameElse: 'L'
+  },
   relativeTime: {
     future: 'over %s',
     past: '%s geleden',


### PR DESCRIPTION
This PR adds translations for the Calendar plugin when the locale is set to Dutch.

So, this works only for NL (missing languages will still fall back to en). Also, this only works with the LocalizedFormat plugin enabled. I don't expect this PR to be merged. But I do hope it starts a conversation.

I have some separate concerns/issues I'd like to address as well.

### 1. Configure plugins

Right now, the dates in calendar are hard to use when combined with other locales. I'd have to pass in the format with every call I make, which is not great.

What I mean by that is that the calendar plugin _does_ use translations. However, as soon as you pass in 1 option, it completely ignores the translations:

```js
dayjs(date).calendar(dayjs())
```

☝️ Uses the translations from the locale.

```js
dayjs(date).calendar(dayjs(), {
  sameElse: 'L LT'
});
```

☝️ This will now no longer read the translations from the locale for the _other_ options. This is the offending line causing that behaviour: https://github.com/iamkun/dayjs/blob/6a297b703f14981fb2458cc2521637750a0f1f2a/src/plugin/calendar/index.js#L14

By allowing the `calendarFormat` to be configured once, you remove both the need to supply the options on each call _and_ the bug that ignores translations.

Something like this perhaps, which is also easy to keep backwards compatible:

```js
dayjs.extend(Calendar.factory({ defaults: 'go here' }));
```

### 2. Translations for calendar

I think the calendar should construct its options [the same way RelativeTime does it](https://github.com/iamkun/dayjs/blob/dev/src/plugin/relativeTime/index.js#L5).

This would solve half of above issue as well and would be more in line with the way locales work.

### 3. Translations

One example where literal translations aren't enough is Portuguese. 

`lastWeek` has `passada` for weekdays whereas sábado and domingo would be `passado`. Weekends are male.

Perhaps those could optionally be made into functions? That way these cases will still work.

### 4. Plugins aware of plugins

For the calendar it would make sense to depend on, or be aware of the LocalizedFormat plugin. It uses localized formats that would otherwise be duplicated. Considering the small size of the plugin I'd say it's not a strange thing to move.

Adding the translations for calendar to locales would already be a huge win (which is what this PR does for Dutch).

## Conclusion

Sorry for all the stuff I'm asking you to read. But I do have the best of intentions. This library rules! 😄 