### PR TITLE
Export module instead of namespace for TS declaration

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,9 +1,6 @@
 /// <reference path="./locale/index.d.ts" />
 
-export = dayjs;
-declare function dayjs (date?: dayjs.ConfigType, option?: dayjs.OptionType, locale?: string): dayjs.Dayjs
-
-declare namespace dayjs {
+declare module 'dayjs' {
   export type ConfigType = string | number | Date | Dayjs
 
   export type OptionType = { locale?: string, format?: string, utc?: boolean } | string
@@ -95,6 +92,8 @@ declare namespace dayjs {
 
     locale(preset: string | ILocale, object?: Partial<ILocale>): Dayjs
   }
+
+  export default function dayjs (date?: ConfigType, option?: OptionType, locale?: string): Dayjs
 
   export type PluginFunc = (option: any, c: typeof Dayjs, d: typeof dayjs) => void
 


### PR DESCRIPTION
The source code uses modules, so now the types will too.

This fixes the issue of not being able to use the default export although it exists.

The existing workaround is to use a project-wide `tsconfig.json` which works around this issue (see below). It's less than ideal, as it affects the entire project of the user. This PR should resolve that.

```
    "esModuleInterop": true,
    "allowSyntheticDefaultImports": true,
```

