### PR TITLE
Fix issues with adding/subtracting durations from Dayjs objects

### DIFF
--- a/src/plugin/duration/index.js
+++ b/src/plugin/duration/index.js
@@ -180,17 +180,12 @@ export default (option, Dayjs, dayjs) => {
 
   const oldAdd = Dayjs.prototype.add
   const oldSubtract = Dayjs.prototype.subtract
-  const transformArgs = (value, units) => {
-    if (isDuration(value)) {
-      value = value.asMilliseconds()
-      units = 'ms'
-    }
-    return [value, units]
+  Dayjs.prototype.add = function (value, unit) {
+    if (isDuration(value)) value = value.asMilliseconds()
+    return oldAdd.bind(this)(value, unit)
   }
-  Dayjs.prototype.add = function (value, units) {
-    return oldAdd.apply(this, transformArgs(value, units))
-  }
-  Dayjs.prototype.subtract = function (value, units) {
-    return oldSubtract.apply(this, transformArgs(value, units))
+  Dayjs.prototype.subtract = function (value, unit) {
+    if (isDuration(value)) value = value.asMilliseconds()
+    return oldSubtract.bind(this)(value, unit)
   }
 }

--- a/src/plugin/duration/index.js
+++ b/src/plugin/duration/index.js
@@ -179,11 +179,18 @@ export default (option, Dayjs, dayjs) => {
   dayjs.isDuration = isDuration
 
   const oldAdd = Dayjs.prototype.add
-  Dayjs.prototype.add = function (addition, units) {
-    if (isDuration(addition)) {
-      addition = addition.asMilliseconds()
+  const oldSubtract = Dayjs.prototype.subtract
+  const transformArgs = (value, units) => {
+    if (isDuration(value)) {
+      value = value.asMilliseconds()
       units = 'ms'
     }
-    return oldAdd.bind(this)(addition, units)
+    return [value, units]
+  }
+  Dayjs.prototype.add = function (value, units) {
+    return oldAdd.apply(this, transformArgs(value, units))
+  }
+  Dayjs.prototype.subtract = function (value, units) {
+    return oldSubtract.apply(this, transformArgs(value, units))
   }
 }

--- a/test/plugin/duration.test.js
+++ b/test/plugin/duration.test.js
@@ -139,7 +139,7 @@ describe('Add', () => {
   expect(a.add({ days: 5 }).days()).toBe(6)
 })
 
-describe('Add duration', () => {
+test('Add duration', () => {
   const a = dayjs('2020-10-01')
   const days = dayjs.duration(2, 'days')
   expect(a.add(days).format('YYYY-MM-DD')).toBe('2020-10-03')
@@ -151,6 +151,11 @@ describe('Subtract', () => {
   expect(a.subtract(b).days()).toBe(1)
 })
 
+test('Subtract duration', () => {
+  const a = dayjs('2020-10-20')
+  const days = dayjs.duration(2, 'days')
+  expect(a.subtract(days).format('YYYY-MM-DD')).toBe('2020-10-18')
+})
 
 describe('Seconds', () => {
   expect(dayjs.duration(500).seconds()).toBe(0)

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -222,7 +222,7 @@ declare namespace dayjs {
      * ```
      * dayjs().add(7, 'day')// => Dayjs
      * ```
-     * Units are case insensitive, support plural and short forms, and default to 'ms' if not supplied.
+     * Units are case insensitive, and support plural and short forms.
      *
      * Docs: https://day.js.org/docs/en/manipulate/add
      */
@@ -232,7 +232,7 @@ declare namespace dayjs {
      * ```
      * dayjs().subtract(7, 'year')// => Dayjs
      * ```
-     * Units are case insensitive, support plural and short forms, and default to 'ms' if not supplied.
+     * Units are case insensitive, and support plural and short forms.
      *
      * Docs: https://day.js.org/docs/en/manipulate/subtract
      */

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -222,21 +222,21 @@ declare namespace dayjs {
      * ```
      * dayjs().add(7, 'day')// => Dayjs
      * ```
-     * Units are case insensitive, and support plural and short forms.
+     * Units are case insensitive, support plural and short forms, and default to 'ms' if not supplied.
      *
      * Docs: https://day.js.org/docs/en/manipulate/add
      */
-    add(value: number, unit: OpUnitType): Dayjs
+    add(value: number, unit?: OpUnitType): Dayjs
     /**
      * Returns a cloned Day.js object with a specified amount of time subtracted.
      * ```
      * dayjs().subtract(7, 'year')// => Dayjs
      * ```
-     * Units are case insensitive, and support plural and short forms.
+     * Units are case insensitive, support plural and short forms, and default to 'ms' if not supplied.
      *
      * Docs: https://day.js.org/docs/en/manipulate/subtract
      */
-    subtract(value: number, unit: OpUnitType): Dayjs
+    subtract(value: number, unit?: OpUnitType): Dayjs
     /**
      * Returns a cloned Day.js object and set it to the start of a unit of time.
      * ```

--- a/types/plugin/duration.d.ts
+++ b/types/plugin/duration.d.ts
@@ -56,6 +56,11 @@ declare namespace plugin {
 }
 
 declare module 'dayjs' {
+  interface Dayjs {
+    add(value: plugin.Duration): Dayjs
+    subtract(value: plugin.Duration): Dayjs
+  }
+
   export function duration(input?: plugin.DurationInputType , unit?: string): plugin.Duration
   export function isDuration(d: any): d is plugin.Duration
 }


### PR DESCRIPTION
In #1099 support was added for passing in a duration object to `add()` or `subtract()`, which is awesome. I ran across a few issues when using it. This PR:

- adds support for `subtract(duration)` (changelog thinks this was part of #1099, but it wasn't)
- adds typescript type signatures for `add(duration)` and `subtract(duration)`

Also missing are docs for this feature, though that looks like that should be done in the [website repo](https://github.com/dayjs/dayjs-website) so not included in this PR.

Thanks a ton for dayjs!