### PR TITLE
Add fil locale (same as tl-ph)

### DIFF
--- a/src/locale/fil.js
+++ b/src/locale/fil.js
@@ -1,0 +1,7 @@
+import dayjs from 'dayjs'
+import tlLocale from './tl-ph'
+
+const locale = Object.assign({}, tlLocale, { name: 'fil' })
+dayjs.locale(locale, null, true)
+
+export default locale


### PR DESCRIPTION
Filipino language (`fil`) is synonym to tagalog language (`tl-ph`)

https://en.wikipedia.org/wiki/Filipino_language#Filipino_vs._Tagalog