### PR TITLE
fix: timezone plugin should have the same behavior in latest ICU v…

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ cache:
     - ~/.npm
     - node_modules
 node_js:
+  - '14'
   - '12'
   - '10'
   - '8'

--- a/src/plugin/timezone/index.js
+++ b/src/plugin/timezone/index.js
@@ -33,24 +33,39 @@ export default (o, c, d) => {
         filled[pos] = parseInt(value, 10)
       }
     }
-    const utcString = `${filled[0]}-${filled[1]}-${filled[2]} ${filled[3]}:${filled[4]}:${filled[5]}:000`
+    // Workaround for the same performance in different node version
+    // https://github.com/nodejs/node/issues/33027
+    const hour = filled[3]
+    const fixedHour = hour === 24 ? 0 : hour
+    const utcString = `${filled[0]}-${filled[1]}-${filled[2]} ${fixedHour}:${filled[4]}:${filled[5]}:000`
     const utcTs = d.utc(utcString).valueOf()
     let asTS = +date
     const over = asTS % 1000
     asTS -= over
     return (utcTs - asTS) / (60 * 1000)
   }
+
+  // find the right offset a given local time. The o input is our guess, which determines which
+  // offset we'll pick in ambiguous cases (e.g. there are two 3 AMs b/c Fallback DST)
+  // https://github.com/moment/luxon/blob/master/src/datetime.js#L76
   const fixOffset = (localTS, o0, tz) => {
+    // Our UTC time is just a guess because our offset is just a guess
     let utcGuess = localTS - (o0 * 60 * 1000)
+    // Test whether the zone matches the offset for this ts
     const o2 = tzOffset(utcGuess, tz)
+    // If so, offset didn't change and we're done
     if (o0 === o2) {
       return [utcGuess, o0]
     }
+    // If not, change the ts by the difference in the offset
     utcGuess -= (o2 - o0) * 60 * 1000
+    // If that gives us the local time we want, we're done
     const o3 = tzOffset(utcGuess, tz)
     if (o2 === o3) {
       return [utcGuess, o2]
     }
+    // If it's different, we're in a hole time.
+    // The offset has changed, but the we don't adjust the time
     return [localTS - (Math.min(o2, o3) * 60 * 1000), Math.max(o2, o3)]
   }
   const proto = c.prototype


### PR DESCRIPTION
Node 14 use new ICU rules: https://github.com/nodejs/node/issues/33027 which will cause the timezone plugin testing failed.

The behavior should be the same in different node version.