### PR TITLE
fix: remove module entry in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,6 @@
   "description": "2KB immutable date time library alternative to Moment.js with the same modern API ",
   "main": "dayjs.min.js",
   "types": "index.d.ts",
-  "module": "esm/index.js",
   "scripts": {
     "test": "TZ=Pacific/Auckland npm run test-tz && TZ=Europe/London npm run test-tz && TZ=America/Whitehorse npm run test-tz && npm run test-tz && jest",
     "test-tz": "date && jest test/timezone.test --coverage=false",


### PR DESCRIPTION
ref #1281 

This change in 1.10.1 add ES6 Module Support, package.json module point to "esm/index.js" (#1298) (f63375d)

really has an unexpected breaking change, and that's of course not what we want.

I am planning to revert this change in the next release 1.10.2 and delete the "module" entry.

Besides, maybe there's no need for Day.js to support ESM bundle, this would only introduce some conflict but no benefits in the tree shaking. A better way might be a separate npm package (like "dayjs-esm") to ship an ESM package.