### PR TITLE
Minor localisation change

### DIFF
--- a/src/locale/uk.js
+++ b/src/locale/uk.js
@@ -10,7 +10,7 @@ const locale = {
   weekStart: 1,
   relativeTime: {
     future: 'через %s',
-    past: '%s назад',
+    past: '%s тому',
     s: 'декілька секунд',
     m: 'хвилина',
     mm: '%d хвилин',


### PR DESCRIPTION
relativeTime.past is defined as '%s назад' which is Russian translation. Correct Ukrainian localisation is '%s тому'.