### PR TITLE
 fix: update Finnish [fi] locale yearStart config

### DIFF
--- a/src/locale/fi.js
+++ b/src/locale/fi.js
@@ -47,6 +47,7 @@ const locale = {
   monthsShort: 'tammi_helmi_maalis_huhti_touko_kesä_heinä_elo_syys_loka_marras_joulu'.split('_'),
   ordinal: n => `${n}.`,
   weekStart: 1,
+  yearStart: 4,
   relativeTime: {
     future: '%s päästä',
     past: '%s sitten',


### PR DESCRIPTION
The Finnish locale should have 2020-12-31 as week 53. According to https://en.wikipedia.org/wiki/Date_and_time_notation_in_Finland
"The week begins with a Monday and week 1 is the week containing the year's first Thursday"