### PR TITLE
fix: Add format options for iso week and weekyear

### DIFF
--- a/docs/en/Plugin.md
+++ b/docs/en/Plugin.md
@@ -123,18 +123,21 @@ dayjs().format('Q Do k kk X x')
 
 List of added formats:
 
-| Format | Output                | Description                                           |
-| ------ | --------------------- | ----------------------------------------------------- |
-| `Q`    | 1-4                   | Quarter                                               |
-| `Do`   | 1st 2nd ... 31st      | Day of Month with ordinal                             |
-| `k`    | 1-24                  | The hour, beginning at 1                              |
-| `kk`   | 01-24                 | The hour, 2-digits, beginning at 1                    |
-| `X`    | 1360013296            | Unix Timestamp in second                              |
-| `x`    | 1360013296123         | Unix Timestamp in millisecond                         |
-| `w`    | 1 2 ... 52 53         | Week of year (depend: weekOfYear plugin)              |
-| `ww`   | 01 02 ... 52 53       | Week of year, 2-digits (depend: weekOfYear plugin)    |
-| `wo`   | 1st 2nd ... 52nd 53rd | Week of year with ordinal (depend: weekOfYear plugin) |
-| `gggg` | 2017                  | Week Year (depend: weekYear plugin)                   |
+| Format | Output                | Description                                                     |
+| ------ | --------------------- | --------------------------------------------------------------- |
+| `Q`    | 1-4                   | Quarter                                                         |
+| `Do`   | 1st 2nd ... 31st      | Day of Month with ordinal                                       |
+| `k`    | 1-24                  | The hour, beginning at 1                                        |
+| `kk`   | 01-24                 | The hour, 2-digits, beginning at 1                              |
+| `X`    | 1360013296            | Unix Timestamp in second                                        |
+| `x`    | 1360013296123         | Unix Timestamp in millisecond                                   |
+| `w`    | 1 2 ... 52 53         | Week of year (depend: weekOfYear plugin)                        |
+| `ww`   | 01 02 ... 52 53       | Week of year, 2-digits (depend: weekOfYear plugin)              |
+| `W`    | 1 2 ... 52 53         | ISO Week of year (depend: weekOfYear & isoWeek plugin)          |
+| `WW`   | 01 02 ... 52 53       | ISO Week of year, 2-digits (depend: weekOfYear & isoWeek plugin)|
+| `wo`   | 1st 2nd ... 52nd 53rd | Week of year with ordinal (depend: weekOfYear plugin)           |
+| `gggg` | 2017                  | Week Year (depend: weekYear plugin)                             |
+| `GGGG` | 2017                  | ISO Week Year (depend: weekYear & isoWeek plugin)               |
 
 ### LocalizedFormat
 

--- a/docs/es-es/Plugin.md
+++ b/docs/es-es/Plugin.md
@@ -131,10 +131,13 @@ Lista de formatos añadidos:
 | `kk`    | 01-24                 | Hora, con 2 dígitos, contando desde 1                 |
 | `X`     | 1360013296            | Tiempo Unix en segundos                               |
 | `x`     | 1360013296123         | Tiempo Unix en milisegundos                           |
-| `w`     | 1 2 ... 52 53         | Week of year (depend: weekOfYear plugin)              |
-| `ww`    | 01 02 ... 52 53       | Week of year, 2-digits (depend: weekOfYear plugin)    |
-| `wo`    | 1st 2nd ... 52nd 53rd | Week of year with ordinal (depend: weekOfYear plugin) |
-| `gggg`  | 2017                  | Week Year (depend: weekYear plugin)                   |
+| `w`    | 1 2 ... 52 53         | Week of year (depend: weekOfYear plugin)                        |
+| `ww`   | 01 02 ... 52 53       | Week of year, 2-digits (depend: weekOfYear plugin)              |
+| `W`    | 1 2 ... 52 53         | ISO Week of year (depend: weekOfYear & isoWeek plugin)          |
+| `WW`   | 01 02 ... 52 53       | ISO Week of year, 2-digits (depend: weekOfYear & isoWeek plugin)|
+| `wo`   | 1st 2nd ... 52nd 53rd | Week of year with ordinal (depend: weekOfYear plugin)           |
+| `gggg` | 2017                  | Week Year (depend: weekYear plugin)                             |
+| `GGGG` | 2017                  | ISO Week Year (depend: weekYear & isoWeek plugin)               |
 
 ### LocalizedFormat
 

