### PR TITLE
Follow moment.js's change about `monthDiff` function

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -16,6 +16,9 @@ const padZoneStr = (instance) => {
 
 const monthDiff = (a, b) => {
   // function from moment.js in order to keep the same result
+  if (a.date() < b.date()) {
+    return -monthDiff(b, a)
+  }
   const wholeMonthDiff = ((b.year() - a.year()) * 12) + (b.month() - a.month())
   const anchor = a.clone().add(wholeMonthDiff, C.M)
   const c = b - anchor < 0


### PR DESCRIPTION
`monthDiff` function of moment.js was changed.

https://github.com/moment/moment/commit/a63b46a84e559be632348f284ef8b83f70593e73

Reason of failing rarely `diff` test may be caused by this effect.

Failure example: https://github.com/iamkun/dayjs/runs/935186346