### PR TITLE
Fall back relative time to english if cant find loaded locale

### DIFF
--- a/src/plugin/relativeTime/index.js
+++ b/src/plugin/relativeTime/index.js
@@ -18,7 +18,15 @@ export default (o, c, d) => {
     yy: '%d years'
   }
   const fromTo = (input, withoutSuffix, instance, isFrom) => {
-    const loc = instance.$locale().relativeTime
+    let loc
+
+    try {
+      loc = instance.$locale().relativeTime
+    } catch (e) {
+      console.error('Tried to access locale which was not loaded. Falling back to EN.')
+      loc = d.en.relativeTime
+    }
+
     const T = [
       { l: 's', r: 44, d: C.S },
       { l: 'm', r: 89 },

--- a/test/plugin/relativeTime.test.js
+++ b/test/plugin/relativeTime.test.js
@@ -105,3 +105,8 @@ it('Time from now with UTC', () => {
 
   expect(dutc.fromNow()).toBe(mutc.fromNow())
 })
+
+it('Fall back to english in case of missing locale', () => {
+  const d = dayjs(Date.now()).locale('pl').fromNow()
+  expect(d).toBeDefined()
+})


### PR DESCRIPTION
Currently dayjs is not actually "safe" in terms of usage.

I know there is a goal of keeping size limit, however maybe there is a reasonable way to improve code quality and move code compiling to some super-minifier like Closure compiler, without omitting code security and overall readability (variable names etc)?

In this PR I do fallback to english locale in relativeTime plugin, which throws without reasonable message if locale isn't loaded properly. I also show error in console. I have expected behavior like this since I failed loading language in my project and it didn't inform me about it.

Don't know if this is something expected in this library or it's very "raw" deliberately 