### PR TITLE
Speed up dayjs#tz()

### DIFF
--- a/src/plugin/timezone/index.js
+++ b/src/plugin/timezone/index.js
@@ -13,7 +13,8 @@ const ms = 'ms'
 // as it is a *very* slow method.
 const dtfCache = {}
 const getDateTimeFormat = (timezone, options = {}) => {
-  const key = `${timezone}|${(options.timeZoneName || 'short')}`
+  const timeZoneName = options.timeZoneName || 'short'
+  const key = `${timezone}|${timeZoneName}`
   let dtf = dtfCache[key]
   if (!dtf) {
     dtf = new Intl.DateTimeFormat('en-US', {
@@ -25,7 +26,7 @@ const getDateTimeFormat = (timezone, options = {}) => {
       hour: '2-digit',
       minute: '2-digit',
       second: '2-digit',
-      timeZoneName: options.timeZoneName || 'short'
+      timeZoneName
     })
     dtfCache[key] = dtf
   }


### PR DESCRIPTION
**Description**

Improve the parse speed of `dayjs#tz()` (the timezone plugin) by caching the result from `Intl#getDateTimeFormat()`, as it is _very slow_.

There is also a discussion on speed on Luxon's GitHub. See https://github.com/moment/luxon/issues/89#issuecomment-378826414 for a similar result by not invoking the functions in `Intl.*` more times than needed.

**Speed test**

Running the following benchmark before and after the patch.

```
suite.add('dayjs#tz', function () {
    dayjs.tz("2018-06-23T23:43:12.337+08:00", "Europe/London")
})
```

Here are the results on my machine (a **~8.6x improvement**):

```
Before: dayjs#tz x 3,514 ops/sec ±2.33% (86 runs sampled)
After:  dayjs#tz x 30,347 ops/sec ±1.12% (89 runs sampled)
```
