### PR TITLE
fix: update wrong char in Ukranian [uk] locale

### DIFF
--- a/src/locale/uk.js
+++ b/src/locale/uk.js
@@ -43,7 +43,7 @@ const locale = {
   weekdaysShort: 'ндл_пнд_втр_срд_чтв_птн_сбт'.split('_'),
   weekdaysMin: 'нд_пн_вт_ср_чт_пт_сб'.split('_'),
   months,
-  monthsShort: 'січ_лют_бер_квiт_трав_черв_лип_серп_вер_жовт_лист_груд'.split('_'),
+  monthsShort: 'січ_лют_бер_квіт_трав_черв_лип_серп_вер_жовт_лист_груд'.split('_'),
   weekStart: 1,
   relativeTime: {
     future: 'за %s',


### PR DESCRIPTION
Tests were failing because the Ukranian month for April (квіт) was written using i (0x69) not і (0x456)

They look exactly the same, but `===` thinks they are different.

### Failing Test

```
Summary of all failing tests
 FAIL  test/locale/uk.test.js
  ● Format Month with locale function

    expect(received).toEqual(expected)
    
    Expected value to equal:
      "09 квітня 2021 квіт"
    Received:
      "09 квітня 2021 квiт"

      22 |     const testFormat2 = 'MMMM'
      23 |     const testFormat3 = 'MMM'
    > 24 |     expect(dayjsUK.format(testFormat1)).toEqual(momentUK.format(testFormat1))
      25 |     expect(dayjsUK.format(testFormat2)).toEqual(momentUK.format(testFormat2))
      26 |     expect(dayjsUK.format(testFormat3)).toEqual(momentUK.format(testFormat3))
      27 |   }
      
      at Object.<anonymous> (test/locale/uk.test.js:24:41)
```