### PR TITLE
Fix double meaning for nb locale

### DIFF
--- a/src/locale/nb.js
+++ b/src/locale/nb.js
@@ -19,7 +19,7 @@ const locale = {
   },
   relativeTime: {
     future: 'om %s',
-    past: 'for %s siden',
+    past: '%s siden',
     s: 'noen sekunder',
     m: 'ett minutt',
     mm: '%d minutter',


### PR DESCRIPTION
"for %s siden" is a double meaning, "for" means "for" and "siden" means since. The translation here is basically `for %s since`.

In Norwegian it works, and it's a common way to communicate verbally, but in writing it becomes redundant. I've also read that you like to keep these things similar to Moment, which is what I'm switching from, and I reacted on this immediately :/

As a side note, the language name here should be `nb_NO` or from what I can gather from your structure `no-nb`. Norway has two official languages, that being `nb_NO` and `nn_NO`