### PR TITLE
modify types of diff

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -65,7 +65,7 @@ declare namespace dayjs {
 
     format(template?: string): string
 
-    diff(date: ConfigType, unit: QUnitType | OpUnitType, float?: boolean): number
+    diff(date: ConfigType, unit?: QUnitType | OpUnitType, float?: boolean): number
 
     valueOf(): number
 


### PR DESCRIPTION
If passing only one argument to a dayjs diff method, it is said that the type is not correct.
So I fixed it.

-  document
![image](https://user-images.githubusercontent.com/5327886/59662233-7fda5a00-91e7-11e9-89e5-c50ebe801ffa.png)

- code
![image](https://user-images.githubusercontent.com/5327886/59662330-ac8e7180-91e7-11e9-8404-31abaabc1087.png)
