### PR TITLE
[locale] Breton [br]: Fix lack of meridiem

### DIFF
--- a/src/locale/br.js
+++ b/src/locale/br.js
@@ -18,7 +18,7 @@ const locale = {
     LLL: 'D [a viz] MMMM YYYY h[e]mm A',
     LLLL: 'dddd, D [a viz] MMMM YYYY h[e]mm A'
   },
-  meridiem: hour => (hour < 12 ? 'a.m.' : 'g.m.'), // a-raok merenn | goude merenn
+  meridiem: hour => (hour < 12 ? 'a.m.' : 'g.m.') // a-raok merenn | goude merenn
 }
 
 dayjs.locale(locale, null, true)

--- a/src/locale/br.js
+++ b/src/locale/br.js
@@ -3,11 +3,11 @@ import dayjs from 'dayjs'
 
 const locale = {
   name: 'br',
-  weekdays: "Sul_Lun_Meurzh_Merc'her_Yaou_Gwener_Sadorn".split('_'),
-  months: "Genver_C'hwevrer_Meurzh_Ebrel_Mae_Mezheven_Gouere_Eost_Gwengolo_Here_Du_Kerzu".split('_'),
+  weekdays: 'Sul_Lun_Meurzh_Mercʼher_Yaou_Gwener_Sadorn'.split('_'),
+  months: 'Genver_Cʼhwevrer_Meurzh_Ebrel_Mae_Mezheven_Gouere_Eost_Gwengolo_Here_Du_Kerzu'.split('_'),
   weekStart: 1,
   weekdaysShort: 'Sul_Lun_Meu_Mer_Yao_Gwe_Sad'.split('_'),
-  monthsShort: "Gen_C'hwe_Meu_Ebr_Mae_Eve_Gou_Eos_Gwe_Her_Du_Ker".split('_'),
+  monthsShort: 'Gen_Cʼhwe_Meu_Ebr_Mae_Eve_Gou_Eos_Gwe_Her_Du_Ker'.split('_'),
   weekdaysMin: 'Su_Lu_Me_Mer_Ya_Gw_Sa'.split('_'),
   ordinal: n => n,
   formats: {
@@ -24,4 +24,3 @@ const locale = {
 dayjs.locale(locale, null, true)
 
 export default locale
-

--- a/src/locale/br.js
+++ b/src/locale/br.js
@@ -17,7 +17,8 @@ const locale = {
     LL: 'D [a viz] MMMM YYYY',
     LLL: 'D [a viz] MMMM YYYY h[e]mm A',
     LLLL: 'dddd, D [a viz] MMMM YYYY h[e]mm A'
-  }
+  },
+  meridiem: hour => (hour < 12 ? 'a.m.' : 'g.m.'), // a-raok merenn | goude merenn
 }
 
 dayjs.locale(locale, null, true)


### PR DESCRIPTION
eur e brezhoneg Lizherennañ

Mat eo g.m. evit PM (goude merenn) ha a.m. evit AM (a-raok merenn).

--
Should be g.m. for PM, stand for goude merenn and a.m. for AM stand for a-raok Merenn

Here some sources :
http://www.brezhoneg.bzh/177-divizou-hag-erbedadennou-ar-chuzul-skiantel.htm
https://www.unicode.org/cldr/charts/latest/summary/br.html