--- a/docs/ja/Plugin.md
+++ b/docs/ja/Plugin.md
@@ -131,10 +131,13 @@ dayjs().format('Q Do k kk X x')
 | `kk`         | 01-24                 | 1 始まりで 2 桁の時間                                 |
 | `X`          | 1360013296            | Unix タイムスタンプ (秒)                              |
 | `x`          | 1360013296123         | Unix タイムスタンプ (ミリ秒)                          |
-| `w`          | 1 2 ... 52 53         | Week of year (depend: weekOfYear plugin)              |
-| `ww`         | 01 02 ... 52 53       | Week of year, 2-digits (depend: weekOfYear plugin)    |
-| `wo`         | 1st 2nd ... 52nd 53rd | Week of year with ordinal (depend: weekOfYear plugin) |
-| `gggg`       | 2017                  | Week Year (depend: weekYear plugin)                   |
+| `w`    | 1 2 ... 52 53         | Week of year (depend: weekOfYear plugin)                        |
+| `ww`   | 01 02 ... 52 53       | Week of year, 2-digits (depend: weekOfYear plugin)              |
+| `W`    | 1 2 ... 52 53         | ISO Week of year (depend: weekOfYear & isoWeek plugin)          |
+| `WW`   | 01 02 ... 52 53       | ISO Week of year, 2-digits (depend: weekOfYear & isoWeek plugin)|
+| `wo`   | 1st 2nd ... 52nd 53rd | Week of year with ordinal (depend: weekOfYear plugin)           |
+| `gggg` | 2017                  | Week Year (depend: weekYear plugin)                             |
+| `GGGG` | 2017                  | ISO Week Year (depend: weekYear & isoWeek plugin)               |
 
 ### LocalizedFormat
 

--- a/docs/ko/Plugin.md
+++ b/docs/ko/Plugin.md
@@ -131,10 +131,13 @@ dayjs().format('Q Do k kk X x')
 | `kk`   | 01-24                 | 시간, 2자리 표현, 1부터 시작                          |
 | `X`    | 1360013296            | 유닉스 타임스템프, 초                                 |
 | `x`    | 1360013296123         | 유닉스 타임스탬프, 밀리 초                            |
-| `w`    | 1 2 ... 52 53         | Week of year (depend: weekOfYear plugin)              |
-| `ww`   | 01 02 ... 52 53       | Week of year, 2-digits (depend: weekOfYear plugin)    |
-| `wo`   | 1st 2nd ... 52nd 53rd | Week of year with ordinal (depend: weekOfYear plugin) |
-| `gggg` | 2017                  | Week Year (depend: weekYear plugin)                   |
+| `w`    | 1 2 ... 52 53         | Week of year (depend: weekOfYear plugin)                        |
+| `ww`   | 01 02 ... 52 53       | Week of year, 2-digits (depend: weekOfYear plugin)              |
+| `W`    | 1 2 ... 52 53         | ISO Week of year (depend: weekOfYear & isoWeek plugin)          |
+| `WW`   | 01 02 ... 52 53       | ISO Week of year, 2-digits (depend: weekOfYear & isoWeek plugin)|
+| `wo`   | 1st 2nd ... 52nd 53rd | Week of year with ordinal (depend: weekOfYear plugin)           |
+| `gggg` | 2017                  | Week Year (depend: weekYear plugin)                             |
+| `GGGG` | 2017                  | ISO Week Year (depend: weekYear & isoWeek plugin)               |
 
 ### LocalizedFormat
 

