### PR TITLE
feat: #965 add duration.format()

### DIFF
--- a/src/constant.js
+++ b/src/constant.js
@@ -27,4 +27,4 @@ export const INVALID_DATE_STRING = 'Invalid Date'
 
 // regex
 export const REGEX_PARSE = /^(\d{4})[-/]?(\d{1,2})?[-/]?(\d{0,2})[^0-9]*(\d{1,2})?:?(\d{1,2})?:?(\d{1,2})?.?(\d+)?$/
-export const REGEX_FORMAT = /\[([^\]]+)]|Y{2,4}|M{1,4}|D{1,2}|d{1,4}|H{1,2}|h{1,2}|a|A|m{1,2}|s{1,2}|Z{1,2}|SSS/g
+export const REGEX_FORMAT = /\[([^\]]+)]|Y{1,4}|M{1,4}|D{1,2}|d{1,4}|H{1,2}|h{1,2}|a|A|m{1,2}|s{1,2}|Z{1,2}|SSS/g

--- a/src/locale/lv.js
+++ b/src/locale/lv.js
@@ -17,6 +17,21 @@ const locale = {
     LL: 'YYYY. [gada] D. MMMM',
     LLL: 'YYYY. [gada] D. MMMM, HH:mm',
     LLLL: 'YYYY. [gada] D. MMMM, dddd, HH:mm'
+  },
+  relativeTime: {
+    future: 'pēc %s',
+    past: 'pirms %s',
+    s: 'dažām sekundēm',
+    m: 'minūtes',
+    mm: '%d minūtēm',
+    h: 'stundas',
+    hh: '%d stundām',
+    d: 'dienas',
+    dd: '%d dienām',
+    M: 'mēneša',
+    MM: '%d mēnešiem',
+    y: 'gada',
+    yy: '%d gadiem'
   }
 }
 

--- a/src/plugin/duration/index.js
+++ b/src/plugin/duration/index.js
@@ -1,4 +1,4 @@
-import { MILLISECONDS_A_DAY, MILLISECONDS_A_HOUR, MILLISECONDS_A_MINUTE, MILLISECONDS_A_SECOND, MILLISECONDS_A_WEEK } from '../../constant'
+import { MILLISECONDS_A_DAY, MILLISECONDS_A_HOUR, MILLISECONDS_A_MINUTE, MILLISECONDS_A_SECOND, MILLISECONDS_A_WEEK, REGEX_FORMAT } from '../../constant'
 
 const MILLISECONDS_A_YEAR = MILLISECONDS_A_DAY * 365
 const MILLISECONDS_A_MONTH = MILLISECONDS_A_DAY * 30
@@ -103,6 +103,27 @@ class Duration {
 
   toJSON() {
     return this.toISOString()
+  }
+
+  format(formatStr) {
+    const str = formatStr || 'YYYY-MM-DDTHH:mm:ss'
+    const matches = {
+      Y: this.$d.years,
+      YY: $u.s(this.$d.years, 2, '0'),
+      YYYY: $u.s(this.$d.years, 4, '0'),
+      M: this.$d.months,
+      MM: $u.s(this.$d.months, 2, '0'),
+      D: this.$d.days,
+      DD: $u.s(this.$d.days, 2, '0'),
+      H: this.$d.hours,
+      HH: $u.s(this.$d.hours, 2, '0'),
+      m: this.$d.minutes,
+      mm: $u.s(this.$d.minutes, 2, '0'),
+      s: this.$d.seconds,
+      ss: $u.s(this.$d.seconds, 2, '0'),
+      SSS: $u.s(this.$d.milliseconds, 3, '0')
+    }
+    return str.replace(REGEX_FORMAT, (match, $1) => $1 || String(matches[match]))
   }
 
   as(unit) {

--- a/test/plugin/duration.test.js
+++ b/test/plugin/duration.test.js
@@ -208,3 +208,27 @@ describe('prettyUnit', () => {
     m: 12
   }).toISOString()).toBe('P12MT12M')
 })
+
+describe('Format', () => {
+  test('no formatStr', () => {
+    const d = dayjs.duration(15, 'seconds')
+      .add(13, 'hours')
+      .add(35, 'minutes')
+      .add(16, 'days')
+      .add(10, 'months')
+      .add(22, 'years')
+    expect(d.format()).toBe('0022-10-16T13:35:15')
+  })
+
+  test('with formatStr for all tokens', () => {
+    const d = dayjs.duration(1, 'seconds')
+      .add(8, 'hours')
+      .add(5, 'minutes')
+      .add(6, 'days')
+      .add(9, 'months')
+      .add(2, 'years')
+      .add(10, 'milliseconds')
+    expect(d.format('Y/YY.YYYYTESTM:MM:D:DD:H:HH:m:mm:s:ss:SSS'))
+      .toBe('2/02.0002TEST9:09:6:06:8:08:5:05:1:01:010')
+  })
+})

--- a/types/plugin/duration.d.ts
+++ b/types/plugin/duration.d.ts
@@ -51,6 +51,8 @@ declare namespace plugin {
 
     toISOString(): string
 
+    format(formatStr?: string): string
+
     locale(locale: string): Duration
   }
 }


### PR DESCRIPTION
Heya! This should close #965. Key things to note:
* Is it okay to change REGEX_FORMAT to accept singular Ys? From what I've seen in the code in `src/index.js`, it seems like the original .format() ignores regex matches which are not in the `const matches = { ... }` variable, so this should be safe to do.
* Single Y would be very useful, because you don't often display durations which has double-digit years. So you can do `dayjs.duration(15, 'years').format('Y years has passed') === '15 years has passed'`

Also, difference between the original `dayjs.format()` and this format:
* No 'A'/'a' token (because you can't reason about meridians in durations)
* No 'dddd' token
* No 'ZZ' token

Not sure why commit 6545739 got dragged along as a change in the diff, but doesn't seem like any files are explicitly changed after I resync'd with upstream, so...