### PR TITLE
[Feauture] Support string arguments to `utcOffset` method

### DIFF
--- a/src/constant.js
+++ b/src/constant.js
@@ -28,5 +28,3 @@ export const INVALID_DATE_STRING = 'Invalid Date'
 // regex
 export const REGEX_PARSE = /^(\d{4})[-/]?(\d{1,2})?[-/]?(\d{0,2})[^0-9]*(\d{1,2})?:?(\d{1,2})?:?(\d{1,2})?[.:]?(\d+)?$/
 export const REGEX_FORMAT = /\[([^\]]+)]|Y{1,4}|M{1,4}|D{1,2}|d{1,4}|H{1,2}|h{1,2}|a|A|m{1,2}|s{1,2}|Z{1,2}|SSS/g
-export const REGEX_VALID_OFFSET_FORMAT = /[+-]\d\d(?::?\d\d)?/g
-export const REGEX_OFFSET_HOURS_MINUTES_FORMAT = /([+-]|\d\d)/g

--- a/src/constant.js
+++ b/src/constant.js
@@ -28,3 +28,5 @@ export const INVALID_DATE_STRING = 'Invalid Date'
 // regex
 export const REGEX_PARSE = /^(\d{4})[-/]?(\d{1,2})?[-/]?(\d{0,2})[^0-9]*(\d{1,2})?:?(\d{1,2})?:?(\d{1,2})?[.:]?(\d+)?$/
 export const REGEX_FORMAT = /\[([^\]]+)]|Y{1,4}|M{1,4}|D{1,2}|d{1,4}|H{1,2}|h{1,2}|a|A|m{1,2}|s{1,2}|Z{1,2}|SSS/g
+export const REGEX_VALID_OFFSET_FORMAT = /[+-]\d\d(?::?\d\d)?/g
+export const REGEX_OFFSET_HOURS_MINUTES_FORMAT = /([+-]|\d\d)/g

--- a/src/plugin/utc/index.js
+++ b/src/plugin/utc/index.js
@@ -1,5 +1,7 @@
-import { MILLISECONDS_A_MINUTE, MIN, REGEX_VALID_OFFSET_FORMAT, REGEX_OFFSET_HOURS_MINUTES_FORMAT } from '../../constant'
+import { MILLISECONDS_A_MINUTE, MIN } from '../../constant'
 
