### PR TITLE
feat: add ordinal to localeData plugin

### DIFF
--- a/src/plugin/localeData/index.js
+++ b/src/plugin/localeData/index.js
@@ -29,7 +29,8 @@ export default (o, c, dayjs) => { // locale needed later
       weekdaysShort: instance =>
         (instance ? instance.format('ddd') : getShort(this, 'weekdaysShort', 'weekdays', 3)),
       longDateFormat: format => getLongDateFormat(this.$locale(), format),
-      meridiem: this.$locale().meridiem
+      meridiem: this.$locale().meridiem,
+      ordinal: this.$locale().ordinal
     }
   }
   proto.localeData = function () {
@@ -46,7 +47,8 @@ export default (o, c, dayjs) => { // locale needed later
       months: () => dayjs.months(),
       monthsShort: () => dayjs.monthsShort(),
       longDateFormat: format => getLongDateFormat(localeObject, format),
-      meridiem: localeObject.meridiem
+      meridiem: localeObject.meridiem,
+      ordinal: localeObject.ordinal
     }
   }
 

--- a/test/plugin/localeData.test.js
+++ b/test/plugin/localeData.test.js
@@ -110,3 +110,10 @@ it('meridiem', () => {
   expect(typeof dayjs().localeData().meridiem).toEqual('function')
   dayjs.locale('en')
 })
+
+it('ordinal', () => {
+  dayjs.locale('zh-cn')
+  expect(typeof dayjs.localeData().ordinal).toEqual('function')
+  expect(typeof dayjs().localeData().ordinal).toEqual('function')
+  dayjs.locale('en')
+})


### PR DESCRIPTION
Moment.js exposes the ordinal function in [localeData][1].

Let's add ordinal to the localeData plugin as well.

[1]: https://momentjs.com/docs/#/i18n/locale-data/