### PR TITLE
Fix Polish, Hungarian and Lithuanian localization.

### DIFF
--- a/src/locale/hr.js
+++ b/src/locale/hr.js
@@ -1,13 +1,26 @@
 // Croatian [hr]
 import dayjs from 'dayjs'
 
+const monthFormat = 'siječnja_veljače_ožujka_travnja_svibnja_lipnja_srpnja_kolovoza_rujna_listopada_studenoga_prosinca'.split('_')
+const monthStandalone = 'siječanj_veljača_ožujak_travanj_svibanj_lipanj_srpanj_kolovoz_rujan_listopad_studeni_prosinac'.split('_')
+const MONTHS_IN_FORMAT = /D[oD]?(\[[^[\]]*\]|\s)+MMMM?/
+
+const months = (dayjsInstance, format) => {
+  if (MONTHS_IN_FORMAT.test(format)) {
+    return monthFormat[dayjsInstance.month()]
+  }
+  return monthStandalone[dayjsInstance.month()]
+}
+months.s = monthStandalone
+months.f = monthFormat
+
 const locale = {
   name: 'hr',
-  weekdays: 'Nedjelja_Ponedjeljak_Utorak_Srijeda_Četvrtak_Petak_Subota'.split('_'),
-  weekdaysShort: 'Ned._Pon._Uto._Sri._Čet._Pet._Sub.'.split('_'),
-  weekdaysMin: 'Ne_Po_Ut_Sr_Če_Pe_Su'.split('_'),
-  months: 'Siječanj_Veljača_Ožujak_Travanj_Svibanj_Lipanj_Srpanj_Kolovoz_Rujan_Listopad_Studeni_Prosinac'.split('_'),
-  monthsShort: 'Sij._Velj._Ožu._Tra._Svi._Lip._Srp._Kol._Ruj._Lis._Stu._Pro.'.split('_'),
+  weekdays: 'nedjelja_ponedjeljak_utorak_srijeda_četvrtak_petak_subota'.split('_'),
+  weekdaysShort: 'ned._pon._uto._sri._čet._pet._sub.'.split('_'),
+  weekdaysMin: 'ne_po_ut_sr_če_pe_su'.split('_'),
+  months,
+  monthsShort: 'sij._velj._ožu._tra._svi._lip._srp._kol._ruj._lis._stu._pro.'.split('_'),
   weekStart: 1,
   formats: {
     LT: 'H:mm',

--- a/src/locale/lt.js
+++ b/src/locale/lt.js
@@ -3,6 +3,7 @@ import dayjs from 'dayjs'
 
 const monthFormat = 'sausio_vasario_kovo_balandžio_gegužės_birželio_liepos_rugpjūčio_rugsėjo_spalio_lapkričio_gruodžio'.split('_')
 const monthStandalone = 'sausis_vasaris_kovas_balandis_gegužė_birželis_liepa_rugpjūtis_rugsėjis_spalis_lapkritis_gruodis'.split('_')
+// eslint-disable-next-line no-useless-escape
 const MONTHS_IN_FORMAT = /D[oD]?(\[[^\[\]]*\]|\s)+MMMM?|MMMM?(\[[^\[\]]*\]|\s)+D[oD]?/
 
 const months = (dayjsInstance, format) => {

--- a/src/locale/lt.js
+++ b/src/locale/lt.js
@@ -1,12 +1,25 @@
 // Lithuanian [lt]
 import dayjs from 'dayjs'
 
+const monthFormat = 'sausio_vasario_kovo_balandžio_gegužės_birželio_liepos_rugpjūčio_rugsėjo_spalio_lapkričio_gruodžio'.split('_')
+const monthStandalone = 'sausis_vasaris_kovas_balandis_gegužė_birželis_liepa_rugpjūtis_rugsėjis_spalis_lapkritis_gruodis'.split('_')
+const MONTHS_IN_FORMAT = /D[oD]?(\[[^\[\]]*\]|\s)+MMMM?|MMMM?(\[[^\[\]]*\]|\s)+D[oD]?/
+
+const months = (dayjsInstance, format) => {
+  if (MONTHS_IN_FORMAT.test(format)) {
+    return monthFormat[dayjsInstance.month()]
+  }
+  return monthStandalone[dayjsInstance.month()]
+}
+months.s = monthStandalone
+months.f = monthFormat
+
 const locale = {
   name: 'lt',
   weekdays: 'sekmadienis_pirmadienis_antradienis_trečiadienis_ketvirtadienis_penktadienis_šeštadienis'.split('_'),
   weekdaysShort: 'sek_pir_ant_tre_ket_pen_šeš'.split('_'),
   weekdaysMin: 's_p_a_t_k_pn_š'.split('_'),
-  months: 'sausis_vasaris_kovas_balandis_gegužė_birželis_liepa_rugpjūtis_rugsėjis_spalis_lapkritis_gruodis'.split('_'),
+  months,
   monthsShort: 'sau_vas_kov_bal_geg_bir_lie_rgp_rgs_spa_lap_grd'.split('_'),
   ordinal: n => `${n}.`,
   weekStart: 1,

--- a/src/locale/pl.js
+++ b/src/locale/pl.js
@@ -23,12 +23,26 @@ function translate(number, withoutSuffix, key) {
   }
 }
 /* eslint-enable */
+
+const monthFormat = 'stycznia_lutego_marca_kwietnia_maja_czerwca_lipca_sierpnia_września_października_listopada_grudnia'.split('_')
+const monthStandalone = 'styczeń_luty_marzec_kwiecień_maj_czerwiec_lipiec_sierpień_wrzesień_październik_listopad_grudzień'.split('_')
+const MONTHS_IN_FORMAT = /D MMMM/
+
+const months = (dayjsInstance, format) => {
+  if (MONTHS_IN_FORMAT.test(format)) {
+    return monthFormat[dayjsInstance.month()]
+  }
+  return monthStandalone[dayjsInstance.month()]
+}
+months.s = monthStandalone
+months.f = monthFormat
+
 const locale = {
   name: 'pl',
-  weekdays: 'Niedziela_Poniedziałek_Wtorek_Środa_Czwartek_Piątek_Sobota'.split('_'),
-  weekdaysShort: 'Ndz_Pon_Wt_Śr_Czw_Pt_Sob'.split('_'),
+  weekdays: 'niedziela_poniedziałek_wtorek_środa_czwartek_piątek_sobota'.split('_'),
+  weekdaysShort: 'ndz_pon_wt_śr_czw_pt_sob'.split('_'),
   weekdaysMin: 'Nd_Pn_Wt_Śr_Cz_Pt_So'.split('_'),
-  months: 'Styczeń_Luty_Marzec_Kwiecień_Maj_Czerwiec_Lipiec_Sierpień_Wrzesień_Październik_Listopad_Grudzień'.split('_'),
+  months,
   monthsShort: 'sty_lut_mar_kwi_maj_cze_lip_sie_wrz_paź_lis_gru'.split('_'),
   ordinal: n => `${n}.`,
   weekStart: 1,

--- a/test/locale/hr.test.js
+++ b/test/locale/hr.test.js
@@ -1,0 +1,18 @@
+import moment from 'moment'
+import dayjs from '../../src'
+import '../../src/locale/hr'
+
+it('Format month with locale function', () => {
+  for (let i = 0; i <= 7; i += 1) {
+      const dayjsUK = dayjs().locale('hr').add(i, 'day')
+      const momentUK = moment().locale('hr').add(i, 'day')
+      const testFormat1 = 'DD MMMM YYYY MMM'
+      const testFormat2 = 'dddd, MMMM D YYYY'
+      const testFormat3 = 'MMMM'
+      const testFormat4 = 'MMM'
+      expect(dayjsUK.format(testFormat1)).toEqual(momentUK.format(testFormat1))
+      expect(dayjsUK.format(testFormat2)).toEqual(momentUK.format(testFormat2))
+      expect(dayjsUK.format(testFormat3)).toEqual(momentUK.format(testFormat3))
+      expect(dayjsUK.format(testFormat4)).toEqual(momentUK.format(testFormat4))
+  }
+})

--- a/test/locale/hr.test.js
+++ b/test/locale/hr.test.js
@@ -4,15 +4,15 @@ import '../../src/locale/hr'
 
 it('Format month with locale function', () => {
   for (let i = 0; i <= 7; i += 1) {
-      const dayjsUK = dayjs().locale('hr').add(i, 'day')
-      const momentUK = moment().locale('hr').add(i, 'day')
-      const testFormat1 = 'DD MMMM YYYY MMM'
-      const testFormat2 = 'dddd, MMMM D YYYY'
-      const testFormat3 = 'MMMM'
-      const testFormat4 = 'MMM'
-      expect(dayjsUK.format(testFormat1)).toEqual(momentUK.format(testFormat1))
-      expect(dayjsUK.format(testFormat2)).toEqual(momentUK.format(testFormat2))
-      expect(dayjsUK.format(testFormat3)).toEqual(momentUK.format(testFormat3))
-      expect(dayjsUK.format(testFormat4)).toEqual(momentUK.format(testFormat4))
+    const dayjsUK = dayjs().locale('hr').add(i, 'day')
+    const momentUK = moment().locale('hr').add(i, 'day')
+    const testFormat1 = 'DD MMMM YYYY MMM'
+    const testFormat2 = 'dddd, MMMM D YYYY'
+    const testFormat3 = 'MMMM'
+    const testFormat4 = 'MMM'
+    expect(dayjsUK.format(testFormat1)).toEqual(momentUK.format(testFormat1))
+    expect(dayjsUK.format(testFormat2)).toEqual(momentUK.format(testFormat2))
+    expect(dayjsUK.format(testFormat3)).toEqual(momentUK.format(testFormat3))
+    expect(dayjsUK.format(testFormat4)).toEqual(momentUK.format(testFormat4))
   }
 })

--- a/test/locale/lt.test.js
+++ b/test/locale/lt.test.js
@@ -1,0 +1,18 @@
+import moment from 'moment'
+import dayjs from '../../src'
+import '../../src/locale/lt'
+
+it('Format month with locale function', () => {
+  for (let i = 0; i <= 7; i += 1) {
+      const dayjsUK = dayjs().locale('lt').add(i, 'day')
+      const momentUK = moment().locale('lt').add(i, 'day')
+      const testFormat1 = 'DD MMMM YYYY MMM'
+      const testFormat2 = 'dddd, MMMM D YYYY'
+      const testFormat3 = 'MMMM'
+      const testFormat4 = 'MMM'
+      expect(dayjsUK.format(testFormat1)).toEqual(momentUK.format(testFormat1))
+      expect(dayjsUK.format(testFormat2)).toEqual(momentUK.format(testFormat2))
+      expect(dayjsUK.format(testFormat3)).toEqual(momentUK.format(testFormat3))
+      expect(dayjsUK.format(testFormat4)).toEqual(momentUK.format(testFormat4))
+  }
+})

--- a/test/locale/lt.test.js
+++ b/test/locale/lt.test.js
@@ -4,15 +4,15 @@ import '../../src/locale/lt'
 
 it('Format month with locale function', () => {
   for (let i = 0; i <= 7; i += 1) {
-      const dayjsUK = dayjs().locale('lt').add(i, 'day')
-      const momentUK = moment().locale('lt').add(i, 'day')
-      const testFormat1 = 'DD MMMM YYYY MMM'
-      const testFormat2 = 'dddd, MMMM D YYYY'
-      const testFormat3 = 'MMMM'
-      const testFormat4 = 'MMM'
-      expect(dayjsUK.format(testFormat1)).toEqual(momentUK.format(testFormat1))
-      expect(dayjsUK.format(testFormat2)).toEqual(momentUK.format(testFormat2))
-      expect(dayjsUK.format(testFormat3)).toEqual(momentUK.format(testFormat3))
-      expect(dayjsUK.format(testFormat4)).toEqual(momentUK.format(testFormat4))
+    const dayjsUK = dayjs().locale('lt').add(i, 'day')
+    const momentUK = moment().locale('lt').add(i, 'day')
+    const testFormat1 = 'DD MMMM YYYY MMM'
+    const testFormat2 = 'dddd, MMMM D YYYY'
+    const testFormat3 = 'MMMM'
+    const testFormat4 = 'MMM'
+    expect(dayjsUK.format(testFormat1)).toEqual(momentUK.format(testFormat1))
+    expect(dayjsUK.format(testFormat2)).toEqual(momentUK.format(testFormat2))
+    expect(dayjsUK.format(testFormat3)).toEqual(momentUK.format(testFormat3))
+    expect(dayjsUK.format(testFormat4)).toEqual(momentUK.format(testFormat4))
   }
 })

--- a/test/locale/pl.test.js
+++ b/test/locale/pl.test.js
@@ -14,6 +14,21 @@ afterEach(() => {
   MockDate.reset()
 })
 
+it('Format month with locale function', () => {
+  for (let i = 0; i <= 7; i += 1) {
+    const dayjsUK = dayjs().locale('pl').add(i, 'day')
+    const momentUK = moment().locale('pl').add(i, 'day')
+    const testFormat1 = 'DD MMMM YYYY MMM'
+    const testFormat2 = 'dddd, MMMM D YYYY'
+    const testFormat3 = 'MMMM'
+    const testFormat4 = 'MMM'
+    expect(dayjsUK.format(testFormat1)).toEqual(momentUK.format(testFormat1))
+    expect(dayjsUK.format(testFormat2)).toEqual(momentUK.format(testFormat2))
+    expect(dayjsUK.format(testFormat3)).toEqual(momentUK.format(testFormat3))
+    expect(dayjsUK.format(testFormat4)).toEqual(momentUK.format(testFormat4))
+  }
+})
+
 it('RelativeTime: Time from X', () => {
   const T = [
     [44.4, 'second'], // a few seconds


### PR DESCRIPTION
Fixing months names for Polish, Hungarian and Lithuanian locales:
- added formatted month names
- added function which determines which format to use

Fixing weekday names casing.

#1044 
