### PR TITLE
With module you can define the path to ES module

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "2KB immutable date time library alternative to Moment.js with the same modern API ",
   "main": "dayjs.min.js",
   "types": "index.d.ts",
-  "module": "dayjs.min.js",
+  "module": "esm/index.js",
   "scripts": {
     "test": "TZ=Pacific/Auckland npm run test-tz && TZ=Europe/London npm run test-tz && TZ=America/Whitehorse npm run test-tz && npm run test-tz && jest",
     "test-tz": "date && jest test/timezone.test --coverage=false",


### PR DESCRIPTION
The module attribute is too define ES module so that loaders can find the unpackaged code.

https://github.com/rollup/rollup/wiki/pkg.module

https://pikapkg.com is looking for ES modules in that field

https://unpkg.com serves that file if you define that it should load with `?module`