### PR TITLE
Update index.js: Changed assignment of "this.$L" in "Dayjs" constructor

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -76,7 +76,7 @@ const parseDate = (cfg) => {
 
 class Dayjs {
   constructor(cfg) {
-    this.$L = this.$L || parseLocale(cfg.locale, null, true)
+    this.$L = parseLocale(cfg.locale, null, true)
     this.parse(cfg) // for plugin
   }
 


### PR DESCRIPTION
Hello,

In the constructor of the Dayjs class, I changed the line:
`this.$L = this.$L || parseLocale(cfg.locale, null, true)` to
`    this.$L = parseLocale(cfg.locale, null, true)`
because `this.$L` is undefined at the time of assignment and the right operand of the OR-operation will then always set `this.$L`.

Hope it can save you some bytes!

Kind regards,
Florian