### PR TITLE
Fix TS2339: Property 'week' does not exist on type 'Dayjs'.

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -51,6 +51,8 @@ declare namespace dayjs {
 
     millisecond(value: number): Dayjs
 
+    week(): number
+
     set(unit: UnitType, value: number): Dayjs
 
     get(unit: UnitType): number


### PR DESCRIPTION
Fix `TS2339: Property 'week' does not exist on type 'Dayjs'` when in `TypeScript`