### PR TITLE
Add optional properties to DA locale

### DIFF
--- a/src/locale/da.js
+++ b/src/locale/da.js
@@ -3,7 +3,10 @@ import dayjs from 'dayjs'
 const locale = {
   name: 'da',
   weekdays: 'søndag_mandag_tirsdag_onsdag_torsdag_fredag_lørdag'.split('_'),
+  weekdaysShort: 'søn._man._tirs._ons._tors._fre._lør.'.split('_'),
+  weekdaysMin: 'sø._ma._ti._on._to._fr._lø.'.split('_'),
   months: 'januar_februar_marts_april_maj_juni_juli_august_september_oktober_november_december'.split('_'),
+  monthsShort: 'jan._feb._mar._apr._maj_juni_juli_aug._sept._okt._nov._dec.'.split('_'),
   weekStart: 1,
   ordinal: n => `${n}.`,
   formats: {


### PR DESCRIPTION
This PR adds the optional properties `weekdaysShort`, `weekdaysMin` and `monthsShort` to the Danish locale.

All changes have been crosschecked using a Danish dictionary:
https://ordnet.dk/ddo/ordbog