### PR TITLE
Prevent failing tests caused by a timezone on each machine

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "types": "index.d.ts",
   "module": "dayjs.min.js",
   "scripts": {
-    "test": "TZ=Pacific/Auckland npm run test-tz && TZ=Europe/London npm run test-tz && TZ=America/Whitehorse npm run test-tz && npm run test-tz && jest",
+    "test": "TZ=Pacific/Auckland npm run test-tz && TZ=Europe/London npm run test-tz && TZ=America/Whitehorse npm run test-tz && npm run test-tz && TZ=UTC jest",
     "test-tz": "date && jest test/timezone.test --coverage=false",
     "lint": "./node_modules/.bin/eslint src/* test/* build/*",
     "prettier": "prettier --write \"docs/**/*.md\"",


### PR DESCRIPTION
## My Env

- macOS Catalina
- Node.js 12.12.0
- npm 6.14.5
- timezone Asia/Tokyo

## Problem

Some tests assume the UTC timezone.
When `npm run test` , they are failed if the local machine is not set the UTC timezone.

## My Suggestion

It was resolved by setting the `TZ=UTC`.
Checking behavior related to timezones is not the main purpose of the tests, so this solution looks no problem.

## Minimum Reproduction Case

### ./test/parse.test.js

```bash
# If your machine timezone is Asia/Tokyo:
./node_modules/.bin/jest ./test/parse.test.js
```

or

```bash
TZ=Asia/Tokyo ./node_modules/.bin/jest ./test/parse.test.js
```

The part of output:

```
  ● Parse › moment-js like formatted dates

    expect(received).toBe(expected) // Object.is equality
    
    Expected value to be:
      "2018-01-01T00:00:00+09:00"
    Received:
      "2018-01-01T09:00:00+09:00"

      37 |     expect(dayjs(d).valueOf()).toBe(moment(d).valueOf()) // not recommend
      38 |     d = '2018'
    > 39 |     expect(dayjs(d).format()).toBe(moment(d).format()) // not recommend
      40 |     d = '2018-05-02T11:12:13Z' // should go direct to new Date() rather our regex
      41 |     expect(dayjs(d).format()).toBe(moment(d).format()) // not recommend
      42 |   })
      
      at Object.<anonymous> (test/parse.test.js:39:31)
```

###  ./test/plugin/utc-utcOffset.test.js

```bash
# If your machine timezone is Asia/Tokyo:
./node_modules/.bin/jest ./test/plugin/utc-utcOffset.test.js
```

or

```bash
TZ=Asia/Tokyo ./node_modules/.bin/jest ./test/plugin/utc-utcOffset.test.js
```

The part of output:

```
  ● immutable

    expect(received).not.toBe(expected) // Object.is equality
    
    Expected value to not be:
      540
    Received:
      540

      50 |   const d = dayjs()
      51 |   const du = d.utcOffset(9)
    > 52 |   expect(d.utcOffset()).not.toBe(du.utcOffset())
      53 |   expect(d.format()).not.toBe(du.format())
      54 | })
      55 | 
      
      at Object.<anonymous> (test/plugin/utc-utcOffset.test.js:52:29)
```