--- a/docs/pt-br/Plugin.md
+++ b/docs/pt-br/Plugin.md
@@ -131,10 +131,13 @@ Lista de formatos adicionados:
 | `kk`    | 01-24                 | Hora, com 2 dígitos (começando do 1)                  |
 | `X`     | 1360013296            | Unix Timestamp em segundos                            |
 | `x`     | 1360013296123         | Unix Timestamp em milissegundos                       |
-| `w`     | 1 2 ... 52 53         | Week of year (depend: weekOfYear plugin)              |
-| `ww`    | 01 02 ... 52 53       | Week of year, 2-digits (depend: weekOfYear plugin)    |
-| `wo`    | 1st 2nd ... 52nd 53rd | Week of year with ordinal (depend: weekOfYear plugin) |
-| `gggg`  | 2017                  | Week Year (depend: weekYear plugin)                   |
+| `w`    | 1 2 ... 52 53         | Week of year (depend: weekOfYear plugin)                        |
+| `ww`   | 01 02 ... 52 53       | Week of year, 2-digits (depend: weekOfYear plugin)              |
+| `W`    | 1 2 ... 52 53         | ISO Week of year (depend: weekOfYear & isoWeek plugin)          |
+| `WW`   | 01 02 ... 52 53       | ISO Week of year, 2-digits (depend: weekOfYear & isoWeek plugin)|
+| `wo`   | 1st 2nd ... 52nd 53rd | Week of year with ordinal (depend: weekOfYear plugin)           |
+| `gggg` | 2017                  | Week Year (depend: weekYear plugin)                             |
+| `GGGG` | 2017                  | ISO Week Year (depend: weekYear & isoWeek plugin)               |
 
 ### LocalizedFormat
 

--- a/docs/zh-cn/Plugin.md
+++ b/docs/zh-cn/Plugin.md
@@ -132,8 +132,11 @@ dayjs().format('Q Do k kk X x')
 | `x`    | 1360013296123         | 毫秒单位的 Unix 时间戳                     |
 | `w`    | 1 2 ... 52 53         | 年中第几周 (依赖: weekOfYear 插件)         |
 | `ww`   | 01 02 ... 52 53       | 年中第几周，二位数 (依赖: weekOfYear 插件) |
+| `W`    | 1 2 ... 52 53         | ISO 年中第几周 (依赖: weekOfYear & isoWeek 插件)         |
+| `WW`   | 01 02 ... 52 53       | ISO 年中第几周，二位数 (依赖: weekOfYear & isoWeek 插件) |
 | `wo`   | 1st 2nd ... 52nd 53rd | 带序号的年中第几周 (依赖: weekOfYear 插件) |
 | `gggg` | 2017                  | 根据周计算的年份 (依赖: weekYear 插件)     |
+| `GGGG` | 2017                  | ISO 根据周计算的年份 (依赖: weekYear & isoWeek& isoWeek 插件)  |
 
 ### LocalizedFormat
 

