### PR TITLE
fix: support parsing unlimited decimals of millisecond

### DIFF
--- a/src/constant.js
+++ b/src/constant.js
@@ -26,5 +26,5 @@ export const FORMAT_DEFAULT = 'YYYY-MM-DDTHH:mm:ssZ'
 export const INVALID_DATE_STRING = 'Invalid Date'
 
 // regex
-export const REGEX_PARSE = /^(\d{4})[-/]?(\d{1,2})?[-/]?(\d{0,2})[^0-9]*(\d{1,2})?:?(\d{1,2})?:?(\d{1,2})?.?(\d{1,3})?$/
+export const REGEX_PARSE = /^(\d{4})[-/]?(\d{1,2})?[-/]?(\d{0,2})[^0-9]*(\d{1,2})?:?(\d{1,2})?:?(\d{1,2})?.?(\d+)?$/
 export const REGEX_FORMAT = /\[([^\]]+)]|Y{2,4}|M{1,4}|D{1,2}|d{1,4}|H{1,2}|h{1,2}|a|A|m{1,2}|s{1,2}|Z{1,2}|SSS/g

--- a/src/index.js
+++ b/src/index.js
@@ -60,12 +60,13 @@ const parseDate = (cfg) => {
     const d = date.match(C.REGEX_PARSE)
     if (d) {
       const m = d[2] - 1 || 0
+      const ms = (d[7] || '0').substring(0, 3)
       if (utc) {
         return new Date(Date.UTC(d[1], m, d[3]
-          || 1, d[4] || 0, d[5] || 0, d[6] || 0, d[7] || 0))
+          || 1, d[4] || 0, d[5] || 0, d[6] || 0, ms))
       }
       return new Date(d[1], m, d[3]
-          || 1, d[4] || 0, d[5] || 0, d[6] || 0, d[7] || 0)
+          || 1, d[4] || 0, d[5] || 0, d[6] || 0, ms)
     }
   }
 

--- a/test/parse.test.js
+++ b/test/parse.test.js
@@ -81,6 +81,14 @@ describe('Parse', () => {
     expect(normalized.toISOString()).toEqual(expected)
   })
 
+  it('parses unlimited millisecond', () => {
+    const date = '2019-03-25T06:41:00.999999999'
+    const ds = dayjs(date)
+    const ms = moment(date)
+    expect(ds.valueOf()).toEqual(ms.valueOf())
+    expect(ds.millisecond()).toEqual(ms.millisecond())
+  })
+
   it('String Other, Null and isValid', () => {
     global.console.warn = jest.genMockFunction()// moment.js otherString will throw warn
     expect(dayjs('otherString').toString().toLowerCase()).toBe(moment('otherString').toString().toLowerCase())
@@ -133,5 +141,11 @@ describe('REGEX_PARSE', () => {
     const d = date.match(REGEX_PARSE)
     expect(dayjs(date).valueOf()).toBe(moment(date).valueOf())
     expect(d.join('-')).toBe('2020/9/30-2020-9-30----')
+  })
+  it('2019-03-25T06:41:00.999999999', () => {
+    const date = '2019-03-25T06:41:00.999999999'
+    const d = date.match(REGEX_PARSE)
+    expect(dayjs(date).valueOf()).toBe(moment(date).valueOf())
+    expect(d.join('-')).toBe('2019-03-25T06:41:00.999999999-2019-03-25-06-41-00-999999999')
   })
 })

--- a/test/plugin/utc.test.js
+++ b/test/plugin/utc.test.js
@@ -94,6 +94,14 @@ describe('Parse UTC ', () => {
     expect(dayjs.utc(d).format()).toEqual('2018-09-06T19:34:28Z')
     expect(dayjs.utc(d).format()).toEqual(moment.utc(d).format())
   })
+
+  it('parses unlimited millisecond in utc', () => {
+    const date = '2019-03-25T06:41:00.999999999'
+    const ds = dayjs.utc(date)
+    const ms = moment.utc(date)
+    expect(ds.valueOf()).toEqual(ms.valueOf())
+    expect(ds.millisecond()).toEqual(ms.millisecond())
+  })
 })
 
 it('Clone retains the UTC mode', () => {


### PR DESCRIPTION
fix #544


support parsing 
```
dayjs('2019-03-25T06:41:00.999999999')
```