### PR TITLE
fix: Pad formatted year string with zeros

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -295,7 +295,7 @@ class Dayjs {
 
     const matches = {
       YY: String(this.$y).slice(-2),
-      YYYY: this.$y,
+      YYYY: Utils.s(this.$y, 4, '0'),
       M: $M + 1,
       MM: Utils.s($M + 1, 2, '0'),
       MMM: getShort(locale.monthsShort, $M, months, 3),

--- a/test/display.test.js
+++ b/test/display.test.js
@@ -253,3 +253,9 @@ it('As JSON -> toJSON', () => {
 it('As ISO 8601 String -> toISOString e.g. 2013-02-04T22:44:30.652Z', () => {
   expect(dayjs().toISOString()).toBe(moment().toISOString())
 })
+
+it('Format YYYY with leading zeros', () => {
+  const date = new Date('0001-01-01');
+  const yearFormat = 'YYYY';
+  expect(dayjs(date).format(yearFormat)).toBe(moment(date).format(yearFormat));
+})


### PR DESCRIPTION
This pull request fixes formatting of date with pattern "YYYY" for years less than 1000