### PR TITLE
fix: utcOffset when local in DST but date is not

### DIFF
--- a/src/plugin/utc/index.js
+++ b/src/plugin/utc/index.js
@@ -114,7 +114,7 @@ export default (option, Dayjs, dayjs) => {
 
   proto.valueOf = function () {
     const addedOffset = !this.$utils().u(this.$offset)
-      ? this.$offset + (this.$x.$localOffset || (new Date()).getTimezoneOffset()) : 0
+      ? this.$offset + (this.$x.$localOffset || this.$d.getTimezoneOffset()) : 0
     return this.$d.valueOf() - (addedOffset * MILLISECONDS_A_MINUTE)
   }
 

--- a/test/plugin/timezone.test.js
+++ b/test/plugin/timezone.test.js
@@ -21,6 +21,7 @@ const NY = 'America/New_York'
 const VAN = 'America/Vancouver'
 const DEN = 'America/Denver'
 const TOKYO = 'Asia/Tokyo'
+const PARIS = 'Europe/Paris'
 
 describe('Guess', () => {
   it('return string', () => {
@@ -210,6 +211,18 @@ describe('DST, a time that never existed Fall Back', () => {
       expect(d.valueOf()).toBe(1352012400000)
     })
   })
+})
+
+it('DST valueOf', () => {
+  const day1 = '2021-11-17T09:45:00.000Z'
+  const d1 = dayjs.utc(day1).tz(PARIS)
+  const m1 = moment.tz(day1, PARIS)
+  expect(d1.valueOf()).toBe(m1.valueOf())
+
+  const day2 = '2021-05-17T09:45:00.000Z'
+  const d2 = dayjs.utc(day2).tz(PARIS)
+  const m2 = moment.tz(day2, PARIS)
+  expect(d2.valueOf()).toBe(m2.valueOf())
 })
 
 describe('set Default', () => {

--- a/test/timezone.test.js
+++ b/test/timezone.test.js
@@ -57,12 +57,20 @@ it('UTC add day in DST', () => {
 })
 
 it('UTC and utcOffset', () => {
-  const test1 = 1331449199000 // 2012/3/11 14:59:59
-  expect(moment(test1).utcOffset(-300).format())
-    .toBe(dayjs(test1).utcOffset(-300).format())
+  const test1 = 1331449199000 // 2012/3/11 06:59:59 GMT+0000
+  expect(dayjs(test1).utcOffset(-300).format())
+    .toBe(moment(test1).utcOffset(-300).format())
   const test2 = '2000-01-01T06:31:00Z'
-  expect(moment.utc(test2).utcOffset(-60).format())
-    .toBe(dayjs.utc(test2).utcOffset(-60).format())
+  expect(dayjs.utc(test2).utcOffset(-60).format())
+    .toBe(moment.utc(test2).utcOffset(-60).format())
+
+  // across DST, copied from utc.test.js#get utc offset with a number value
+  const time = '2021-02-28 19:40:10'
+  const hoursOffset = -8
+  const daysJS = dayjs(time).utc().utcOffset(hoursOffset * 60, true)
+  const momentJS = moment(time).utc(true).utcOffset(hoursOffset, true)
+
+  expect(daysJS.toISOString()).toEqual(momentJS.toISOString())
 })
 
 it('UTC diff in DST', () => {


### PR DESCRIPTION
Fixes a bug in the valueOf() function after setting a utcOffset, when the the local timezone offset changes.

I added a test for it to `test/timezone.test.js`, so it should be reproducible on other people's computers as well.

Without this fix, when trying to run `npm test` in my timezone (British Summer Time - BST), there are quite a lot of off-by-one errors, e.g.

```
  ● DST, a time that never existed Fall Back › 2012-11-04 02:00:00

    expect(received).toBe(expected) // Object.is equality
    
    Expected value to be:
      1352012400000
    Received:
      1352016000000

      206 |       expect(d.format()).toBe('2012-11-04T02:00:00-05:00')
      207 |       expect(d.utcOffset()).toBe(-300)
    > 208 |       expect(d.valueOf()).toBe(1352012400000)
      209 |     })
      210 |   })
      211 | })
      
      at forEach (test/plugin/timezone.test.js:208:27)
          at Array.forEach (<anonymous>)
      at Object.<anonymous> (test/plugin/timezone.test.js:204:21)

  ● keepLocalTime › keepLocalTime

    expect(received).toBe(expected) // Object.is equality
    
    Expected value to be:
      "2013-11-18T17:55:00+01:00"
    Received:
      "2013-11-18T18:55:00+02:00"

      263 |   const base = dayjs.tz('2013-11-18 11:55', 'America/Toronto')
      264 |   it('keepLocalTime', () => {
    > 265 |     expect(base.tz('Europe/Berlin').format()).toBe('2013-11-18T17:55:00+01:00')
      266 |     expect(base.tz('Europe/Berlin', true).format()).toBe('2013-11-18T11:55:00+01:00')
      267 |   })
      268 | })
      
      at Object.<anonymous> (test/plugin/timezone.test.js:265:47)

```