### PR TITLE
add unit value: date support for `.add()` & `.diff()` function and perfect reference

### DIFF
--- a/docs/en/API-reference.md
+++ b/docs/en/API-reference.md
@@ -208,6 +208,7 @@ dayjs().get('day')
 | `minute`      | `m`       | Minute                                   |
 | `second`      | `s`       | Second                                   |
 | `millisecond` | `ms`      | Millisecond                              |
+| `quarter`     | `Q`       | Quarter (Only support in `.diff()`)      |
 
 ### Set `.set(unit: string, value: number)`
 

--- a/src/index.js
+++ b/src/index.js
@@ -256,7 +256,7 @@ class Dayjs {
     if (unit === C.Y) {
       return this.set(C.Y, this.$y + number)
     }
-    if (unit === C.D) {
+    if (unit === C.D || unit === C.DATE) {
       return instanceFactorySet(1)
     }
     if (unit === C.W) {
@@ -347,6 +347,7 @@ class Dayjs {
       [C.Q]: result / 3,
       [C.W]: (diff - zoneDelta) / C.MILLISECONDS_A_WEEK,
       [C.D]: (diff - zoneDelta) / C.MILLISECONDS_A_DAY,
+      [C.DATE]: (diff - zoneDelta) / C.MILLISECONDS_A_DAY,
       [C.H]: diff / C.MILLISECONDS_A_HOUR,
       [C.MIN]: diff / C.MILLISECONDS_A_MINUTE,
       [C.S]: diff / C.MILLISECONDS_A_SECOND

--- a/test/plugin/badMutable.test.js
+++ b/test/plugin/badMutable.test.js
@@ -123,7 +123,7 @@ describe('Add', () => {
     m.add(1, 'day')
     expect(d.format()).toBe(m.format())
     d.add(1, 'date')
-    m.add(1, 'date')
+    m.add(1, 'day')
     expect(d.format()).toBe(m.format())
     d.add(1, 'hour')
     m.add(1, 'hour')


### PR DESCRIPTION
fix: Add unit quarter explain to API reference
fix: Add unit date for `.add()` & `.diff()` function