### PR TITLE
fix: update Duration plugin to support global locale

### DIFF
--- a/src/plugin/duration/index.js
+++ b/src/plugin/duration/index.js
@@ -28,7 +28,7 @@ const prettyUnit = unit => `${$u.p(unit)}s`
 class Duration {
   constructor(input, unit, locale) {
     this.$d = {}
-    this.$l = locale || 'en'
+    this.$l = locale
     if (unit) {
       return wrapper(input * unitToMS[prettyUnit(unit)], this)
     }
@@ -172,7 +172,8 @@ export default (option, Dayjs, dayjs) => {
   $d = dayjs
   $u = dayjs().$utils()
   dayjs.duration = function (input, unit) {
-    return wrapper(input, {}, unit)
+    const $l = dayjs.locale()
+    return wrapper(input, { $l }, unit)
   }
   dayjs.isDuration = isDuration
 }

--- a/test/plugin/duration.test.js
+++ b/test/plugin/duration.test.js
@@ -101,6 +101,15 @@ describe('Humanize', () => {
     expect(dayjs.duration(1, 'minutes').locale('fr').humanize(true)).toBe('dans une minute')
     expect(dayjs.duration(1, 'minutes').locale('es').humanize(true)).toBe('en un minuto')
   })
+  it('Global Locale', () => {
+    dayjs.locale('en')
+    expect(dayjs.duration(1, 'minutes').humanize(true)).toBe('in a minute')
+    dayjs.locale('fr')
+    expect(dayjs.duration(1, 'minutes').humanize(true)).toBe('dans une minute')
+    dayjs.locale('es')
+    expect(dayjs.duration(1, 'minutes').humanize(true)).toBe('en un minuto')
+    dayjs.locale('en')
+  })
 })
 
 describe('Clone', () => {


### PR DESCRIPTION
fix #1007

this will support set duration plugin global locale

```
dayjs.locale('zh-cn')

dayjs.duration(24 * 60 * 60 * 1000).humanize() // in zh-cn locale
```