### PR TITLE
Add Bislama Locale

### DIFF
--- a/src/locale/bi.js
+++ b/src/locale/bi.js
@@ -1,0 +1,39 @@
+import dayjs from 'dayjs'
+
+const locale = {
+  name: 'bi',
+  weekdays: 'Sande_Mande_Tusde_Wenesde_Tosde_Fraede_Sarade'.split('_'),
+  months: 'Januari_Februari_Maj_Eprel_Mei_Jun_Julae_Okis_Septemba_Oktoba_Novemba_Disemba'.split('_'),
+  weekStart: 1,
+  weekdaysShort: 'San_Man_Tus_Wen_Tos_Frae_Sar'.split('_'),
+  monthsShort: 'Jan_Feb_Maj_Epr_Mai_Jun_Jul_Oki_Sep_Okt_Nov_Dis'.split('_'),
+  weekdaysMin: 'San_Ma_Tu_We_To_Fr_Sar'.split('_'),
+  ordinal: n => n,
+  formats: {
+    LT: 'h:mm A',
+    LTS: 'h:mm:ss A',
+    L: 'DD/MM/YYYY',
+    LL: 'D MMMM YYYY',
+    LLL: 'D MMMM YYYY h:mm A',
+    LLLL: 'dddd, D MMMM YYYY h:mm A'
+  },
+  relativeTime: {
+    future: 'lo %s',
+    past: '%s bifo',
+    s: 'sam seken',
+    m: 'wan minit',
+    mm: '%d minit',
+    h: 'wan haoa',
+    hh: '%d haoa',
+    d: 'wan dei',
+    dd: '%d dei',
+    M: 'wan manis',
+    MM: '%d manis',
+    y: 'wan yia',
+    yy: '%d yia'
+  }
+}
+
+dayjs.locale(locale, null, true)
+
+export default locale


### PR DESCRIPTION
Bislama is the national language of Vanuatu. 

Perhaps there may be a rule about `weekdaysMin` being 2 characters but I needed 3 characters for Sunday/Saturday. Same for my choice of using a 4 character `weekdaysShort` for Friday. The `ae` in `Fraede` is a diphthong and would be wrong I believe if the vowels are not kept together.