### PR TITLE
fix: better nil check on utils

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -43,7 +43,9 @@ const prettyUnit = (u) => {
   return special[u] || String(u || '').toLowerCase().replace(/s$/, '')
 }
 
-const isUndefined = s => s === undefined
+const isNil = val => {
+  return (typeof === 'string' && !Boolean(val.length) || val === undefined || val === null;
+}
 
 export default {
   s: padStart,
@@ -51,5 +53,5 @@ export default {
   m: monthDiff,
   a: absFloor,
   p: prettyUnit,
-  u: isUndefined
+  u: isNil
 }


### PR DESCRIPTION
When you try to pass an empty string for the constructor an obtrusive `Invalid date` error is showing.
Something like that doesn't work: `dayjs('').format(YYYY-MM-DD')` and breaks the system.

What I did is just check if a string is an empty string or is undefined or null.