### PR TITLE
Fix ISO8601 parse on Safari

### DIFF
--- a/src/constant.js
+++ b/src/constant.js
@@ -28,3 +28,4 @@ export const INVALID_DATE_STRING = 'Invalid Date'
 // regex
 export const REGEX_PARSE = /^(\d{4})-?(\d{1,2})-?(\d{0,2})[^0-9]*(\d{1,2})?:?(\d{1,2})?:?(\d{1,2})?.?(\d{1,3})?$/
 export const REGEX_FORMAT = /\[([^\]]+)]|Y{2,4}|M{1,4}|D{1,2}|d{1,4}|H{1,2}|h{1,2}|a|A|m{1,2}|s{1,2}|Z{1,2}|SSS/g
+export const REGEX_ISO8601_NO_COLON_TZ = /(\+|-)(\d{2})(\d{2})$/i

--- a/src/index.js
+++ b/src/index.js
@@ -55,14 +55,21 @@ const parseDate = (cfg) => {
   if (date === null) return new Date(NaN) // null is invalid
   if (Utils.u(date)) return new Date() // today
   if (date instanceof Date) return new Date(date)
-  if (typeof date === 'string' && !/Z$/i.test(date)) {
-    const d = date.match(C.REGEX_PARSE)
-    if (d) {
-      if (utc) {
-        return new Date(Date.UTC(d[1], d[2] - 1, d[3]
-          || 1, d[4] || 0, d[5] || 0, d[6] || 0, d[7] || 0))
+  if (typeof date === 'string') {
+    if (C.REGEX_ISO8601_NO_COLON_TZ.test(date)) {
+      const dateColonized = date.replace(C.REGEX_ISO8601_NO_COLON_TZ, (string, $1, $2, $3) => `${$1}${$2}:${$3}`)
+      return new Date(dateColonized)
+    }
+
+    if (!/Z$/i.test(date)) {
+      const d = date.match(C.REGEX_PARSE)
+      if (d) {
+        if (utc) {
+          return new Date(Date.UTC(d[1], d[2] - 1, d[3]
+            || 1, d[4] || 0, d[5] || 0, d[6] || 0, d[7] || 0))
+        }
+        return new Date(d[1], d[2] - 1, d[3] || 1, d[4] || 0, d[5] || 0, d[6] || 0, d[7] || 0)
       }
-      return new Date(d[1], d[2] - 1, d[3] || 1, d[4] || 0, d[5] || 0, d[6] || 0, d[7] || 0)
     }
   }
 


### PR DESCRIPTION
This PR fixes #723 

When is detected the date ends in the ISO8601 format but without the colon it will add this missin colon.
The issue only appear in Safari.
Unit tests don't get this error.