### PR TITLE
add zh locale

### DIFF
--- a/src/locale/zh.js
+++ b/src/locale/zh.js
@@ -1,0 +1,71 @@
+// Chinese (China) [zh]
+import dayjs from 'dayjs'
+
+const locale = {
+  name: 'zh',
+  weekdays: '星期日_星期一_星期二_星期三_星期四_星期五_星期六'.split('_'),
+  weekdaysShort: '周日_周一_周二_周三_周四_周五_周六'.split('_'),
+  weekdaysMin: '日_一_二_三_四_五_六'.split('_'),
+  // prettier conflicts with eslint, so
+  // prettier-ignore
+  months: '一月_二月_三月_四月_五月_六月_七月_八月_九月_十月_十一月_十二月'.split('_'),
+  monthsShort: '1月_2月_3月_4月_5月_6月_7月_8月_9月_10月_11月_12月'.split('_'),
+  ordinal: (number, period) => {
+    switch (period) {
+      case 'W':
+        return `第${number}周`
+      default:
+        return `${number}日`
+    }
+  },
+  weekStart: 1,
+  yearStart: 4,
+  formats: {
+    LT: 'HH:mm',
+    LTS: 'HH:mm:ss',
+    L: 'YYYY/MM/DD',
+    LL: 'YYYY年M月D日',
+    LLL: 'YYYY年M月D日Ah点mm分',
+    LLLL: 'YYYY年M月D日ddddAh点mm分',
+    l: 'YYYY/M/D',
+    ll: 'YYYY年M月D日',
+    lll: 'YYYY年M月D日 HH:mm',
+    llll: 'YYYY年M月D日dddd HH:mm'
+  },
+  relativeTime: {
+    future: '%s后',
+    past: '%s前',
+    s: '几秒',
+    m: '1分钟',
+    mm: '%d分钟',
+    h: '1小时',
+    hh: '%d小时',
+    d: '1天',
+    dd: '%d天',
+    M: '1个月',
+    MM: '%d个月',
+    y: '1年',
+    yy: '%d年'
+  },
+  meridiem: (hour, minute) => {
+    // prettier conflicts with eslint, so
+    // prettier-ignore
+    const hm = (hour * 100) + minute
+    if (hm < 600) {
+      return '凌晨'
+    } else if (hm < 900) {
+      return '早上'
+    } else if (hm < 1130) {
+      return '上午'
+    } else if (hm < 1230) {
+      return '中午'
+    } else if (hm < 1800) {
+      return '下午'
+    }
+    return '晚上'
+  }
+}
+
+dayjs.locale(locale, null, true)
+
+export default locale

--- a/src/locale/zh.js
+++ b/src/locale/zh.js
@@ -1,4 +1,4 @@
-// Chinese (China) [zh]
+// Chinese [zh]
 import dayjs from 'dayjs'
 
 const locale = {

--- a/test/locale/zh.test.js
+++ b/test/locale/zh.test.js
@@ -1,33 +1,20 @@
-import moment from 'moment'
-import MockDate from 'mockdate'
 import dayjs from '../../src'
 import advancedFormat from '../../src/plugin/advancedFormat'
 import weekOfYear from '../../src/plugin/weekOfYear'
-
 import '../../src/locale/zh.js'
+import '../../src/locale/zh-cn.js'
 
 dayjs.extend(advancedFormat).extend(weekOfYear)
 
-beforeEach(() => {
-  MockDate.set(new Date())
-})
-
-afterEach(() => {
-  MockDate.reset()
-})
-
-const dayjsObj = dayjs().locale('zh')
-
-test('Meridiem', () => {
-  const momentObj = moment().locale('zh-cn')
-  for (let i = 0; i <= 24; i += 1) {
-    // prettier conflicts with eslint, so
-    // prettier-ignore
-    expect(dayjsObj.add(i, 'hour').format('A'))
-      .toEqual(momentObj.clone().add(i, 'hour').format('A'))
-  }
-})
+const zh = dayjs().locale('zh')
+const zhCN = dayjs().locale('zh-cn')
 
 test('ordinal', () => {
-  expect(dayjsObj.format('wo')).toEqual(`第${dayjsObj.format('w')}周`)
+  expect(zh.format('wo')).toEqual(`第${zh.format('w')}周`)
+})
+
+test('Meridiem', () => {
+  for (let i = 0; i <= 24; i += 1) {
+    expect(zh.add(i, 'hour').format('A')).toBe(zhCN.add(i, 'hour').format('A'))
+  }
 })

--- a/test/locale/zh.test.js
+++ b/test/locale/zh.test.js
@@ -1,0 +1,33 @@
+import moment from 'moment'
+import MockDate from 'mockdate'
+import dayjs from '../../src'
+import advancedFormat from '../../src/plugin/advancedFormat'
+import weekOfYear from '../../src/plugin/weekOfYear'
+
+import '../../src/locale/zh.js'
+
+dayjs.extend(advancedFormat).extend(weekOfYear)
+
+beforeEach(() => {
+  MockDate.set(new Date())
+})
+
+afterEach(() => {
+  MockDate.reset()
+})
+
+const dayjsObj = dayjs().locale('zh')
+
+test('Meridiem', () => {
+  const momentObj = moment().locale('zh-cn')
+  for (let i = 0; i <= 24; i += 1) {
+    // prettier conflicts with eslint, so
+    // prettier-ignore
+    expect(dayjsObj.add(i, 'hour').format('A'))
+      .toEqual(momentObj.clone().add(i, 'hour').format('A'))
+  }
+})
+
+test('ordinal', () => {
+  expect(dayjsObj.format('wo')).toEqual(`第${dayjsObj.format('w')}周`)
+})


### PR DESCRIPTION
In `window.navigator.languages` in Chrome, there are 4 valid Chinese locales that could appear: `zh`, `zh-cn`, `zh-cn`, `zh-hk`. Currently `zh` is missing from dayjs. This PR adds the `zh` locale.

`zh` has some minor improvements over the other 3 locales. For developers, this won't affect your existing code, but if you start using `zh`, your output will be slightly more correct in some occasional cases.

For example:

```js
// no more unecessary whitespace:
dayjs().locale('zh-cn').subtract(7, 'month').fromNow() // 7 个月前
dayjs().locale('zh').subtract(7, 'month').fromNow() // 7个月前

// use "后" instead of "内" for relative future:
dayjs().locale('zh-cn').add(3, 'day').fromNow() // 3 天内
dayjs().locale('zh').add(3, 'day').fromNow() // 3天后

// improve ordinal week of year:
dayjs('2020-10-13').locale('zh-tw').format('wo') // 42日 // wrong
dayjs('2020-10-13').locale('zh-hk').format('wo') // 42日 // wrong
dayjs('2020-10-13').locale('zh-cn').format('wo') // 42周 // ok
dayjs('2020-10-13').locale('zh').format('wo') // 第42周 // better
```
issue #820