### PR TITLE
fix: update utc plugin to support keepLocalTime `.utc(true)`

### DIFF
--- a/src/plugin/utc/index.js
+++ b/src/plugin/utc/index.js
@@ -7,8 +7,12 @@ export default (option, Dayjs, dayjs) => {
     return new Dayjs(cfg) // eslint-disable-line no-use-before-define
   }
 
-  proto.utc = function () {
-    return dayjs(this.toDate(), { locale: this.$L, utc: true })
+  proto.utc = function (keepLocalTime) {
+    const ins = dayjs(this.toDate(), { locale: this.$L, utc: true })
+    if (keepLocalTime) {
+      return ins.add(this.utcOffset(), MIN)
+    }
+    return ins
   }
 
   proto.local = function () {

--- a/test/plugin/utc.test.js
+++ b/test/plugin/utc.test.js
@@ -1,8 +1,8 @@
 import MockDate from 'mockdate'
 import moment from 'moment'
 import dayjs from '../../src'
-import utc from '../../src/plugin/utc'
 import customParseFormat from '../../src/plugin/customParseFormat'
+import utc from '../../src/plugin/utc'
 
 dayjs.extend(utc)
 
@@ -249,4 +249,20 @@ describe('Diff', () => {
     expect(dayjs.utc(d1).diff(d2, 'm'))
       .toBe(moment.utc(d1).diff(d2, 'm'))
   })
+})
+
+it('utc keepLocalTime', () => {
+  const t = '2016-05-03T22:15:01+02:00'
+  const d = dayjs(t).utc(true)
+  const m = moment(t).utc(true)
+  const fd = d.format()
+  const dd = d.toDate()
+  const vd = d.valueOf()
+  const fm = m.format()
+  const dm = m.toDate()
+  const vm = m.valueOf()
+  expect(fd).toEqual(fm)
+  expect(dd).toEqual(dm)
+  expect(vd).toEqual(vm)
+  expect(vd).toEqual(1462335301000)
 })

--- a/test/plugin/utc.test.js
+++ b/test/plugin/utc.test.js
@@ -252,7 +252,7 @@ describe('Diff', () => {
 })
 
 it('utc keepLocalTime', () => {
-  const t = '2016-05-03T22:15:01+02:00'
+  const t = '2016-05-03 22:15:01'
   const d = dayjs(t).utc(true)
   const m = moment(t).utc(true)
   const fd = d.format()
@@ -262,7 +262,7 @@ it('utc keepLocalTime', () => {
   const dm = m.toDate()
   const vm = m.valueOf()
   expect(fd).toEqual(fm)
+  expect(fd).toEqual('2016-05-03T22:15:01Z')
   expect(dd).toEqual(dm)
   expect(vd).toEqual(vm)
-  expect(vd).toEqual(1462335301000)
 })

--- a/types/plugin/utc.d.ts
+++ b/types/plugin/utc.d.ts
@@ -6,7 +6,7 @@ export = plugin
 declare module 'dayjs' {
   interface Dayjs {
     
-    utc(): Dayjs
+    utc(keepLocalTime?: boolean): Dayjs
     
     local(): Dayjs
 


### PR DESCRIPTION
fix #1078