### PR TITLE
fix: Add `setDefault` typing to timezone.d.ts

### DIFF
--- a/types/plugin/timezone.d.ts
+++ b/types/plugin/timezone.d.ts
@@ -11,7 +11,7 @@ declare module 'dayjs' {
   interface DayjsTimezone {
     (date: ConfigType, timezone: string): Dayjs
     guess(): string
-    setDefault(timezone?: string): Dayjs
+    setDefault(timezone?: string): void
   }
 
   const tz: DayjsTimezone

--- a/types/plugin/timezone.d.ts
+++ b/types/plugin/timezone.d.ts
@@ -11,6 +11,7 @@ declare module 'dayjs' {
   interface DayjsTimezone {
     (date: ConfigType, timezone: string): Dayjs
     guess(): string
+    setDefault(timezone?: string): Dayjs
   }
 
   const tz: DayjsTimezone


### PR DESCRIPTION
Timezone plugin set default timezone at v1.8.36, however `timezone.d.ts` does not have type definition of `setDefault` method.