### PR TITLE
Parse 'YYYY' correctly

### DIFF
--- a/src/constant.js
+++ b/src/constant.js
@@ -26,5 +26,5 @@ export const FORMAT_DEFAULT = 'YYYY-MM-DDTHH:mm:ssZ'
 export const INVALID_DATE_STRING = 'Invalid Date'
 
 // regex
-export const REGEX_PARSE = /^(\d{4})-?(\d{1,2})-?(\d{0,2})[^0-9]*(\d{1,2})?:?(\d{1,2})?:?(\d{1,2})?.?(\d{1,3})?$/
+export const REGEX_PARSE = /^(\d{4})-?(\d{1,2})?-?(\d{0,2})[^0-9]*(\d{1,2})?:?(\d{1,2})?:?(\d{1,2})?.?(\d{1,3})?$/
 export const REGEX_FORMAT = /\[([^\]]+)]|Y{2,4}|M{1,4}|D{1,2}|d{1,4}|H{1,2}|h{1,2}|a|A|m{1,2}|s{1,2}|Z{1,2}|SSS/g

--- a/src/index.js
+++ b/src/index.js
@@ -59,11 +59,12 @@ const parseDate = (cfg) => {
   if (typeof date === 'string' && !/Z$/i.test(date)) {
     const d = date.match(C.REGEX_PARSE)
     if (d) {
+      const m = d[2] - 1 || 0
       if (utc) {
-        return new Date(Date.UTC(d[1], d[2] ? d[2] - 1 : 0, d[3]
+        return new Date(Date.UTC(d[1], m, d[3]
           || 1, d[4] || 0, d[5] || 0, d[6] || 0, d[7] || 0))
       }
-      return new Date(d[1], d[2] ? d[2] - 1 : 0, d[3]
+      return new Date(d[1], m, d[3]
           || 1, d[4] || 0, d[5] || 0, d[6] || 0, d[7] || 0)
     }
   }

--- a/src/index.js
+++ b/src/index.js
@@ -60,10 +60,11 @@ const parseDate = (cfg) => {
     const d = date.match(C.REGEX_PARSE)
     if (d) {
       if (utc) {
-        return new Date(Date.UTC(d[1], d[2] - 1, d[3]
+        return new Date(Date.UTC(d[1], d[2] ? d[2] - 1 : 0, d[3]
           || 1, d[4] || 0, d[5] || 0, d[6] || 0, d[7] || 0))
       }
-      return new Date(d[1], d[2] - 1, d[3] || 1, d[4] || 0, d[5] || 0, d[6] || 0, d[7] || 0)
+      return new Date(d[1], d[2] ? d[2] - 1 : 0, d[3]
+          || 1, d[4] || 0, d[5] || 0, d[6] || 0, d[7] || 0)
     }
   }
 

--- a/test/plugin/utc.test.js
+++ b/test/plugin/utc.test.js
@@ -56,12 +56,17 @@ describe('Parse UTC ', () => {
 
   it('Parse date string without timezome', () => {
     const d = '2018-09-06'
-    const d2 = '2018-09'
     expect(dayjs.utc(d).format()).toEqual(moment.utc(d).format())
     expect(dayjs.utc(d).format()).toEqual('2018-09-06T00:00:00Z')
+    expect(dayjs(d).utc().format()).toEqual(moment(d).utc().format())
+    const d2 = '2018-09'
     expect(dayjs.utc(d2).format()).toEqual(moment.utc(d2).format())
     expect(dayjs.utc(d2).format()).toEqual('2018-09-01T00:00:00Z')
-    expect(dayjs(d).utc().format()).toEqual(moment(d).utc().format())
+    expect(dayjs(d2).utc().format()).toEqual(moment(d2).utc().format())
+    const d3 = '2018'
+    expect(dayjs.utc(d3).format()).toEqual(moment.utc(d3).format())
+    expect(dayjs.utc(d3).format()).toEqual('2018-01-01T00:00:00Z')
+    expect(dayjs(d3).utc().format()).toEqual(moment(d3).utc().format())
   })
 
   it('creating with utc with timezone', () => {


### PR DESCRIPTION
When only 'YYYY', parsed result was incorrect.

```bash
TZ=Asia/Tokyo yarn jest ./test/parse.test.js
```

Output:

```
  ● Parse › moment-js like formatted dates

    expect(received).toBe(expected) // Object.is equality
    
    Expected value to be:
      "2018-01-01T00:00:00+09:00"
    Received:
      "2018-01-01T09:00:00+09:00"

      37 |     expect(dayjs(d).valueOf()).toBe(moment(d).valueOf()) // not recommend
      38 |     d = '2018'
    > 39 |     expect(dayjs(d).format()).toBe(moment(d).format()) // not recommend
      40 |     d = '2018-05-02T11:12:13Z' // should go direct to new Date() rather our regex
      41 |     expect(dayjs(d).format()).toBe(moment(d).format()) // not recommend
      42 |   })
      
      at Object.<anonymous> (test/parse.test.js:39:31)

```

Failed this test in my local env which is in `Asia/tokyo` time zone.

Compare dayjs and moment:

```js
// TZ=Asia/Tokyo

import dayjs from 'dayjs'
import moment from 'moment'

console.log(dayjs('2018').format())
// 2018-01-01T09:00:00+09:00

console.log(moment('2018').format())
// 2018-01-01T00:00:00+09:00
```

So I think expected behavior: `2018-01-01T00:00:00+09:00` .