### PR TITLE
fixed incorrect definition of locale in typescript

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -100,7 +100,7 @@ declare namespace dayjs {
 
   export function extend<T = unknown>(plugin: PluginFunc<T>, option?: T): Dayjs
 
-  export function locale(preset: string | ILocale, object?: Partial<ILocale>, isLocal?: boolean): string
+  export function locale(preset?: string | ILocale, object?: Partial<ILocale>, isLocal?: boolean): string
 
   export function isDayjs(d: any): d is Dayjs
 


### PR DESCRIPTION
the first parameter of locale is optional so that locale() can be called with no arguments to return the current locale.
I would have added a test case to prove this works, but everything is in javascript and I expect you would not appreciate adding typescript to the unit tests.

This fixes #870 