### PR TITLE
Set Swedish [sv] locale to use ISO 8061 weeks

### DIFF
--- a/src/locale/sv.js
+++ b/src/locale/sv.js
@@ -9,6 +9,7 @@ const locale = {
   months: 'januari_februari_mars_april_maj_juni_juli_augusti_september_oktober_november_december'.split('_'),
   monthsShort: 'jan_feb_mar_apr_maj_jun_jul_aug_sep_okt_nov_dec'.split('_'),
   weekStart: 1,
+  yearStart: 4,
   ordinal: (n) => {
     const b = n % 10
     const o = (b === 1) || (b === 2) ? 'a' : 'e'


### PR DESCRIPTION
Sweden uses ISO 8061 weeks, i.e. they follow the convention that the week that contains Jan 4th is the first week of the year.

Followed the example of #1378 