### PR TITLE
Update zh-cn.js

### DIFF
--- a/src/locale/zh-cn.js
+++ b/src/locale/zh-cn.js
@@ -51,9 +51,9 @@ const locale = {
       return '凌晨'
     } else if (hm < 900) {
       return '早上'
-    } else if (hm < 1130) {
+    } else if (hm < 1100) {
       return '上午'
-    } else if (hm < 1230) {
+    } else if (hm < 1300) {
       return '中午'
     } else if (hm < 1800) {
       return '下午'


### PR DESCRIPTION
Changed the definition of “中午”(noon), which is between 11am to 13pm, the lunch time. 
"中午“（noon） means exactly 12o'clock, or the time interval around 12 o'clock. The most common definition of "中午” for Chinese is 11am to 13pm. 