### PR TITLE
Added some edge cases to WeekOfYear, that should work correctly

### DIFF
--- a/test/plugin/weekOfYear.test.js
+++ b/test/plugin/weekOfYear.test.js
@@ -40,6 +40,8 @@ it('Week of year with locale', () => {
   // Edges
   expect(dayjs('2018-12-30').week()).toBe(moment('2018-12-30').week())
   expect(dayjs('2019-12-29').week()).toBe(moment('2019-12-29').week())
+  expect(dayjs('2016-01-01').week()).toBe(moment('2016-01-01').week())
+  expect(dayjs('2016-01-04').week()).toBe(moment('2016-01-04').week())
 })
 
 it('Format w ww wo', () => {


### PR DESCRIPTION
We noticed, that in some years - we have an off-by-one error.
These cases are the year 2010 and 2016 - where the first week of the year has more than 4 days in the old year.