+export const REGEX_VALID_OFFSET_FORMAT = /[+-]\d\d(?::?\d\d)?/g
+export const REGEX_OFFSET_HOURS_MINUTES_FORMAT = /([+-]|\d\d)/g
 
 function offsetFromString(value = '') {
   const offset = value.match(REGEX_VALID_OFFSET_FORMAT)

--- a/src/plugin/utc/index.js
+++ b/src/plugin/utc/index.js
@@ -1,4 +1,23 @@
-import { MILLISECONDS_A_MINUTE, MIN } from '../../constant'
+import { MILLISECONDS_A_MINUTE, MIN, REGEX_VALID_OFFSET_FORMAT, REGEX_OFFSET_HOURS_MINUTES_FORMAT } from '../../constant'
+
+
+function offsetFromString(value = '') {
+  const offset = value.match(REGEX_VALID_OFFSET_FORMAT)
+
+  if (!offset) {
+    return null
+  }
+
+  const [indicator, hoursOffset, minutesOffset] = `${offset[0]}`.match(REGEX_OFFSET_HOURS_MINUTES_FORMAT) || ['-', 0, 0]
+  const totalOffsetInMinutes = (+hoursOffset * 60) + (+minutesOffset)
+
+  if (totalOffsetInMinutes === 0) {
+    return 0
+  }
+
+  return indicator === '+' ? totalOffsetInMinutes : -totalOffsetInMinutes
+}
+
 
 export default (option, Dayjs, dayjs) => {
   const proto = Dayjs.prototype
@@ -58,6 +77,12 @@ export default (option, Dayjs, dayjs) => {
         return this.$offset
       }
       return oldUtcOffset.call(this)
+    }
+    if (typeof input === 'string') {
+      input = offsetFromString(input)
+      if (input === null) {
+        return this
+      }
     }
     const offset = Math.abs(input) <= 16 ? input * 60 : input
     let ins = this

--- a/test/plugin/utc.test.js
+++ b/test/plugin/utc.test.js
@@ -226,6 +226,71 @@ describe('UTC Offset', () => {
     expect(dayjs().utcOffset()).toBe(moment().utcOffset())
     expect(dayjs().utc().utcOffset()).toBe(moment().utc().utcOffset())
   })
+
+  it('get utc offset with a number value', () => {
+    const time = '2021-02-28 19:40:10'
+    const hoursOffset = -8
+    const daysJS = dayjs(time).utc().utcOffset(hoursOffset * 60, true)
+    const momentJS = moment(time).utc(true).utcOffset(hoursOffset, true)
+
+    expect(daysJS.toISOString()).toEqual(momentJS.toISOString())
+    expect(daysJS.utcOffset()).toEqual(hoursOffset * 60)
+    expect(daysJS.utcOffset()).toEqual(momentJS.utcOffset())
+  })
+
+  it('get utc offset with a negative valid string value, format: HH:mm', () => {
+    const time = '2021-02-28 19:40:10'
+    const hoursOffset = -8
+    const daysJS = dayjs(time).utc().utcOffset(`-0${Math.abs(hoursOffset)}:00`, true)
+    const momentJS = moment(time).utc(true).utcOffset(`-0${Math.abs(hoursOffset)}:00`, true)
+
+    expect(daysJS.toISOString()).toEqual(momentJS.toISOString())
+    expect(daysJS.utcOffset()).toEqual(hoursOffset * 60)
+    expect(daysJS.utcOffset()).toEqual(momentJS.utcOffset())
+  })
+
+  it('get utc offset with a positive valid string value, format: HH:mm', () => {
+    const time = '2021-02-28 19:40:10'
+    const hoursOffset = 8
+    const daysJS = dayjs(time).utc().utcOffset(`+0${hoursOffset}:00`, true)
+    const momentJS = moment(time).utc(true).utcOffset(`+0${hoursOffset}:00`, true)
+
+    expect(daysJS.toISOString()).toEqual(momentJS.toISOString())
+    expect(daysJS.utcOffset()).toEqual(hoursOffset * 60)
+    expect(daysJS.utcOffset()).toEqual(momentJS.utcOffset())
+  })
+
+  it('get utc offset with a negative valid string value, format: HHmm', () => {
+    const time = '2021-02-28 19:40:10'
+    const hoursOffset = -8
+    const daysJS = dayjs(time).utc().utcOffset(`-0${Math.abs(hoursOffset)}00`, true)
+    const momentJS = moment(time).utc(true).utcOffset(`-0${Math.abs(hoursOffset)}00`, true)
+
+    expect(daysJS.toISOString()).toEqual(momentJS.toISOString())
+    expect(daysJS.utcOffset()).toEqual(hoursOffset * 60)
+    expect(daysJS.utcOffset()).toEqual(momentJS.utcOffset())
+  })
+
+  it('get utc offset with a positive valid string value, format: HHmm', () => {
+    const time = '2021-02-28 19:40:10'
+    const hoursOffset = 8
+    const daysJS = dayjs(time).utc().utcOffset(`+0${hoursOffset}00`, true)
+    const momentJS = moment(time).utc(true).utcOffset(`+0${hoursOffset}00`, true)
+
+    expect(daysJS.toISOString()).toEqual(momentJS.toISOString())
+    expect(daysJS.utcOffset()).toEqual(hoursOffset * 60)
+    expect(daysJS.utcOffset()).toEqual(momentJS.utcOffset())
+  })
+
+  it('get utc offset with an invalid string value, value: random', () => {
+    const time = '2021-02-28 19:40:10'
+    const daysJS = dayjs(time, { utc: true }).utc(true).utcOffset('random')
+    const momentJS = moment(time).utc(true).utcOffset('random')
+
+    expect(daysJS.toISOString()).toEqual(momentJS.toISOString())
+    expect(daysJS.utcOffset()).toEqual(0)
+    expect(daysJS.utcOffset()).toEqual(momentJS.utcOffset())
+  })
 })
 
 describe('Diff', () => {


### PR DESCRIPTION
✅ Closes: #1085 

# ↪️ Pull Request

 * Extend `utcOffset` method with support for string argument representing the offset.
 * Provide the unit test(s) for the code change.

## Code example

Allow UTC offset to be defined as a string. Valid formats are:
 * +HH:mm,
 * -HH:mm,
 * +HHmm
 * -HHmm

Example usage:
```javascript
dayjs().utcOffset(`+08:00`, true)
```

## ✔️ PR Todo

- [x] Added/updated unit tests for this change
- [x] Included links to related issues/PRs.

## 📝 Additional notes

After the change I ensured that:
 * all tests are passing, by running `npm run test && npm run test-tz`,
 * formating / code style is consistent, by running `npm run lint`*.

*There are 2 failing unit tests present on the `dev` branch and as such are present in this fix as well, however they are *not* affected by this issue / code introduced.*