### PR TITLE
fix: Fix CustomParseFormat plugin of parsing only YYYY / YYYY-MM bug

### DIFF
--- a/src/plugin/customParseFormat/index.js
+++ b/src/plugin/customParseFormat/index.js
@@ -151,21 +151,20 @@ const parseFormattedInput = (input, format, utc) => {
     const {
       year, month, day, hours, minutes, seconds, milliseconds, zone
     } = parser(input)
-    if (zone) {
-      return new Date(Date.UTC(
-        year, month - 1, day,
-        hours || 0,
-        minutes || 0, seconds || 0, milliseconds || 0
-      ) + (zone.offset * 60 * 1000))
-    }
     const now = new Date()
     const d = day || ((!year && !month) ? now.getDate() : 1)
     const y = year || now.getFullYear()
-    const M = month > 0 ? month - 1 : now.getMonth()
+    let M = 0
+    if (!(year && !month)) {
+      M = month > 0 ? month - 1 : now.getMonth()
+    }
     const h = hours || 0
     const m = minutes || 0
     const s = seconds || 0
     const ms = milliseconds || 0
+    if (zone) {
+      return new Date(Date.UTC(y, M, d, h, m, s, ms + (zone.offset * 60 * 1000)))
+    }
     if (utc) {
       return new Date(Date.UTC(y, M, d, h, m, s, ms))
     }

--- a/test/plugin/customParseFormat.test.js
+++ b/test/plugin/customParseFormat.test.js
@@ -98,6 +98,25 @@ it('parse HH:mm:ss but only one digit', () => {
   expect(dayjs(input, format).valueOf()).toBe(moment(input, format).valueOf())
 })
 
+describe('parse YYYY / YYYY-MM only', () => {
+  it('YYYY', () => {
+    const input = '2001 +08:00'
+    const format = 'YYYY Z'
+    expect(dayjs(input, format).valueOf()).toBe(moment(input, format).valueOf())
+    const input2 = '2001'
+    const format2 = 'YYYY'
+    expect(dayjs(input2, format2).valueOf()).toBe(moment(input2, format2).valueOf())
+  })
+  it('YYYY-MM', () => {
+    const input = '2001-01 +08:00'
+    const format = 'YYYY-MM Z'
+    expect(dayjs(input, format).valueOf()).toBe(moment(input, format).valueOf())
+    const input2 = '2001-01'
+    const format2 = 'YYYY-MM'
+    expect(dayjs(input2, format2).valueOf()).toBe(moment(input2, format2).valueOf())
+  })
+})
+
 it('parse hh:mm:ss but only one digit', () => {
   const input = '0:0:1'
   const format = 'hh:mm:ss'


### PR DESCRIPTION
fix #849