### PR TITLE
Add type definition for offsetName

### DIFF
--- a/types/plugin/timezone.d.ts
+++ b/types/plugin/timezone.d.ts
@@ -6,6 +6,7 @@ export = plugin
 declare module 'dayjs' {
   interface Dayjs {
     tz(timezone?: string, keepLocalTime?: boolean): Dayjs
+    offsetName(type?: 'short' | 'long'): string | undefined
   }
 
   interface DayjsTimezone {


### PR DESCRIPTION
The `offsetName` method for the timezone plugin was added in 1.9.0, but it's not in the TypeScript definitions.  This adds it.