### PR TITLE
fix: Duration plugin supports parse ISO string with week (W)

### DIFF
--- a/src/plugin/duration/index.js
+++ b/src/plugin/duration/index.js
@@ -48,7 +48,7 @@ class Duration {
       const d = input.match(durationRegex)
       if (d) {
         [,,
-          this.$d.years, this.$d.months,,
+          this.$d.years, this.$d.months, this.$d.weeks,
           this.$d.days, this.$d.hours, this.$d.minutes, this.$d.seconds] = d
         this.calMilliseconds()
         return this
@@ -83,7 +83,7 @@ class Duration {
   toISOString() {
     const Y = this.$d.years ? `${this.$d.years}Y` : ''
     const M = this.$d.months ? `${this.$d.months}M` : ''
-    let days = this.$d.days || 0
+    let days = +this.$d.days || 0
     if (this.$d.weeks) {
       days += this.$d.weeks * 7
     }

--- a/test/plugin/duration.test.js
+++ b/test/plugin/duration.test.js
@@ -62,6 +62,12 @@ describe('Parse ISO string', () => {
   it('Part ISO string', () => {
     expect(dayjs.duration('PT2777H46M40S').toISOString()).toBe('PT2777H46M40S')
   })
+  it('ISO string with week', () => {
+    const d = dayjs.duration('P2M3W4D')
+    expect(d.toISOString()).toBe('P2M25D')
+    expect(d.asDays()).toBe(85) // moment 85, count 2M as 61 days
+    expect(d.asWeeks()).toBe(12.142857142857142) // moment 12.285714285714286
+  })
   it('Invalid ISO string', () => {
     expect(dayjs.duration('Invalid').toISOString()).toBe('P0D')
   })


### PR DESCRIPTION
fix #949