### PR TITLE
fix: Significantly improve `Duration` types

### DIFF
--- a/test/plugin/duration.test.js
+++ b/test/plugin/duration.test.js
@@ -201,7 +201,7 @@ describe('Years', () => {
 describe('prettyUnit', () => {
   const d = dayjs.duration(2, 's')
   expect(d.toISOString()).toBe('PT2S')
-  expect(d.as('Second')).toBe(2)
+  expect(d.as('seconds')).toBe(2)
   expect(d.get('s')).toBe(2)
   expect(dayjs.duration({
     M: 12,

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -13,11 +13,11 @@ declare namespace dayjs {
 
   export type OptionType = { locale?: string, format?: string, utc?: boolean } | string | string[]
 
-  type UnitTypeShort = 'd' | 'M' | 'y' | 'h' | 'm' | 's' | 'ms'
+  export type UnitTypeShort = 'd' | 'M' | 'y' | 'h' | 'm' | 's' | 'ms'
 
-  type UnitTypeLong = 'millisecond' | 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year' | 'date'
+  export type UnitTypeLong = 'millisecond' | 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year' | 'date'
 
-  type UnitTypeLongPlural = 'milliseconds' | 'seconds' | 'minutes' | 'hours' | 'days' | 'months' | 'years' | 'dates'
+  export type UnitTypeLongPlural = 'milliseconds' | 'seconds' | 'minutes' | 'hours' | 'days' | 'months' | 'years' | 'dates'
   
   export type UnitType = UnitTypeLong | UnitTypeLongPlural | UnitTypeShort;
 

--- a/types/plugin/duration.d.ts
+++ b/types/plugin/duration.d.ts
@@ -1,15 +1,22 @@
 import { PluginFunc } from 'dayjs'
+import type { OpUnitType, UnitTypeLongPlural } from "../index";
 
 declare const plugin: PluginFunc
 export as namespace plugin;
 export = plugin
 
 declare namespace plugin {
-  type DurationInputType = string | number | object
-  type DurationAddType = number | object | Duration
+  type DurationUnitsObjectType = Partial<{
+    [unit in Exclude<UnitTypeLongPlural, "dates"> | "weeks"]: number
+  }>;
+  type DurationUnitType = Exclude<OpUnitType, "date" | "dates">
+  type CreateDurationType = 
+    & ((units: DurationUnitsObjectType) => Duration)
+    & ((time: number, unit?: DurationUnitType) => Duration)
+    & ((ISO_8601: string) => Duration)
 
   interface Duration {
-    new (input: DurationInputType, unit?: string, locale?: string): Duration
+    new (input: string | number | object, unit?: string, locale?: string): Duration
 
     clone(): Duration
 
@@ -39,13 +46,13 @@ declare namespace plugin {
     years(): number
     asYears(): number
 
-    as(unit: string): number
+    as(unit: DurationUnitType): number
 
-    get(unit: string): number
+    get(unit: DurationUnitType): number
 
-    add(input: DurationAddType, unit? : string): Duration
-
-    subtract(input: DurationAddType, unit? : string): Duration
+    add: CreateDurationType;
+    
+    subtract: CreateDurationType
 
     toJSON(): string
 
@@ -59,10 +66,13 @@ declare namespace plugin {
 
 declare module 'dayjs' {
   interface Dayjs {
-    add(value: plugin.Duration): Dayjs
-    subtract(value: plugin.Duration): Dayjs
+    add(duration: plugin.Duration): Dayjs
+    subtract(duration: plugin.Duration): Dayjs
   }
 
-  export function duration(input?: plugin.DurationInputType , unit?: string): plugin.Duration
+  /**
+   * @param time If unit is not present, time treated as number of milliseconds
+   */
+  export const duration: plugin.CreateDurationType;
   export function isDuration(d: any): d is plugin.Duration
 }

--- a/types/plugin/duration.d.ts
+++ b/types/plugin/duration.d.ts
@@ -11,7 +11,7 @@ declare namespace plugin {
   }>;
   type DurationUnitType = Exclude<OpUnitType, "date" | "dates">
   type CreateDurationType = 
-    & ((units: DurationUnitsObjectType) => Duration)
+    ((units: DurationUnitsObjectType) => Duration)
     & ((time: number, unit?: DurationUnitType) => Duration)
     & ((ISO_8601: string) => Duration)
 

--- a/types/plugin/duration.d.ts
+++ b/types/plugin/duration.d.ts
@@ -1,5 +1,5 @@
 import { PluginFunc } from 'dayjs'
-import type { OpUnitType, UnitTypeLongPlural } from "../index";
+import { OpUnitType, UnitTypeLongPlural } from "../index";
 
 declare const plugin: PluginFunc
 export as namespace plugin;


### PR DESCRIPTION
This PR improves [Duration plugin](https://day.js.org/docs/en/durations/durations) types.
## Why?
- Autocomplete:
<img width="602" alt="autocomplete" src="https://user-images.githubusercontent.com/46503702/104731589-fab18100-574c-11eb-8081-84b0d9195c9a.png">

- And for more strict checks (just compare):
<img width="365" alt="pr-1" src="https://user-images.githubusercontent.com/46503702/104732014-9a6f0f00-574d-11eb-9670-ba9e7cc6736f.png">
<img width="241" alt="pr-2" src="https://user-images.githubusercontent.com/46503702/104732018-9cd16900-574d-11eb-8b7a-b9f7565687f6.png">



## New types

```ts
// That's how computed type looks like
type plugin.DurationUnitsObjectType = {
    milliseconds?: number;
    seconds?: number;
    minutes?: number;
    hours?: number;
    days?: number;
    months?: number;
    years?: number;
    weeks?: number;
}
```
I also added `CreateDurationType` to reduce code duplication, so `duration()`, `duration.add()` and `duration.substract()` using the same function signature.
Other changes you can view in diff. Please, let me know if don't understand something. I can explain every line of code.

UPD: With this PR TypeScript users **can't** use functions `duration()`, `duration.add()` and `duration.substract()` without args any more. But I don't think it's a breaking change, because I can't find any example usage in docs for this. In this way we just get empty duration object.

P.S. It also would be good to update TypeScript in devDependencies to latest version.