### PR TITLE
[Need Review] fix: Fix typescript type reference error

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,4 +1,4 @@
-/// <reference path="./locale/index.d.ts" />
+import { ILocale } from './locale/types'
 
 export = dayjs;
 declare function dayjs (date?: dayjs.ConfigType, option?: dayjs.OptionType, locale?: string): dayjs.Dayjs

--- a/types/locale/index.d.ts
+++ b/types/locale/index.d.ts
@@ -1,4 +1,4 @@
-/// <reference path="./types.d.ts" />
+import { ILocale } from './types'
 
 declare module 'dayjs/locale/*' {
   namespace locale {

--- a/types/locale/types.d.ts
+++ b/types/locale/types.d.ts
@@ -1,4 +1,4 @@
-declare interface ILocale {
+export declare interface ILocale {
   name: string
   weekdays?: string[]
   months?: string[]


### PR DESCRIPTION
#792

Tring to fix typescript type error in #792

> /// \<reference path="./locale/index.d.ts" />

It may be caused by `webpack` treats `Triple-Slash Directives` as an imported resource.

I don't know much about typescript, and not sure if this is the correct way to fix it.

A code review is welcomed.
