### PR TITLE
Change string to number in duration object

### DIFF
--- a/src/plugin/duration/index.js
+++ b/src/plugin/duration/index.js
@@ -79,14 +79,17 @@ class Duration {
     if (typeof input === 'string') {
       const d = input.match(durationRegex)
       if (d) {
-        this.$d.years = Number(d[2])
-        this.$d.months = Number(d[3])
-        this.$d.weeks = Number(d[4])
-        this.$d.days = Number(d[5])
-        this.$d.hours = Number(d[6])
-        this.$d.minutes = Number(d[7])
-        this.$d.seconds = Number(d[8])
-
+        const [,, ...properties] = d
+        const numberD = properties.map(value => Number(value));
+        [
+          this.$d.years,
+          this.$d.months,
+          this.$d.weeks,
+          this.$d.days,
+          this.$d.hours,
+          this.$d.minutes,
+          this.$d.seconds
+        ] = numberD
         this.calMilliseconds()
         return this
       }

--- a/src/plugin/duration/index.js
+++ b/src/plugin/duration/index.js
@@ -79,15 +79,14 @@ class Duration {
     if (typeof input === 'string') {
       const d = input.match(durationRegex)
       if (d) {
-        [,,
-          this.$d.years,
-          this.$d.months,
-          this.$d.weeks,
-          this.$d.days,
-          this.$d.hours,
-          this.$d.minutes,
-          this.$d.seconds
-        ] = d
+        this.$d.years = Number(d[2])
+        this.$d.months = Number(d[3])
+        this.$d.weeks = Number(d[4])
+        this.$d.days = Number(d[5])
+        this.$d.hours = Number(d[6])
+        this.$d.minutes = Number(d[7])
+        this.$d.seconds = Number(d[8])
+
         this.calMilliseconds()
         return this
       }

--- a/src/plugin/duration/index.js
+++ b/src/plugin/duration/index.js
@@ -79,7 +79,7 @@ class Duration {
     if (typeof input === 'string') {
       const d = input.match(durationRegex)
       if (d) {
-        const [,, ...properties] = d
+        const properties = d.slice(2)
         const numberD = properties.map(value => Number(value));
         [
           this.$d.years,


### PR DESCRIPTION
Fixes #1389 

I based on `parseFromMilliseconds` function.

I noticed there are already two failing tests:
```
 ● Convert › convert to target time

    expect(received).toBe(expected) // Object.is equality
    
    Expected value to be:
      1401624000000
    Received:
      1401620400000

```