### PR TITLE
Update da.js

### DIFF
--- a/src/locale/da.js
+++ b/src/locale/da.js
@@ -13,7 +13,7 @@ const locale = {
   formats: {
     LT: 'HH:mm',
     LTS: 'HH:mm:ss',
-    L: 'DD.MM.YYYY',
+    L: 'DD-MM-YYYY',
     LL: 'D. MMMM YYYY',
     LLL: 'D. MMMM YYYY HH:mm',
     LLLL: 'dddd [d.] D. MMMM YYYY [kl.] HH:mm'


### PR DESCRIPTION
Danish date formats are using hyphens rather than dots...