### PR TITLE
Fix SL abbreviation for month may

### DIFF
--- a/src/locale/sl.js
+++ b/src/locale/sl.js
@@ -6,7 +6,7 @@ const locale = {
   months: 'januar_februar_marec_april_maj_junij_julij_avgust_september_oktober_november_december'.split('_'),
   weekStart: 1,
   weekdaysShort: 'ned._pon._tor._sre._čet._pet._sob.'.split('_'),
-  monthsShort: 'jan._feb._mar._apr._maj._jun._jul._avg._sep._okt._nov._dec.'.split('_'),
+  monthsShort: 'jan._feb._mar._apr._maj_jun._jul._avg._sep._okt._nov._dec.'.split('_'),
   weekdaysMin: 'ne_po_to_sr_če_pe_so'.split('_'),
   ordinal: n => n,
   formats: {


### PR DESCRIPTION
The SL abbreviation for the month May is wrong. Slovenian word for May is `maj` meaning that it is already only 3 characters long so it doesn't need the trailing `.` which denotes an abbreviation.