### PR TITLE
fix: Update missing calendar for VI

### DIFF
--- a/src/locale/vi.js
+++ b/src/locale/vi.js
@@ -36,6 +36,14 @@ const locale = {
     MM: '%d tháng',
     y: 'một năm',
     yy: '%d năm'
+  },
+  calendar: {
+    sameDay: '[Hôm nay lúc] LT',
+    nextDay: '[Ngày mai lúc] LT',
+    nextWeek: 'dddd [tuần tới lúc] LT',
+    lastDay: '[Hôm qua lúc] LT',
+    lastWeek: 'dddd [tuần trước lúc] LT',
+    sameElse: 'L',
   }
 }
 

--- a/src/locale/vi.js
+++ b/src/locale/vi.js
@@ -43,7 +43,7 @@ const locale = {
     nextWeek: 'dddd [tuần tới lúc] LT',
     lastDay: '[Hôm qua lúc] LT',
     lastWeek: 'dddd [tuần trước lúc] LT',
-    sameElse: 'L',
+    sameElse: 'L'
   }
 }
 


### PR DESCRIPTION
Copied from momentjs: https://github.com/moment/moment/blob/2c0b063b3bf95a285f9b38c173e262b6416c2e7f/locale/vi.js#L52-L59