### PR TITLE
fix: Relative times in Finnish locale

### DIFF
--- a/src/locale/fi.js
+++ b/src/locale/fi.js
@@ -1,6 +1,36 @@
 // Finnish [fi]
 import dayjs from 'dayjs'
 
+function relativeTimeFormatter(number, withoutSuffix, key, isFuture) {
+  const past = {
+    s: 'muutama sekunti',
+    m: 'minuutti',
+    mm: '%d minuuttia',
+    h: 'tunti',
+    hh: '%d tuntia',
+    d: 'päivä',
+    dd: '%d päivää',
+    M: 'kuukausi',
+    MM: '%d kuukautta',
+    y: 'vuosi',
+    yy: '%d vuotta'
+  }
+  const future = {
+    s: 'muutaman sekunnin',
+    m: 'minuutin',
+    mm: '%d minuutin',
+    h: 'tunnin',
+    hh: '%d tunnin',
+    d: 'päivän',
+    dd: '%d päivän',
+    M: 'kuukauden',
+    MM: '%d kuukauden',
+    y: 'vuoden',
+    yy: '%d vuoden'
+  }
+  return ((isFuture && !withoutSuffix) ? future : past)[key].replace('%d', number)
+}
+
 const locale = {
   name: 'fi', // Finnish
   weekdays: 'sunnuntai_maanantai_tiistai_keskiviikko_torstai_perjantai_lauantai'.split('_'), // Note weekdays are not capitalized in Finnish
@@ -10,29 +40,20 @@ const locale = {
   monthsShort: 'tammi_helmi_maalis_huhti_touko_kesä_heinä_elo_syys_loka_marras_joulu'.split('_'),
   ordinal: n => `${n}.`,
   weekStart: 1,
-  /*
-   * This relativeTime is currently configured for having proper past
-   * tense forms since Finnish needs a separate version for future tense
-   * and I think past tense is a more common use case for this kind of
-   * library.
-   *
-   * Doing this properly requires this issue to be fixed:
-   * https://github.com/iamkun/dayjs/issues/302
-   */
   relativeTime: {
     future: '%s kuluttua',
     past: '%s sitten',
-    s: 'muutama sekunti', // for past tense
-    m: 'minuutti', // for past tense
-    mm: '%d minuuttia', // for past tense
-    h: 'tunti', // for past tense
-    hh: '%d tuntia', // for past tense
-    d: 'päivä', // for past tense
-    dd: '%d päivää', // for past tense
-    M: 'kuukausi', // for past tense
-    MM: '%d kuukautta', // for past tense
-    y: 'vuosi', // for past tense
-    yy: '%d vuotta' // for past tense
+    s: relativeTimeFormatter,
+    m: relativeTimeFormatter,
+    mm: relativeTimeFormatter,
+    h: relativeTimeFormatter,
+    hh: relativeTimeFormatter,
+    d: relativeTimeFormatter,
+    dd: relativeTimeFormatter,
+    M: relativeTimeFormatter,
+    MM: relativeTimeFormatter,
+    y: relativeTimeFormatter,
+    yy: relativeTimeFormatter
   },
   formats: {
     LT: 'HH.mm',

--- a/src/locale/fi.js
+++ b/src/locale/fi.js
@@ -13,7 +13,8 @@ function relativeTimeFormatter(number, withoutSuffix, key, isFuture) {
     M: 'kuukausi',
     MM: '%d kuukautta',
     y: 'vuosi',
-    yy: '%d vuotta'
+    yy: '%d vuotta',
+    numbers: 'nolla_yksi_kaksi_kolme_neljä_viisi_kuusi_seitsemän_kahdeksan_yhdeksän'.split('_')
   }
   const future = {
     s: 'muutaman sekunnin',
@@ -26,9 +27,15 @@ function relativeTimeFormatter(number, withoutSuffix, key, isFuture) {
     M: 'kuukauden',
     MM: '%d kuukauden',
     y: 'vuoden',
-    yy: '%d vuoden'
+    yy: '%d vuoden',
+    numbers: 'nollan_yhden_kahden_kolmen_neljän_viiden_kuuden_seitsemän_kahdeksan_yhdeksän'.split('_')
   }
-  return ((isFuture && !withoutSuffix) ? future : past)[key].replace('%d', number)
+  const words = (isFuture && !withoutSuffix) ? future : past
+  const result = words[key]
+  if (number < 10) {
+    return result.replace('%d', words.numbers[number])
+  }
+  return result.replace('%d', number)
 }
 
 const locale = {
@@ -41,7 +48,7 @@ const locale = {
   ordinal: n => `${n}.`,
   weekStart: 1,
   relativeTime: {
-    future: '%s kuluttua',
+    future: '%s päästä',
     past: '%s sitten',
     s: relativeTimeFormatter,
     m: relativeTimeFormatter,

--- a/test/locale/fi.test.js
+++ b/test/locale/fi.test.js
@@ -1,4 +1,5 @@
 import MockDate from 'mockdate'
+import moment from 'moment'
 import dayjs from '../../src'
 import relativeTime from '../../src/plugin/relativeTime'
 import '../../src/locale/fi'
@@ -14,14 +15,30 @@ afterEach(() => {
 })
 
 it('Finnish locale relative time in past and future', () => {
-  expect(dayjs().add(1, 'd').locale('fi').fromNow())
-    .toBe('päivän kuluttua')
-  expect(dayjs().add(2, 'd').locale('fi').fromNow())
-    .toBe('2 päivän kuluttua')
-  expect(dayjs().add(2, 'd').locale('fi').fromNow(true))
-    .toBe('2 päivää')
-  expect(dayjs().add(-1, 'd').locale('fi').fromNow())
-    .toBe('päivä sitten')
-  expect(dayjs().add(-2, 'd').locale('fi').fromNow())
-    .toBe('2 päivää sitten')
+  const cases = [
+    [1, 'd', 'päivän päästä'],
+    [-1, 'd', 'päivä sitten'],
+    [2, 'd', 'kahden päivän päästä'],
+    [-2, 'd', 'kaksi päivää sitten'],
+    [10, 'd', '10 päivän päästä'],
+    [-10, 'd', '10 päivää sitten'],
+    [6, 'm', 'kuuden minuutin päästä'],
+    [-6, 'm', 'kuusi minuuttia sitten'],
+    [5, 'h', 'viiden tunnin päästä'],
+    [-5, 'h', 'viisi tuntia sitten'],
+    [3, 'M', 'kolmen kuukauden päästä'],
+    [-3, 'M', 'kolme kuukautta sitten'],
+    [4, 'y', 'neljän vuoden päästä'],
+    [-4, 'y', 'neljä vuotta sitten']
+  ]
+  cases.forEach((c) => {
+    expect(dayjs().add(c[0], c[1]).locale('fi').fromNow())
+      .toBe(c[2])
+    expect(dayjs().add(c[0], c[1]).locale('fi').fromNow())
+      .toBe(moment().add(c[0], c[1]).locale('fi').fromNow())
+  })
+  expect(dayjs().add(-10, 'd').locale('fi').fromNow(true))
+    .toBe('10 päivää')
+  expect(dayjs().add(-10, 'd').locale('fi').fromNow(true))
+    .toBe(moment().add(-10, 'd').locale('fi').fromNow(true))
 })

--- a/test/locale/fi.test.js
+++ b/test/locale/fi.test.js
@@ -1,0 +1,27 @@
+import MockDate from 'mockdate'
+import dayjs from '../../src'
+import relativeTime from '../../src/plugin/relativeTime'
+import '../../src/locale/fi'
+
+dayjs.extend(relativeTime)
+
+beforeEach(() => {
+  MockDate.set(new Date())
+})
+
+afterEach(() => {
+  MockDate.reset()
+})
+
+it('Finnish locale relative time in past and future', () => {
+  expect(dayjs().add(1, 'd').locale('fi').fromNow())
+    .toBe('päivän kuluttua')
+  expect(dayjs().add(2, 'd').locale('fi').fromNow())
+    .toBe('2 päivän kuluttua')
+  expect(dayjs().add(2, 'd').locale('fi').fromNow(true))
+    .toBe('2 päivää')
+  expect(dayjs().add(-1, 'd').locale('fi').fromNow())
+    .toBe('päivä sitten')
+  expect(dayjs().add(-2, 'd').locale('fi').fromNow())
+    .toBe('2 päivää sitten')
+})


### PR DESCRIPTION
This fixes problems in Finnish translation (#351) which are now possible to solve after merging #767. Also, the output is now the same as in Moment.js.