### PR TITLE
customParseFormat: added logic to parse the week day

### DIFF
--- a/src/plugin/customParseFormat/index.js
+++ b/src/plugin/customParseFormat/index.js
@@ -1,4 +1,4 @@
-const formattingTokens = /(\[[^[]*\])|([-:/.()\s]+)|(A|a|YYYY|YY?|MM?M?M?|Do|DD?|hh?|HH?|mm?|ss?|S{1,3}|z|ZZ?)/g
+const formattingTokens = /(\[[^[]*\])|([-:/.()\s]+)|(A|a|YYYY|YY?|MM?M?M?|Do|dddd|DD?|hh?|HH?|mm?|ss?|S{1,3}|z|ZZ?)/g
 
 const match1 = /\d/ // 0 - 9
 const match2 = /\d\d/ // 00 - 99
@@ -56,6 +56,13 @@ const expressions = {
   hh: [match1to2, addInput('hours')],
   D: [match1to2, addInput('day')],
   DD: [match2, addInput('day')],
+  dddd: [matchWord, function (input) {
+    const { weekdays } = locale
+    const matchIndex = weekdays.indexOf(input)
+    if (matchIndex < 0) {
+      throw new Error()
+    }
+  }],
   Do: [matchWord, function (input) {
     const { ordinal } = locale;
     [this.day] = input.match(/\d+/)

--- a/src/plugin/customParseFormat/index.js
+++ b/src/plugin/customParseFormat/index.js
@@ -1,4 +1,4 @@
-const formattingTokens = /(\[[^[]*\])|([-:/.()\s]+)|(A|a|YYYY|YY?|MM?M?M?|Do|dddd|DD?|hh?|HH?|mm?|ss?|S{1,3}|z|ZZ?)/g
+const formattingTokens = /(\[[^[]*\])|([-:/.,()\s]+)|(A|a|YYYY|YY?|MM?M?M?|Do|dddd|DD?|hh?|HH?|mm?|ss?|S{1,3}|z|ZZ?)/g
 
 const match1 = /\d/ // 0 - 9
 const match2 = /\d\d/ // 00 - 99
@@ -9,7 +9,7 @@ const matchUpperCaseAMPM = /[AP]M/
 const matchLowerCaseAMPM = /[ap]m/
 const matchSigned = /[+-]?\d+/ // -inf - inf
 const matchOffset = /[+-]\d\d:?\d\d/ // +00:00 -00:00 +0000 or -0000
-const matchWord = /\d*[^\s\d-:/.()]+/ // Word
+const matchWord = /\d*[^\s\d-:/.,()]+/ // Word
 
 let locale
 

--- a/test/plugin/customParseFormat.test.js
+++ b/test/plugin/customParseFormat.test.js
@@ -171,8 +171,8 @@ it('Valid Date', () => {
 })
 
 it('parse week day format', () => {
-  const input = 'Tuesday 16 January 18:00'
-  const format = 'dddd DD MMMM HH:mm'
+  const input = 'Tuesday, 16 January 18:00'
+  const format = 'dddd, DD MMMM HH:mm'
   expect(dayjs(input, format).valueOf()).toBe(moment(input, format).valueOf())
 })
 

--- a/test/plugin/customParseFormat.test.js
+++ b/test/plugin/customParseFormat.test.js
@@ -170,6 +170,19 @@ it('Valid Date', () => {
   expect(dayjs('2014/10/12', 'YYYY-MM-DD').format('MM-DD-YYYY')).toBe('10-12-2014')
 })
 
+it('parse week day format', () => {
+  const input = 'Tuesday 16 January 18:00'
+  const format = 'dddd DD MMMM HH:mm'
+  expect(dayjs(input, format).valueOf()).toBe(moment(input, format).valueOf())
+})
+
+
+it('parse invalid week day format', () => {
+  const input = 'xyz 16 January 18:00'
+  const format = 'dddd DD MMMM HH:mm'
+  expect(dayjs(input, format).format()).toBe('Invalid Date')
+})
+
 it('correctly parse month from string after changing locale globally', () => {
   const input = '2018 лютий 03'
   const format = 'YYYY MMMM DD'


### PR DESCRIPTION
Resolves issue #571 

import customParseFormat from 'dayjs/plugin/customParseFormat';
dayjs.extend(customParseFormat);

var fmt = 'dddd DD MMMM HH:mm';

var d = dayjs('Tuesday 16 January 18:00', fmt);
// works fine: d.isValid() is true

d = dayjs('Monday 15 January 18:00', fmt);
// works fine: d.isValid() is true

d = dayjs('Saturday 20 January 18:00', fmt);
// works fine: d.isValid() is true

