### PR TITLE
build: Add npm prepare script

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "babel": "cross-env BABEL_ENV=build babel src --out-dir esm --copy-files && node build/esm",
     "build": "cross-env BABEL_ENV=build node build && npm run size",
     "sauce": "npx karma start karma.sauce.conf.js",
+    "prepare": "npm run build",
     "test:sauce": "npm run sauce -- 0 && npm run sauce -- 1 && npm run sauce -- 2  && npm run sauce -- 3",
     "size": "size-limit && gzip-size dayjs.min.js"
   },


### PR DESCRIPTION
Adds an `npm prepare` script to package.json

`npm prepare` runs automatically when doing `npm install` from a git dependency.

This will allow users to use dayjs with npm directly from the git repo, e.g. with:

```bash
npm install https://github.com/iamkun/dayjs.git
```

(feel free to test it by installing this branch, with `npm install https://github.com/aloisklink/dayjs.git#add-npm-prepare-script`)

It should be helpful for testing `dayjs`, as well as if people want to use bugfixes before dayjs pushes releases to NPM.

See https://docs.npmjs.com/cli/v7/using-npm/scripts for more details about `npm prepare`.