### PR TITLE
feat: add no-argument duration support

### DIFF
--- a/src/plugin/duration/index.js
+++ b/src/plugin/duration/index.js
@@ -61,6 +61,10 @@ class Duration {
   constructor(input, unit, locale) {
     this.$d = {}
     this.$l = locale
+    if (input === undefined) {
+      this.$ms = 0
+      this.parseFromMilliseconds()
+    }
     if (unit) {
       return wrapper(input * unitToMS[prettyUnit(unit)], this)
     }

--- a/test/plugin/duration.test.js
+++ b/test/plugin/duration.test.js
@@ -17,6 +17,10 @@ afterEach(() => {
 })
 
 describe('Creating', () => {
+  it('no argument', () => {
+    expect(dayjs.duration().toISOString()).toBe('P0D')
+    expect(dayjs.duration().asMilliseconds()).toBe(0)
+  })
   it('milliseconds', () => {
     expect(dayjs.duration(1, 'ms').toISOString()).toBe('PT0.001S')
     expect(dayjs.duration(100).toISOString()).toBe('PT0.1S')


### PR DESCRIPTION
As described in #1398 , this PR add support to call `dayjs.duration()` to create a duration of `0`. This mimic the behavior of `Moment.JS` and ease the migration for users.