### PR TITLE
Adding localization for Haitian Creole and Spanish (Puerto Rico)

### DIFF
--- a/src/locale/es-pr.js
+++ b/src/locale/es-pr.js
@@ -1,0 +1,41 @@
+// Spanish (Puerto Rico) [es-PR]
+import dayjs from 'dayjs'
+
+const locale = {
+  name: 'es-pr',
+  monthsShort: 'ene_feb_mar_abr_may_jun_jul_ago_sep_oct_nov_dic'.split('_'),
+  weekdays: 'domingo_lunes_martes_miércoles_jueves_viernes_sábado'.split('_'),
+  weekdaysShort: 'dom._lun._mar._mié._jue._vie._sáb.'.split('_'),
+  weekdaysMin: 'do_lu_ma_mi_ju_vi_sá'.split('_'),
+  months: 'Enero_Febrero_Marzo_Abril_Mayo_Junio_Julio_Agosto_Septiembre_Octubre_Noviembre_Diciembre'.split('_'),
+  weekStart: 1,
+  formats: {
+    LT: 'h:mm A',
+    LTS: 'h:mm:ss A',
+    L: 'MM/DD/YYYY',
+    LL: 'D [de] MMMM [de] YYYY',
+    LLL: 'D [de] MMMM [de] YYYY h:mm A',
+    LLLL: 'dddd, D [de] MMMM [de] YYYY h:mm A'
+  },
+  relativeTime: {
+    future: 'en %s',
+    past: 'hace %s',
+    s: 'unos segundos',
+    m: 'un minuto',
+    mm: '%d minutos',
+    h: 'una hora',
+    hh: '%d horas',
+    d: 'un día',
+    dd: '%d días',
+    M: 'un mes',
+    MM: '%d meses',
+    y: 'un año',
+    yy: '%d años'
+  },
+  ordinal: n => `${n}º`
+}
+
+dayjs.locale(locale, null, true)
+
+export default locale
+

--- a/src/locale/ht.js
+++ b/src/locale/ht.js
@@ -1,4 +1,4 @@
-// French (Canada) [fr-ca]
+// Haitian Creole (Haiti) [ht]
 import dayjs from 'dayjs'
 
 const locale = {

--- a/src/locale/ht.js
+++ b/src/locale/ht.js
@@ -1,0 +1,40 @@
+// French (Canada) [fr-ca]
+import dayjs from 'dayjs'
+
+const locale = {
+  name: 'ht',
+  weekdays: 'dimanch_lendi_madi_mèkredi_jedi_vandredi_samdi'.split('_'),
+  months: 'janvye_fevriye_mas_avril_me_jen_jiyè_out_septanm_oktòb_novanm_desanm'.split('_'),
+  weekdaysShort: 'dim._len._mad._mèk._jed._van._sam.'.split('_'),
+  monthsShort: 'jan._fev._mas_avr._me_jen_jiyè._out_sept._okt._nov._des.'.split('_'),
+  weekdaysMin: 'di_le_ma_mè_je_va_sa'.split('_'),
+  ordinal: n => n,
+  formats: {
+    LT: 'HH:mm',
+    LTS: 'HH:mm:ss',
+    L: 'DD/MM/YYYY',
+    LL: 'D MMMM YYYY',
+    LLL: 'D MMMM YYYY HH:mm',
+    LLLL: 'dddd D MMMM YYYY HH:mm'
+  },
+  relativeTime: {
+    future: 'nan %s',
+    past: 'sa gen %s',
+    s: 'kèk segond',
+    m: 'yon minit',
+    mm: '%d minit',
+    h: 'inèdtan',
+    hh: '%d zè',
+    d: 'yon jou',
+    dd: '%d jou',
+    M: 'yon mwa',
+    MM: '%d mwa',
+    y: 'yon ane',
+    yy: '%d ane'
+  }
+}
+
+dayjs.locale(locale, null, true)
+
+export default locale
+


### PR DESCRIPTION
I would like to add localization/ support for Haitian Creole (ht) and Spanish (Puerto Rico) (es-PR).
Please let me know if I need to do something more on this branch.
Thank you. :) 

_Note: The Haitian Creole translation was contributed by Steve Patrick Louis_