### PR TITLE
Easier Contributions.

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,0 +1,2 @@
+tasks:
+  - init: npm install && npm run build

--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ English | [简体中文](./docs/zh-cn/README.zh-CN.md) | [日本語](./docs/ja/R
             src="https://img.shields.io/codecov/c/github/iamkun/dayjs/master.svg?style=flat-square" alt="Codecov"></a>
     <a href="https://github.com/iamkun/dayjs/blob/master/LICENSE"><img
             src="https://img.shields.io/badge/license-MIT-brightgreen.svg?style=flat-square" alt="License"></a>
+    <a href="https://gitpod.io/from-referrer/"><img 
+            src="https://img.shields.io/badge/Gitpod-Ready--to--Code-blue?style=flat-square&logo=gitpod" alt="Gitpod Ready-to-Code"></a>
     <br>
     <a href="https://saucelabs.com/u/dayjs">
         <img width="750" src="https://user-images.githubusercontent.com/17680888/40040137-8e3323a6-584b-11e8-9dba-bbe577ee8a7b.png" alt="Sauce Test Status">


### PR DESCRIPTION
Hi.

I work for Gitpod. This PR adds gitpod config to the repo to make contributions easier for newcomers i.e with a single click it will launch a workspace and automatically:

- clone the `dayjs` repo.
- install the dependencies.
- run `npm run build`.

This can be helpful for beginners i.e they can start coding instantly without setting anything up.

You can give it a try on my fork of the repo via the following link:

https://gitpod.io/#https://github.com/nisarhassan12/dayjs

This is how it looks:

![image](https://user-images.githubusercontent.com/46004116/99149853-5fe7e800-26b2-11eb-8194-b25f0848d489.png)

