### PR TITLE
fix: fixed missing types for ArraySupport plugin

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -9,7 +9,11 @@ declare function dayjs (date?: dayjs.ConfigType, format?: dayjs.OptionType, stri
 declare function dayjs (date?: dayjs.ConfigType, format?: dayjs.OptionType, locale?: string, strict?: boolean): dayjs.Dayjs
 
 declare namespace dayjs {
-  export type ConfigType = string | number | Date | Dayjs
+  interface ConfigTypeMap {
+    default: string | number | Date | Dayjs
+  }
+
+  export type ConfigType = ConfigTypeMap[keyof ConfigTypeMap]
 
   export type OptionType = { locale?: string, format?: string, utc?: boolean } | string | string[]
 

--- a/types/plugin/arraySupport.d.ts
+++ b/types/plugin/arraySupport.d.ts
@@ -2,7 +2,7 @@ import { PluginFunc } from 'dayjs'
 
 declare module 'dayjs' {
   interface ConfigTypeMap {
-    arraySupport: [year?: number, month?: number, day?: number, hour?: number, minute?: number, second?: number, millisecond?: number]
+    arraySupport: [number?, number?, number?, number?, number?, number?, number?]
   }
 }
 

--- a/types/plugin/arraySupport.d.ts
+++ b/types/plugin/arraySupport.d.ts
@@ -2,7 +2,7 @@ import { PluginFunc } from 'dayjs'
 
 declare module 'dayjs' {
   interface ConfigTypeMap {
-    arraySupport: [year: number, month?: number, day?: number, hour?: number, minute?: number, second?: number, millisecond?: number]
+    arraySupport: [year?: number, month?: number, day?: number, hour?: number, minute?: number, second?: number, millisecond?: number]
   }
 }
 

--- a/types/plugin/arraySupport.d.ts
+++ b/types/plugin/arraySupport.d.ts
@@ -1,4 +1,10 @@
 import { PluginFunc } from 'dayjs'
 
+declare module 'dayjs' {
+  interface ConfigTypeMap {
+    arraySupport: [year: number, month?: number, day?: number, hour?: number, minute?: number, second?: number, millisecond?: number]
+  }
+}
+
 declare const plugin: PluginFunc
 export = plugin


### PR DESCRIPTION
I've added an interface called `ConfigTypeMap`, so other plugins could add their own types to `ConfigType`. The same fix could be applied to ObjectSupport in a future pull request.

Fixes #1170