### PR TITLE
fix: de-locale for relativeTime, and added unit-tests

### DIFF
--- a/src/locale/de.js
+++ b/src/locale/de.js
@@ -17,7 +17,7 @@ const texts = {
   yy: ['%d Jahre', '%d Jahren']
 }
 
-function relativeTimeFormatter(number, withoutSuffix, key, isFuture) {
+function relativeTimeFormatter(number, withoutSuffix, key) {
   let l = texts[key]
   if (Array.isArray(l)) {
     l = l[withoutSuffix ? 0 : 1]

--- a/src/locale/de.js
+++ b/src/locale/de.js
@@ -2,8 +2,6 @@
 import dayjs from 'dayjs'
 
 const texts = {
-  future: 'in %s',
-  past: 'vor %s',
   s: 'ein paar Sekunden',
   m: ['eine Minute', 'einer Minute'],
   mm: '%d Minuten',

--- a/src/locale/de.js
+++ b/src/locale/de.js
@@ -1,6 +1,30 @@
 // German [de]
 import dayjs from 'dayjs'
 
+const texts = {
+  future: 'in %s',
+  past: 'vor %s',
+  s: 'ein paar Sekunden',
+  m: ['eine Minute', 'einer Minute'],
+  mm: '%d Minuten',
+  h: ['eine Stunde', 'einer Stunde'],
+  hh: '%d Stunden',
+  d: ['ein Tag', 'einem Tag'],
+  dd: ['%d Tage', '%d Tagen'],
+  M: ['ein Monat', 'einem Monat'],
+  MM: ['%d Monate', '%d Monaten'],
+  y: ['ein Jahr', 'einem Jahr'],
+  yy: ['%d Jahre', '%d Jahren']
+}
+
+function relativeTimeFormatter(number, withoutSuffix, key, isFuture) {
+  let l = texts[key]
+  if (Array.isArray(l)) {
+    l = l[withoutSuffix ? 0 : 1]
+  }
+  return l.replace('%d', number)
+}
+
 const locale = {
   name: 'de',
   weekdays: 'Sonntag_Montag_Dienstag_Mittwoch_Donnerstag_Freitag_Samstag'.split('_'),
@@ -21,17 +45,17 @@ const locale = {
   relativeTime: {
     future: 'in %s',
     past: 'vor %s',
-    s: 'wenigen Sekunden',
-    m: 'einer Minute',
-    mm: '%d Minuten',
-    h: 'einer Stunde',
-    hh: '%d Stunden',
-    d: 'einem Tag',
-    dd: '%d Tagen',
-    M: 'einem Monat',
-    MM: '%d Monaten',
-    y: 'einem Jahr',
-    yy: '%d Jahren'
+    s: relativeTimeFormatter,
+    m: relativeTimeFormatter,
+    mm: relativeTimeFormatter,
+    h: relativeTimeFormatter,
+    hh: relativeTimeFormatter,
+    d: relativeTimeFormatter,
+    dd: relativeTimeFormatter,
+    M: relativeTimeFormatter,
+    MM: relativeTimeFormatter,
+    y: relativeTimeFormatter,
+    yy: relativeTimeFormatter
   }
 }
 

--- a/test/locale/de.test.js
+++ b/test/locale/de.test.js
@@ -1,0 +1,79 @@
+import MockDate from 'mockdate'
+import moment from 'moment'
+import dayjs from '../../src'
+import relativeTime from '../../src/plugin/relativeTime'
+import '../../src/locale/de'
+
+dayjs.extend(relativeTime)
+
+beforeEach(() => {
+  MockDate.set(new Date())
+})
+
+afterEach(() => {
+  MockDate.reset()
+})
+
+it('German locale relative time in past and future with suffix', () => {
+  const cases = [
+    [1, 's', 'in ein paar Sekunden'],
+    [-1, 's', 'vor ein paar Sekunden'],
+    [1, 'm', 'in einer Minute'],
+    [-1, 'm', 'vor einer Minute'],
+    [1, 'h', 'in einer Stunde'],
+    [-1, 'h', 'vor einer Stunde'],
+    [1, 'd', 'in einem Tag'],
+    [-1, 'd', 'vor einem Tag'],
+    [1, 'M', 'in einem Monat'],
+    [-1, 'M', 'vor einem Monat'],
+    [2, 'd', 'in 2 Tagen'],
+    [-2, 'd', 'vor 2 Tagen'],
+    [10, 'd', 'in 10 Tagen'],
+    [-10, 'd', 'vor 10 Tagen'],
+    [6, 'm', 'in 6 Minuten'],
+    [-6, 'm', 'vor 6 Minuten'],
+    [5, 'h', 'in 5 Stunden'],
+    [-5, 'h', 'vor 5 Stunden'],
+    [3, 'M', 'in 3 Monaten'],
+    [-3, 'M', 'vor 3 Monaten'],
+    [4, 'y', 'in 4 Jahren'],
+    [-4, 'y', 'vor 4 Jahren']
+  ]
+  cases.forEach((c) => {
+    expect(dayjs().add(c[0], c[1]).locale('de').fromNow())
+      .toBe(c[2])
+    expect(dayjs().add(c[0], c[1]).locale('de').fromNow())
+      .toBe(moment().add(c[0], c[1]).locale('de').fromNow())
+  })
+})
+
+it('German locale relative time in past and future without suffix', () => {
+  const cases = [
+    [1, 's', 'ein paar Sekunden'],
+    [-1, 's', 'ein paar Sekunden'],
+    [1, 'm', 'eine Minute'],
+    [-1, 'm', 'eine Minute'],
+    [1, 'h', 'eine Stunde'],
+    [-1, 'h', 'eine Stunde'],
+    [1, 'd', 'ein Tag'],
+    [-1, 'd', 'ein Tag'],
+    [2, 'd', '2 Tage'],
+    [-2, 'd', '2 Tage'],
+    [10, 'd', '10 Tage'],
+    [-10, 'd', '10 Tage'],
+    [6, 'm', '6 Minuten'],
+    [-6, 'm', '6 Minuten'],
+    [5, 'h', '5 Stunden'],
+    [-5, 'h', '5 Stunden'],
+    [3, 'M', '3 Monate'],
+    [-3, 'M', '3 Monate'],
+    [4, 'y', '4 Jahre'],
+    [-4, 'y', '4 Jahre']
+  ]
+  cases.forEach((c) => {
+    expect(dayjs().add(c[0], c[1]).locale('de').fromNow(true))
+      .toBe(c[2])
+    expect(dayjs().add(c[0], c[1]).locale('de').fromNow(true))
+      .toBe(moment().add(c[0], c[1]).locale('de').fromNow(true))
+  })
+})


### PR DESCRIPTION
I've fixed the relativeTime output for the 'de'-locale when withoutSuffix is set. Also added a unit-test that checks the results in absolute and against moment.