### PR TITLE
dox: fix travis-ci build link

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ English | [简体中文](./docs/zh-cn/README.zh-CN.md) | [日本語](./docs/ja/R
             alt="Gzip Size"></a>
     <a href="https://www.npmjs.com/package/dayjs"><img src="https://img.shields.io/npm/v/dayjs.svg?style=flat-square&colorB=51C838"
                                                        alt="NPM Version"></a>
-    <a href="https://travis-ci.org/iamkun/dayjs"><img
+    <a href="https://travis-ci.com/iamkun/dayjs"><img
             src="https://img.shields.io/travis/iamkun/dayjs/master.svg?style=flat-square" alt="Build Status"></a>
     <a href="https://codecov.io/gh/iamkun/dayjs"><img
             src="https://img.shields.io/codecov/c/github/iamkun/dayjs/master.svg?style=flat-square" alt="Codecov"></a>


### PR DESCRIPTION
travis-ci.org will be closed down completely on December 31st, 2020 https://mailchi.mp/3d439eeb1098/travis-ciorg-is-moving-to-travis-cicom