### PR TITLE
feat: add plugin weekOfMonth

### DIFF
--- a/docs/zh-cn/Plugin.md
+++ b/docs/zh-cn/Plugin.md
@@ -289,6 +289,39 @@ dayjs('06/27/2018').week() // 26
 dayjs('2018-06-27').week(5) // 设置周
 ```
 
+### weekOfMonth
+
+- weekOfMonth 增加了 `.weekOfMonth()` API 返回一个 `number` 来表示 `Dayjs` 的日期是当前月中的第几周，其中返回值为 `0` 则代表是上个月最后一周。
+
+```javascript
+import weekOfMonth from 'dayjs/plugin/weekOfMonth'
+
+// 默认每周第一天为星期日
+dayjs.extend(weekOfMonth)
+dayjs('2019-11-02').weekOfMonth() // 0
+dayjs('2019-11-03').weekOfMonth() // 1
+dayjs('2019-11-23').weekOfMonth() // 3
+dayjs('2019-11-24').weekOfMonth() // 4
+
+// or 设置 offset 来将每周第一天定义为星期一
+dayjs.extend(weekOfMonth, { offset: 1 })
+dayjs('2019-11-03').weekOfMonth() // 0
+dayjs('2019-11-04').weekOfMonth() // 1
+dayjs('2019-11-24').weekOfMonth() // 3
+dayjs('2019-11-25').weekOfMonth() // 4
+```
+
+- weekOfMonth 增加了 `.weekMapOfMonth()` API 返回一个对象，key 为当前月的第几周，value 为这一周内包含的 date，其中 key 为 `0` 则代表是上个月最后一周。
+
+```javascript
+dayjs().weekMapOfMonth()
+// {
+//   0: [...],
+//   1: [...].
+//   ...
+// }
+```
+
 ### WeekDay
 
 - WeekDay 增加了 `.weekday()` API 来获取或设置当前语言的星期。

--- a/src/plugin/weekOfMonth/index.js
+++ b/src/plugin/weekOfMonth/index.js
@@ -1,0 +1,46 @@
+export default (o, c) => {
+  // 获取每周第一天的判定标准偏移量 offset
+  // 默认为 0 即星期日为每周第一天，否则如 1 即星期一为每周第一天，以此类推
+  const isOffsetNumber = () => o && o.offset && typeof o.offset === 'number'
+  const isOffsetValid = () => o.offset > 0 && o.offset < 7
+  const offset = isOffsetNumber() && isOffsetValid() ? o.offset : 0
+
+  const proto = c.prototype
+
+  // 获取当前 dayjs 对象在当前月中的第几周
+  proto.weekOfMonth = function () {
+    // 根据 offset 计算实际偏移量 actualOffset
+    const firstDay = this.date(1).day()
+    const actualOffset = (firstDay === 0 ? firstDay : 7 - firstDay) + offset
+
+    // 根据实际偏移量 actualOffset 计算属于第几周
+    function getWeek(date, week = 0) {
+      if (date - actualOffset <= 0) {
+        return week
+      }
+
+      return getWeek(date - 7, week + 1)
+    }
+
+    return getWeek(this.date())
+  }
+
+  // 获取当前月的星期分布
+  proto.weekMapOfMonth = function () {
+    const dateList = Array.from({ length: this.daysInMonth() }, (_, index) => index + 1)
+
+    const weekMap = dateList.reduce((res, date) => {
+      const weekKey = this.date(date).weekOfMonth()
+
+      if (!res[weekKey]) {
+        res[weekKey] = []
+      }
+
+      res[weekKey].push(date)
+
+      return res
+    }, {})
+
+    return weekMap
+  }
+}

--- a/types/plugin/weekOfMonth.d.ts
+++ b/types/plugin/weekOfMonth.d.ts
@@ -1,0 +1,12 @@
+import { PluginFunc } from 'dayjs'
+
+declare const plugin: PluginFunc
+export = plugin
+
+declare module 'dayjs' {
+  interface Dayjs {
+    weekOfMonth(): number
+
+    weekMapOfMonth(): { [key: string]: number[] }
+  }
+}


### PR DESCRIPTION
- weekOfMonth 增加了 `.weekOfMonth()` API 返回一个 `number` 来表示 `Dayjs` 的日期是当前月中的第几周，其中返回值为 `0` 则代表是上个月最后一周。

```javascript
import weekOfMonth from 'dayjs/plugin/weekOfMonth'

// 默认每周第一天为星期日
dayjs.extend(weekOfMonth)
dayjs('2019-11-02').weekOfMonth() // 0
dayjs('2019-11-03').weekOfMonth() // 1
dayjs('2019-11-23').weekOfMonth() // 3
dayjs('2019-11-24').weekOfMonth() // 4

// or 设置 offset 来将每周第一天定义为星期一
dayjs.extend(weekOfMonth, { offset: 1 })
dayjs('2019-11-03').weekOfMonth() // 0
dayjs('2019-11-04').weekOfMonth() // 1
dayjs('2019-11-24').weekOfMonth() // 3
dayjs('2019-11-25').weekOfMonth() // 4
```

- weekOfMonth 增加了 `.weekMapOfMonth()` API 返回一个对象，key 为当前月的第几周，value 为这一周内包含的 date，其中 key 为 `0` 则代表是上个月最后一周。

```javascript
dayjs().weekMapOfMonth()
// {
//   0: [...],
//   1: [...].
//   ...
// }
```