### PR TITLE
feat: support custom two-digit year parse function

### DIFF
--- a/src/plugin/customParseFormat/index.js
+++ b/src/plugin/customParseFormat/index.js
@@ -206,7 +206,7 @@ const parseFormattedInput = (input, format, utc) => {
 export default (o, C, d) => {
   d.p.customParseFormat = true
   if (o && o.parseTwoDigitYear) {
-    ({ parseTwoDigitYear: parseTwoDigitYear } = o)
+    ({ parseTwoDigitYear } = o)
   }
   const proto = C.prototype
   const oldParse = proto.parse

--- a/src/plugin/customParseFormat/index.js
+++ b/src/plugin/customParseFormat/index.js
@@ -13,6 +13,11 @@ const matchWord = /\d*[^\s\d-_:/()]+/ // Word
 
 let locale = {}
 
+let twoDigitYearParseFn = function (input) {
+  input = +input
+  return input + (input > 68 ? 1900 : 2000)
+}
+
 function offsetFromString(string) {
   if (!string) return 0
   if (string === 'Z') return 0
@@ -111,8 +116,7 @@ const expressions = {
   }],
   Y: [matchSigned, addInput('year')],
   YY: [match2, function (input) {
-    input = +input
-    this.year = input + (input > 68 ? 1900 : 2000)
+    this.year = twoDigitYearParseFn(input)
   }],
   YYYY: [match4, addInput('year')],
   Z: zoneExpressions,
@@ -201,6 +205,9 @@ const parseFormattedInput = (input, format, utc) => {
 
 export default (o, C, d) => {
   d.p.customParseFormat = true
+  if (o && o.twoDigitYearParseFn) {
+    ({ twoDigitYearParseFn } = o)
+  }
   const proto = C.prototype
   const oldParse = proto.parse
   proto.parse = function (cfg) {

--- a/src/plugin/customParseFormat/index.js
+++ b/src/plugin/customParseFormat/index.js
@@ -13,7 +13,7 @@ const matchWord = /\d*[^\s\d-_:/()]+/ // Word
 
 let locale = {}
 
-let twoDigitYearParseFn = function (input) {
+let parseTwoDigitYear = function (input) {
   input = +input
   return input + (input > 68 ? 1900 : 2000)
 }
@@ -116,7 +116,7 @@ const expressions = {
   }],
   Y: [matchSigned, addInput('year')],
   YY: [match2, function (input) {
-    this.year = twoDigitYearParseFn(input)
+    this.year = parseTwoDigitYear(input)
   }],
   YYYY: [match4, addInput('year')],
   Z: zoneExpressions,
@@ -205,8 +205,8 @@ const parseFormattedInput = (input, format, utc) => {
 
 export default (o, C, d) => {
   d.p.customParseFormat = true
-  if (o && o.twoDigitYearParseFn) {
-    ({ twoDigitYearParseFn } = o)
+  if (o && o.parseTwoDigitYear) {
+    ({ parseTwoDigitYear: parseTwoDigitYear } = o)
   }
   const proto = C.prototype
   const oldParse = proto.parse

--- a/test/plugin/customParseFormat.test.js
+++ b/test/plugin/customParseFormat.test.js
@@ -355,3 +355,16 @@ it('parse a string for MMM month format with underscore delimiter', () => {
   expect(dayjs(input2, format2).valueOf()).toBe(moment(input2, format2).valueOf())
 })
 
+it('custom two-digit year parse function', () => {
+  delete customParseFormat.$i // this allow plugin to be installed again
+  dayjs.extend(customParseFormat, {
+    twoDigitYearParseFn: yearString => (+yearString) + 1800
+  })
+  const format = 'YY-MM-DD'
+  const input = '00-05-02'
+  expect(dayjs(input, format).year()).toBe(1800)
+  const input2 = '50-05-02'
+  expect(dayjs(input2, format).year()).toBe(1850)
+  const input3 = '99-05-02'
+  expect(dayjs(input3, format).year()).toBe(1899)
+})

--- a/test/plugin/customParseFormat.test.js
+++ b/test/plugin/customParseFormat.test.js
@@ -358,7 +358,7 @@ it('parse a string for MMM month format with underscore delimiter', () => {
 it('custom two-digit year parse function', () => {
   delete customParseFormat.$i // this allow plugin to be installed again
   dayjs.extend(customParseFormat, {
-    twoDigitYearParseFn: yearString => (+yearString) + 1800
+    parseTwoDigitYear: yearString => (+yearString) + 1800
   })
   const format = 'YY-MM-DD'
   const input = '00-05-02'

--- a/types/plugin/customParseFormat.d.ts
+++ b/types/plugin/customParseFormat.d.ts
@@ -1,7 +1,7 @@
 import { PluginFunc } from 'dayjs'
 
 declare interface PluginOptions {
-    twoDigitYearParseFn?: (yearString: string) => number
+    parseTwoDigitYear?: (yearString: string) => number
 }
 
 declare const plugin: PluginFunc<PluginOptions>

--- a/types/plugin/customParseFormat.d.ts
+++ b/types/plugin/customParseFormat.d.ts
@@ -1,4 +1,8 @@
 import { PluginFunc } from 'dayjs'
 
-declare const plugin: PluginFunc
+declare interface PluginOptions {
+    twoDigitYearParseFn?: (yearString: string) => number
+}
+
+declare const plugin: PluginFunc<PluginOptions>
 export = plugin


### PR DESCRIPTION
As proposed in #1418, with this PR a custom two-digit year parse function can be configured in the `customParseFormat` plugin