### PR TITLE
fix: Added missing quarter unit for .add()/.subtrack()

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -253,6 +253,9 @@ class Dayjs {
     if (unit === C.M) {
       return this.set(C.M, this.$M + number)
     }
+    if (unit === C.Q) {
+      return this.set(C.M, this.$M + (number * 3))
+    }
     if (unit === C.Y) {
       return this.set(C.Y, this.$y + number)
     }

--- a/test/manipulate.test.js
+++ b/test/manipulate.test.js
@@ -56,6 +56,7 @@ it('Add Time days', () => {
   expect(dayjs().add(1, 'd').valueOf()).toBe(moment().add(1, 'd').valueOf())
   expect(dayjs().add(1, 'days').valueOf()).toBe(moment().add(1, 'days').valueOf())
   expect(dayjs().add(1, 'M').valueOf()).toBe(moment().add(1, 'M').valueOf())
+  expect(dayjs().add(1, 'Q').valueOf()).toBe(moment().add(1, 'Q').valueOf())
   expect(dayjs().add(1, 'y').valueOf()).toBe(moment().add(1, 'y').valueOf())
   expect(dayjs('20111031').add(1, 'months').valueOf()).toBe(moment('20111031').add(1, 'months').valueOf())
   expect(dayjs('20160131').add(1, 'months').valueOf()).toBe(moment('20160131').add(1, 'months').valueOf())


### PR DESCRIPTION
Added missing quarter unit for .add()/.subtrack().

e.g. `dayjs('2019-10-30T18:25:41.124Z').add(2, 'quarter') // 2020-04-30T17:25:41.124Z`