### PR TITLE
[feature] Add parse duration from string

### DIFF
--- a/src/plugin/duration/index.js
+++ b/src/plugin/duration/index.js
@@ -1,4 +1,10 @@
-import { MILLISECONDS_A_WEEK, MILLISECONDS_A_DAY, MILLISECONDS_A_HOUR, MILLISECONDS_A_MINUTE, MILLISECONDS_A_SECOND } from '../../constant'
+import {
+  MILLISECONDS_A_WEEK,
+  MILLISECONDS_A_DAY,
+  MILLISECONDS_A_HOUR,
+  MILLISECONDS_A_MINUTE,
+  MILLISECONDS_A_SECOND
+} from '../../constant'
 
 const MILLISECONDS_A_YEAR = MILLISECONDS_A_DAY * 365
 const MILLISECONDS_A_MONTH = MILLISECONDS_A_DAY * 30
@@ -15,7 +21,7 @@ const unitToMS = {
   weeks: MILLISECONDS_A_WEEK
 }
 
-const isDuration = d => (d instanceof Duration) // eslint-disable-line no-use-before-define
+const isDuration = d => d instanceof Duration // eslint-disable-line no-use-before-define
 
 let $d
 let $u
@@ -38,7 +44,7 @@ class Duration {
       return this
     }
     if (typeof input === 'object') {
-      Object.keys(input).forEach((k) => {
+      Object.keys(input).forEach(k => {
         this.$d[prettyUnit(k)] = input[k]
       })
       this.calMilliseconds()
@@ -47,9 +53,17 @@ class Duration {
     if (typeof input === 'string') {
       const d = input.match(durationRegex)
       if (d) {
-        [,,
-          this.$d.years, this.$d.months, this.$d.weeks,
-          this.$d.days, this.$d.hours, this.$d.minutes, this.$d.seconds] = d
+        ;[
+          ,
+          ,
+          this.$d.years,
+          this.$d.months,
+          this.$d.weeks,
+          this.$d.days,
+          this.$d.hours,
+          this.$d.minutes,
+          this.$d.seconds
+        ] = d
         this.calMilliseconds()
         return this
       }
@@ -58,9 +72,10 @@ class Duration {
   }
 
   calMilliseconds() {
-    this.$ms = Object.keys(this.$d).reduce((total, unit) => (
-      total + ((this.$d[unit] || 0) * (unitToMS[unit] || 1))
-    ), 0)
+    this.$ms = Object.keys(this.$d).reduce(
+      (total, unit) => total + (this.$d[unit] || 0) * (unitToMS[unit] || 1),
+      0
+    )
   }
 
   parseFromMilliseconds() {
@@ -95,7 +110,7 @@ class Duration {
       seconds += this.$d.milliseconds / 1000
     }
     const S = seconds ? `${seconds}S` : ''
-    const T = (H || m || S) ? 'T' : ''
+    const T = H || m || S ? 'T' : ''
     const result = `P${Y}${M}${D}${T}${H}${m}${S}`
     return result === 'P' ? 'P0D' : result
   }
@@ -130,7 +145,7 @@ class Duration {
     } else {
       another = wrapper(input, this).$ms
     }
-    return wrapper(this.$ms + (another * (isSubtract ? -1 : 1)), this)
+    return wrapper(this.$ms + another * (isSubtract ? -1 : 1), this)
   }
 
   subtract(input, unit) {
@@ -148,30 +163,72 @@ class Duration {
   }
 
   humanize(withSuffix) {
-    return $d().add(this.$ms, 'ms').locale(this.$l).fromNow(!withSuffix)
+    return $d()
+      .add(this.$ms, 'ms')
+      .locale(this.$l)
+      .fromNow(!withSuffix)
   }
-
-  milliseconds() { return this.get('milliseconds') }
-  asMilliseconds() { return this.as('milliseconds') }
-  seconds() { return this.get('seconds') }
-  asSeconds() { return this.as('seconds') }
-  minutes() { return this.get('minutes') }
-  asMinutes() { return this.as('minutes') }
-  hours() { return this.get('hours') }
-  asHours() { return this.as('hours') }
-  days() { return this.get('days') }
-  asDays() { return this.as('days') }
-  weeks() { return this.get('weeks') }
-  asWeeks() { return this.as('weeks') }
-  months() { return this.get('months') }
-  asMonths() { return this.as('months') }
-  years() { return this.get('years') }
-  asYears() { return this.as('years') }
+  fromString(duration) {
+    duration = duration.split(' ')
+    let input = {}
+    for (let i = 1; i <= duration.length; i += 2) {
+      input[duration[i]] = Number(duration[i - 1]) || 0
+    }
+    return new Duration(input)
+  }
+  milliseconds() {
+    return this.get('milliseconds')
+  }
+  asMilliseconds() {
+    return this.as('milliseconds')
+  }
+  seconds() {
+    return this.get('seconds')
+  }
+  asSeconds() {
+    return this.as('seconds')
+  }
+  minutes() {
+    return this.get('minutes')
+  }
+  asMinutes() {
+    return this.as('minutes')
+  }
+  hours() {
+    return this.get('hours')
+  }
+  asHours() {
+    return this.as('hours')
+  }
+  days() {
+    return this.get('days')
+  }
+  asDays() {
+    return this.as('days')
+  }
+  weeks() {
+    return this.get('weeks')
+  }
+  asWeeks() {
+    return this.as('weeks')
+  }
+  months() {
+    return this.get('months')
+  }
+  asMonths() {
+    return this.as('months')
+  }
+  years() {
+    return this.get('years')
+  }
+  asYears() {
+    return this.as('years')
+  }
 }
 export default (option, Dayjs, dayjs) => {
   $d = dayjs
   $u = dayjs().$utils()
-  dayjs.duration = function (input, unit) {
+  dayjs.duration = function(input, unit) {
     return wrapper(input, {}, unit)
   }
   dayjs.isDuration = isDuration

--- a/test/plugin/duration.test.js
+++ b/test/plugin/duration.test.js
@@ -27,37 +27,50 @@ describe('Creating', () => {
     expect(dayjs.duration(13213, 'seconds').toISOString()).toBe('PT3H40M13S')
   })
   it('object with float', () => {
-    expect(dayjs.duration({
-      seconds: 1,
-      minutes: 2,
-      hours: 3,
-      days: 4,
-      months: 6,
-      years: 7
-    }).toISOString()).toBe('P7Y6M4DT3H2M1S')
+    expect(
+      dayjs
+        .duration({
+          seconds: 1,
+          minutes: 2,
+          hours: 3,
+          days: 4,
+          months: 6,
+          years: 7
+        })
+        .toISOString()
+    ).toBe('P7Y6M4DT3H2M1S')
   })
   it('object with weeks and float', () => {
-    expect(dayjs.duration({
-      seconds: 1.1,
-      minutes: 2,
-      hours: 3,
-      days: 4,
-      weeks: 5,
-      months: 6,
-      years: 7
-    }).toISOString()).toBe('P7Y6M39DT3H2M1.1S')
+    expect(
+      dayjs
+        .duration({
+          seconds: 1.1,
+          minutes: 2,
+          hours: 3,
+          days: 4,
+          weeks: 5,
+          months: 6,
+          years: 7
+        })
+        .toISOString()
+    ).toBe('P7Y6M39DT3H2M1.1S')
   })
   it('object with millisecond', () => {
-    expect(dayjs.duration({
-      ms: 1
-    }).toISOString()).toBe('PT0.001S')
+    expect(
+      dayjs
+        .duration({
+          ms: 1
+        })
+        .toISOString()
+    ).toBe('PT0.001S')
   })
 })
 
-
 describe('Parse ISO string', () => {
   it('Full ISO string', () => {
-    expect(dayjs.duration('P7Y6M4DT3H2M1S').toISOString()).toBe('P7Y6M4DT3H2M1S')
+    expect(dayjs.duration('P7Y6M4DT3H2M1S').toISOString()).toBe(
+      'P7Y6M4DT3H2M1S'
+    )
   })
   it('Part ISO string', () => {
     expect(dayjs.duration('PT2777H46M40S').toISOString()).toBe('PT2777H46M40S')
@@ -82,9 +95,11 @@ it('Is duration', () => {
 })
 
 it('toJSON', () => {
-  expect(JSON.stringify({
-    postDuration: dayjs.duration(5, 'minutes')
-  })).toBe('{"postDuration":"PT5M"}')
+  expect(
+    JSON.stringify({
+      postDuration: dayjs.duration(5, 'minutes')
+    })
+  ).toBe('{"postDuration":"PT5M"}')
 })
 
 describe('Humanize', () => {
@@ -98,8 +113,18 @@ describe('Humanize', () => {
 
   it('Locale', () => {
     expect(dayjs.duration(1, 'minutes').humanize(true)).toBe('in a minute')
-    expect(dayjs.duration(1, 'minutes').locale('fr').humanize(true)).toBe('dans une minute')
-    expect(dayjs.duration(1, 'minutes').locale('es').humanize(true)).toBe('en un minuto')
+    expect(
+      dayjs
+        .duration(1, 'minutes')
+        .locale('fr')
+        .humanize(true)
+    ).toBe('dans une minute')
+    expect(
+      dayjs
+        .duration(1, 'minutes')
+        .locale('es')
+        .humanize(true)
+    ).toBe('en un minuto')
   })
 })
 
@@ -135,6 +160,15 @@ describe('Subtract', () => {
   expect(a.subtract(b).days()).toBe(1)
 })
 
+describe('Seconds', () => {
+  expect(dayjs.duration(500).seconds()).toBe(0)
+  expect(dayjs.duration(1500).seconds()).toBe(1)
+  expect(dayjs.duration(15000).seconds()).toBe(15)
+  expect(dayjs.duration(61000).seconds()).toBe(1) // 1 minute 1 second
+  expect(dayjs.duration(500).asSeconds()).toBe(0.5)
+  expect(dayjs.duration(1500).asSeconds()).toBe(1.5)
+  expect(dayjs.duration(15000).asSeconds()).toBe(15)
+})
 
 describe('Seconds', () => {
   expect(dayjs.duration(500).seconds()).toBe(0)
@@ -149,22 +183,42 @@ describe('Seconds', () => {
 describe('Minutes', () => {
   expect(dayjs.duration(100000).minutes()).toBe(1)
   expect(dayjs.duration(61000).minutes()).toBe(1) // 1 minute 1 second
-  expect(dayjs.duration(100000).asMinutes().toFixed(2)).toBe('1.67')
+  expect(
+    dayjs
+      .duration(100000)
+      .asMinutes()
+      .toFixed(2)
+  ).toBe('1.67')
 })
 
 describe('Hours', () => {
   expect(dayjs.duration(10000000).hours()).toBe(2)
-  expect(dayjs.duration(10000000).asHours().toFixed(2)).toBe('2.78')
+  expect(
+    dayjs
+      .duration(10000000)
+      .asHours()
+      .toFixed(2)
+  ).toBe('2.78')
 })
 
 describe('Days', () => {
   expect(dayjs.duration(100000000).days()).toBe(1)
-  expect(dayjs.duration(100000000).asDays().toFixed(2)).toBe('1.16')
+  expect(
+    dayjs
+      .duration(100000000)
+      .asDays()
+      .toFixed(2)
+  ).toBe('1.16')
 })
 
 describe('Weeks', () => {
   expect(dayjs.duration(1000000000).weeks()).toBe(1)
-  expect(dayjs.duration(1000000000).asWeeks().toFixed(2)).toBe('1.65')
+  expect(
+    dayjs
+      .duration(1000000000)
+      .asWeeks()
+      .toFixed(2)
+  ).toBe('1.65')
 })
 
 describe('Month', () => {
@@ -174,7 +228,12 @@ describe('Month', () => {
 
 describe('Years', () => {
   expect(dayjs.duration(100000000000).years()).toBe(3)
-  expect(dayjs.duration(100000000000).asYears().toFixed(2)).toBe('3.17')
+  expect(
+    dayjs
+      .duration(100000000000)
+      .asYears()
+      .toFixed(2)
+  ).toBe('3.17')
 })
 
 describe('prettyUnit', () => {
@@ -182,8 +241,19 @@ describe('prettyUnit', () => {
   expect(d.toISOString()).toBe('PT2S')
   expect(d.as('Second')).toBe(2)
   expect(d.get('s')).toBe(2)
-  expect(dayjs.duration({
-    M: 12,
-    m: 12
-  }).toISOString()).toBe('P12MT12M')
+  expect(
+    dayjs
+      .duration({
+        M: 12,
+        m: 12
+      })
+      .toISOString()
+  ).toBe('P12MT12M')
+})
+
+describe('fromString', () => {
+  const d = dayjs.duration()
+  expect(d.fromString('g days 57 minutes 34 seconds').get('d')).toBe(0)
+  expect(d.fromString('g days 57 minutes 34 seconds').get('s')).toBe(34)
+  expect(d.fromString('g days 57 minutes 34 seconds').get('m')).toBe(57)
 })


### PR DESCRIPTION
Hello everyone,
This is a new feature can be adding to  moment duration
now we can create duration just from a string like  "1 day 57 minutes 34 seconds" will be  parse into normal object and create duration object
how work??
```js
console.log(dayjs.duration().fromString("1 day 57 minutes 34 seconds" )) // duration object
```