### PR TITLE
Add Amharic locale

### DIFF
--- a/src/locale/am.js
+++ b/src/locale/am.js
@@ -1,0 +1,41 @@
+// Amharic [am]
+import dayjs from 'dayjs'
+
+const locale = {
+  name: 'am',
+  weekdays: 'እሑድ_ሰኞ_ማክሰኞ_ረቡዕ_ሐሙስ_አርብ_ቅዳሜ'.split('_'),
+  weekdaysShort: 'እሑድ_ሰኞ_ማክሰ_ረቡዕ_ሐሙስ_አርብ_ቅዳሜ'.split('_'),
+  weekdaysMin: 'እሑ_ሰኞ_ማክ_ረቡ_ሐሙ_አር_ቅዳ'.split('_'),
+  months: 'ጃንዋሪ_ፌብሯሪ_ማርች_ኤፕሪል_ሜይ_ጁን_ጁላይ_ኦገስት_ሴፕቴምበር_ኦክቶበር_ኖቬምበር_ዲሴምበር'.split('_'),
+  monthsShort: 'ጃንዋ_ፌብሯ_ማርች_ኤፕሪ_ሜይ_ጁን_ጁላይ_ኦገስ_ሴፕቴ_ኦክቶ_ኖቬም_ዲሴም'.split('_'),
+  weekStart: 1,
+  yearStart: 4,
+  relativeTime: {
+    future: 'በ%s',
+    past: '%s በፊት',
+    s: 'ጥቂት ሰከንዶች',
+    m: 'አንድ ደቂቃ',
+    mm: '%d ደቂቃዎች',
+    h: 'አንድ ሰዓት',
+    hh: '%d ሰዓታት',
+    d: 'አንድ ቀን',
+    dd: '%d ቀናት',
+    M: 'አንድ ወር',
+    MM: '%d ወራት',
+    y: 'አንድ ዓመት',
+    yy: '%d ዓመታት'
+  },
+  formats: {
+    LT: 'HH:mm',
+    LTS: 'HH:mm:ss',
+    L: 'DD/MM/YYYY',
+    LL: 'MMMM D ፣ YYYY',
+    LLL: 'MMMM D ፣ YYYY HH:mm',
+    LLLL: 'dddd ፣ MMMM D ፣ YYYY HH:mm'
+  },
+  ordinal: (n) => `${n}ኛ`
+}
+
+dayjs.locale(locale, null, true)
+
+export default locale

--- a/src/locale/am.js
+++ b/src/locale/am.js
@@ -33,7 +33,7 @@ const locale = {
     LLL: 'MMMM D ፣ YYYY HH:mm',
     LLLL: 'dddd ፣ MMMM D ፣ YYYY HH:mm'
   },
-  ordinal: (n) => `${n}ኛ`
+  ordinal: n => `${n}ኛ`
 }
 
 dayjs.locale(locale, null, true)


### PR DESCRIPTION
Amharic is the most used official working language of Ethiopia.

This PR adds support for Amharic locale.


_**Note**: The days and months in this locale are the direct English terms to Amharic translations of the Gregorian Calendar, and not the actual terms used in the locally unique [Ethiopian Calendar](https://en.wikipedia.org/wiki/Ethiopian_calendar) system._