--- a/src/plugin/advancedFormat/index.js
+++ b/src/plugin/advancedFormat/index.js
@@ -13,7 +13,7 @@ export default (o, c, d) => { // locale needed later
     const locale = this.$locale()
     const utils = this.$utils()
     const str = formatStr || FORMAT_DEFAULT
-    const result = str.replace(/\[([^\]]+)]|Q|wo|ww|w|zzz|z|gggg|Do|X|x|k{1,2}|S/g, (match) => {
+    const result = str.replace(/\[([^\]]+)]|Q|wo|ww|w|WW|W|zzz|z|gggg|GGGG|Do|X|x|k{1,2}|S/g, (match) => {
       switch (match) {
         case 'Q':
           return Math.ceil((this.$M + 1) / 3)
@@ -21,11 +21,16 @@ export default (o, c, d) => { // locale needed later
           return locale.ordinal(this.$D)
         case 'gggg':
           return this.weekYear()
+        case 'GGGG':
+          return this.isoWeekYear()
         case 'wo':
           return locale.ordinal(this.week(), 'W') // W for week
         case 'w':
         case 'ww':
           return utils.s(this.week(), match === 'w' ? 1 : 2, '0')
+        case 'W':
+        case 'WW':
+          return utils.s(this.isoWeek(), match === 'W' ? 1 : 2, '0')
         case 'k':
         case 'kk':
           return utils.s(String(this.$H === 0 ? 24 : this.$H), match === 'k' ? 1 : 2, '0')

--- a/test/plugin/advancedFormat.test.js
+++ b/test/plugin/advancedFormat.test.js
@@ -2,6 +2,7 @@ import MockDate from 'mockdate'
 import moment from 'moment'
 import dayjs from '../../src'
 import advancedFormat from '../../src/plugin/advancedFormat'
+import isoWeek from '../../src/plugin/isoWeek'
 import weekOfYear from '../../src/plugin/weekOfYear'
 import weekYear from '../../src/plugin/weekYear'
 import timezone from '../../src/plugin/timezone'
@@ -10,6 +11,7 @@ import '../../src/locale/zh-cn'
 
 dayjs.extend(utc)
 dayjs.extend(timezone)
+dayjs.extend(isoWeek)
 dayjs.extend(weekYear)
 dayjs.extend(weekOfYear)
 dayjs.extend(advancedFormat)
@@ -82,9 +84,27 @@ it('Format Week of Year wo', () => {
     .toBe(moment(d).locale('zh-cn').format('wo'))
 })
 
+it('Format Week of Year wo', () => {
+  const d = '2018-12-01'
+  expect(dayjs(d).format('wo')).toBe(moment(d).format('wo'))
+  expect(dayjs(d).locale('zh-cn').format('wo'))
+    .toBe(moment(d).locale('zh-cn').format('wo'))
+})
+
 it('Format Week Year gggg', () => {
   const d = '2018-12-31'
   expect(dayjs(d).format('gggg')).toBe(moment(d).format('gggg'))
+})
+
+it('Format Iso Week Year GGGG', () => {
+  const d = '2021-01-01'
+  expect(dayjs(d).format('GGGG')).toBe(moment(d).format('GGGG'))
+})
+
+it('Format Iso Week of Year', () => {
+  const d = '2021-01-01'
+  expect(dayjs(d).format('W')).toBe(moment(d).format('W'))
+  expect(dayjs(d).format('WW')).toBe(moment(d).format('WW'))
 })
 
 it('Format offsetName z zzz', () => {
@@ -99,6 +119,11 @@ it('Skips format strings inside brackets', () => {
   expect(dayjs().format('[Q]')).toBe('Q')
   expect(dayjs().format('[Do]')).toBe('Do')
   expect(dayjs().format('[gggg]')).toBe('gggg')
+  expect(dayjs().format('[GGGG]')).toBe('GGGG')
+  expect(dayjs().format('[w]')).toBe('w')
+  expect(dayjs().format('[ww]')).toBe('ww')
+  expect(dayjs().format('[W]')).toBe('W')
+  expect(dayjs().format('[WW]')).toBe('WW')
   expect(dayjs().format('[wo]')).toBe('wo')
   expect(dayjs().format('[k]')).toBe('k')
   expect(dayjs().format('[kk]')).toBe('kk')


### PR DESCRIPTION
Like moment.js - day.js should allow the format function to be compatible with iso weeks. and since isoweeks are a plugin already, we can just call it.


Input | Example | Description
-- | -- | --
gggg | 2014 | Locale week year
w ww | 1..53 | Locale week of year
GGGG | 2014 | ISO week year
W WW | 1..53 | ISO week of year