### PR TITLE
fix: Update CustomParseFormat plugin to support Array formats

### DIFF
--- a/src/plugin/customParseFormat/index.js
+++ b/src/plugin/customParseFormat/index.js
@@ -196,11 +196,26 @@ export default (o, C, d) => {
         locale = pl ? d.Ls[pl] : this.$locale()
       }
       this.$d = parseFormattedInput(date, format, utc)
-      this.init(cfg)
+      this.init()
+      if (pl && pl !== true) this.$L = this.locale(pl).$L
       if (isStrict && date !== this.format(format)) {
         this.$d = new Date('')
       }
-      if (pl && pl !== true) this.$L = this.locale(pl).$L
+    } else if (format instanceof Array) {
+      const len = format.length
+      for (let i = 1; i <= len; i += 1) {
+        const arg = Array.prototype.slice.call(args, 0)
+        arg[1] = format[i - 1]
+        const result = d.apply(this, arg)
+        if (result.isValid()) {
+          this.$d = result.$d
+          this.$L = result.$L
+          this.init()
+          break
+        } else if (i === len) {
+          this.$d = new Date('')
+        }
+      }
     } else {
       oldParse.call(this, cfg)
     }

--- a/src/plugin/customParseFormat/index.js
+++ b/src/plugin/customParseFormat/index.js
@@ -204,17 +204,15 @@ export default (o, C, d) => {
     } else if (format instanceof Array) {
       const len = format.length
       for (let i = 1; i <= len; i += 1) {
-        const arg = Array.prototype.slice.call(args, 0)
-        arg[1] = format[i - 1]
-        const result = d.apply(this, arg)
+        args[1] = format[i - 1]
+        const result = d.apply(this, args)
         if (result.isValid()) {
           this.$d = result.$d
           this.$L = result.$L
           this.init()
           break
-        } else if (i === len) {
-          this.$d = new Date('')
         }
+        if (i === len) this.$d = new Date('')
       }
     } else {
       oldParse.call(this, cfg)

--- a/test/plugin/customParseFormat.test.js
+++ b/test/plugin/customParseFormat.test.js
@@ -248,3 +248,22 @@ describe('Strict mode', () => {
     expect(dayjs(input, format, 'zh-cn', true).isValid()).toBe(false)
   })
 })
+
+describe('Array format support', () => {
+  it('second ok', () => {
+    const input = '2012-05-28'
+    const format = ['YYYY', 'YYYY-MM-DD']
+    expect(dayjs(input, format).isValid()).toBe(true)
+    expect(dayjs(input, format, true).format('YYYY-MM-DD')).toBe('2012-05-28')
+  })
+  it('all invalid', () => {
+    const input = '2012-05-28'
+    const format = ['DD', 'MM-DD']
+    expect(dayjs(input, format, true).isValid()).toBe(false)
+  })
+  it('with locale', () => {
+    const input = '2018 三月 12'
+    const format = ['YYYY', 'MM', 'YYYY MMMM DD']
+    expect(dayjs(input, format, 'zh-cn', true).format('YYYY MMMM DD')).toBe(input)
+  })
+})


### PR DESCRIPTION
Add formats Array support `dayjs('2020-02-02', ['YYYY', 'YYYY-DD-MM'])`

#817