### PR TITLE
fix: Add ordinal support for Slovenian [sl]

### DIFF
--- a/src/locale/sl.js
+++ b/src/locale/sl.js
@@ -9,7 +9,7 @@ const locale = {
   weekdaysShort: 'ned._pon._tor._sre._čet._pet._sob.'.split('_'),
   monthsShort: 'jan._feb._mar._apr._maj._jun._jul._avg._sep._okt._nov._dec.'.split('_'),
   weekdaysMin: 'ne_po_to_sr_če_pe_so'.split('_'),
-  ordinal: n => n,
+  ordinal: n => `${n}.`,
   formats: {
     LT: 'H:mm',
     LTS: 'H:mm:ss',


### PR DESCRIPTION
This implements Slovenian ordinals.

The language has genders and cases, but in short form just adding a dot at the end is how it's typically done, and really the only option here.