### PR TITLE
customParseFormat: parse a string with underscore delimiter

### DIFF
--- a/src/plugin/customParseFormat/index.js
+++ b/src/plugin/customParseFormat/index.js
@@ -9,7 +9,7 @@ const match4 = /\d{4}/ // 0000 - 9999
 const match1to2 = /\d\d?/ // 0 - 99
 const matchSigned = /[+-]?\d+/ // -inf - inf
 const matchOffset = /[+-]\d\d:?(\d\d)?/ // +00:00 -00:00 +0000 or -0000 +00
-const matchWord = /\d*[^\s\d-:/()]+/ // Word
+const matchWord = /\d*[^\s\d-_:/()]+/ // Word
 
 let locale = {}
 

--- a/test/plugin/customParseFormat.test.js
+++ b/test/plugin/customParseFormat.test.js
@@ -338,3 +338,12 @@ describe('meridiem locale', () => {
     expect(dayjs(date, format, 'zh-cn').format(format2)).toBe(input)
   })
 })
+
+it('parse a string for MMM month format with underscore delimiter', () => {
+  const input = 'Jan_2021'
+  const format = 'MMM_YYYY'
+  expect(dayjs(input, format).valueOf()).toBe(moment(input, format).valueOf())
+  const input2 = '21_Jan_2021_123523'
+  const format2 = 'DD_MMM_YYYY_hhmmss'
+  expect(dayjs(input2, format2).valueOf()).toBe(moment(input2, format2).valueOf())
+})


### PR DESCRIPTION
This is a small fix to parse a string for MMM month format with underscore delimiters.

Was added support for next custom formats:

```js
dayjs('21_Dec_2021', 'DD_MMM_YYYY').isValid() // true

dayjs('21_Jan_2021_123523', 'DD_MMM_YYYY_hhmmss').isValid() // true
```