### PR TITLE
fix: isoWeek plugin type

### DIFF
--- a/types/plugin/isoWeek.d.ts
+++ b/types/plugin/isoWeek.d.ts
@@ -1,9 +1,9 @@
-import { PluginFunc, UnitType, ConfigType } from 'dayjs'
+import { PluginFunc, OpUnitType, ConfigType } from 'dayjs'
 
 declare const plugin: PluginFunc
 export = plugin
 
-type ISOUnitType = UnitType | 'isoWeek';
+type ISOUnitType = OpUnitType | 'isoWeek';
 
 declare module 'dayjs' {
   interface Dayjs {


### PR DESCRIPTION
Currently isoWeek plugin is excluding `week` from its units because it's extending from `UnitType` instead of `OpUnitType`. This raises typescript errors if the unit is of type `"isoWeek" | "week"` 

```ts
const weekFormat = foo ? 'isoWeek' : 'week';
const weekStart = date.startOf('month').startOf(weekFormat);
```

```
[tsserver 2769] [E] No overload matches this call.
   Overload 1 of 2, '(unit: ISOUnitType): Dayjs', gave the following error.
     Argument of type '"isoWeek" | "week"' is not assignable to parameter of type 'ISOUnitType'.
       Type '"week"' is not assignable to type 'ISOUnitType'.
   Overload 2 of 2, '(unit: OpUnitType): Dayjs', gave the following error.
     Argument of type '"isoWeek" | "week"' is not assignable to parameter of type 'OpUnitType'.
       Type '"isoWeek"' is not assignable to type 'OpUnitType'.
```