### PR TITLE
Allows to add durations to dayjs instance

### DIFF
--- a/src/plugin/duration/index.js
+++ b/src/plugin/duration/index.js
@@ -180,8 +180,9 @@ export default (option, Dayjs, dayjs) => {
   const oldAdd = Dayjs.prototype.add
   Dayjs.prototype.add = function (addition, units) {
     if (isDuration(addition)) {
-      return oldAdd.bind(this)(addition.asMilliseconds(), 'ms')
+      addition = addition.asMilliseconds();
+      units = 'ms';
     }
-    return oldAdd.bind(this)(addition, units)
+    return oldAdd.bind(this)(addition, units);
   }
 }

--- a/src/plugin/duration/index.js
+++ b/src/plugin/duration/index.js
@@ -180,9 +180,9 @@ export default (option, Dayjs, dayjs) => {
   const oldAdd = Dayjs.prototype.add
   Dayjs.prototype.add = function (addition, units) {
     if (isDuration(addition)) {
-      addition = addition.asMilliseconds();
-      units = 'ms';
+      addition = addition.asMilliseconds()
+      units = 'ms'
     }
-    return oldAdd.bind(this)(addition, units);
+    return oldAdd.bind(this)(addition, units)
   }
 }

--- a/src/plugin/duration/index.js
+++ b/src/plugin/duration/index.js
@@ -176,4 +176,12 @@ export default (option, Dayjs, dayjs) => {
     return wrapper(input, { $l }, unit)
   }
   dayjs.isDuration = isDuration
+
+  const oldAdd = Dayjs.prototype.add
+  Dayjs.prototype.add = function (addition, units) {
+    if (isDuration(addition)) {
+      return oldAdd.bind(this)(addition.asMilliseconds(), 'ms')
+    }
+    return oldAdd.bind(this)(addition, units)
+  }
 }

--- a/test/plugin/duration.test.js
+++ b/test/plugin/duration.test.js
@@ -138,6 +138,12 @@ describe('Add', () => {
   expect(a.add({ days: 5 }).days()).toBe(6)
 })
 
+describe('Add duration', () => {
+  const a = dayjs('2020-10-01')
+  const duration = dayjs.duration(2, 'days')
+  expect(a.add(duration).format('YYYY-MM-DD')).toBe('2020-10-03')
+})
+
 describe('Subtract', () => {
   const a = dayjs.duration(3, 'days')
   const b = dayjs.duration(2, 'days')

--- a/test/plugin/duration.test.js
+++ b/test/plugin/duration.test.js
@@ -140,8 +140,8 @@ describe('Add', () => {
 
 describe('Add duration', () => {
   const a = dayjs('2020-10-01')
-  const duration = dayjs.duration(2, 'days')
-  expect(a.add(duration).format('YYYY-MM-DD')).toBe('2020-10-03')
+  const days = dayjs.duration(2, 'days')
+  expect(a.add(days).format('YYYY-MM-DD')).toBe('2020-10-03')
 })
 
 describe('Subtract', () => {


### PR DESCRIPTION
Fixes #1093

Now, once you've added the `Duration` plugin, you can 
```js
const d = dayjs('2020-10-01');
const days = dayjs.duration(2, 'days');
d.add(days).format('YYYY-MM-DD')); // 2020-10-03
```