### PR TITLE
Fix startOf/endOf behavior with timezone

### DIFF
--- a/src/plugin/timezone/index.js
+++ b/src/plugin/timezone/index.js
@@ -114,6 +114,17 @@ export default (o, c, d) => {
     return result && result.value
   }
 
+  const oldStartOf = proto.startOf
+  proto.startOf = function (units, startOf) {
+    if (!this.$x || !this.$x.$timezone) {
+      return oldStartOf.call(this, units, startOf)
+    }
+
+    const withoutTz = d(this.format('YYYY-MM-DD HH:mm:ss:SSS'))
+    const startOfWithoutTz = oldStartOf.call(withoutTz, units, startOf)
+    return startOfWithoutTz.tz(this.$x.$timezone, true)
+  }
+
   d.tz = function (input, arg1, arg2) {
     const parseFormat = arg2 && arg1
     const timezone = arg2 || arg1 || defaultTimezone

--- a/test/plugin/timezone.test.js
+++ b/test/plugin/timezone.test.js
@@ -290,3 +290,17 @@ describe('CustomPraseFormat', () => {
     expect(dayjs.tz('10/15/2020 12:30', 'MM/DD/YYYY HH:mm', DEN).unix()).toBe(result)
   })
 })
+
+describe('startOf and endOf', () => {
+  it('corrects for timezone offset in startOf', () => {
+    const originalDay = dayjs.tz('2010-01-01 00:00:00', NY)
+    const startOfDay = originalDay.startOf('day')
+    expect(startOfDay.valueOf()).toEqual(originalDay.valueOf())
+  })
+
+  it('corrects for timezone offset in endOf', () => {
+    const originalDay = dayjs.tz('2009-12-31 23:59:59.999', NY)
+    const endOfDay = originalDay.endOf('day')
+    expect(endOfDay.valueOf()).toEqual(originalDay.valueOf())
+  })
+})

--- a/test/timezone.test.js
+++ b/test/timezone.test.js
@@ -1,9 +1,11 @@
 import MockDate from 'mockdate'
 import moment from 'moment'
 import dayjs from '../src'
+import timezone from '../src/plugin/timezone'
 import utc from '../src/plugin/utc'
 
 dayjs.extend(utc)
+dayjs.extend(timezone)
 
 beforeEach(() => {
   MockDate.set(new Date())


### PR DESCRIPTION
This fixes #1212.  Because the timezone plugin stores a `$d` value that's relative to the timezone of the dayjs instance, `startOf` and `endOf` need to ignore the absolute `$d` value and instead use the logical value in that time zone.

This overrides `startOf` to ignore the timezone of the instance, calculate the `startOf` value, then reapply the timezone while keeping local time.  This should also fix the behavior for `endOf` since it is actually calling `startOf` internally.