### PR TITLE
Fix: Update RelativeTime plugin default config

### DIFF
--- a/src/plugin/relativeTime/index.js
+++ b/src/plugin/relativeTime/index.js
@@ -19,7 +19,7 @@ export default (o, c, d) => {
     yy: '%d years'
   }
   const fromTo = (input, withoutSuffix, instance, isFrom) => {
-    const loc = instance.$locale().relativeTime
+    const loc = instance.$locale().relativeTime || d.en.relativeTime
     const T = o.thresholds || [
       { l: 's', r: 44, d: C.S },
       { l: 'm', r: 89 },

--- a/src/plugin/relativeTime/index.js
+++ b/src/plugin/relativeTime/index.js
@@ -3,7 +3,7 @@ import * as C from '../../constant'
 export default (o, c, d) => {
   o = o || {}
   const proto = c.prototype
-  d.en.relativeTime = {
+  const relObj = {
     future: 'in %s',
     past: '%s ago',
     s: 'a few seconds',
@@ -18,8 +18,9 @@ export default (o, c, d) => {
     y: 'a year',
     yy: '%d years'
   }
+  d.en.relativeTime = relObj
   const fromTo = (input, withoutSuffix, instance, isFrom) => {
-    const loc = instance.$locale().relativeTime || d.en.relativeTime
+    const loc = instance.$locale().relativeTime || relObj
     const T = o.thresholds || [
       { l: 's', r: 44, d: C.S },
       { l: 'm', r: 89 },


### PR DESCRIPTION
if require('dayjs/locale/en')
instance.$locale().relativeTime is undefined

Loc in fromTo is undefined
The loc[t.l] throws an error: Cannot read property 'xx' of undefined