### PR TITLE
Fix broken UTC plugin due to rollup

### DIFF
--- a/build/index.js
+++ b/build/index.js
@@ -35,23 +35,27 @@ async function listLocaleJson(localeArr) {
 
 (async () => {
   try {
+    /* eslint-disable no-restricted-syntax, no-await-in-loop */
+    // We use await-in-loop to make rollup run sequentially to save on RAM
     const locales = await promisifyReadDir(localePath)
-    locales.forEach((l) => {
-      build(configFactory({
+    for (const l of locales) {
+      // run builds sequentially to limit RAM usage
+      await build(configFactory({
         input: `./src/locale/${l}`,
         fileName: `./locale/${l}`,
         name: `dayjs_locale_${formatName(l)}`
       }))
-    })
+    }
 
     const plugins = await promisifyReadDir(path.join(__dirname, '../src/plugin'))
-    plugins.forEach((l) => {
-      build(configFactory({
-        input: `./src/plugin/${l}/index`,
-        fileName: `./plugin/${l}.js`,
-        name: `dayjs_plugin_${formatName(l)}`
+    for (const plugin of plugins) {
+      // run builds sequentially to limit RAM usage
+      await build(configFactory({
+        input: `./src/plugin/${plugin}/index`,
+        fileName: `./plugin/${plugin}.js`,
+        name: `dayjs_plugin_${formatName(plugin)}`
       }))
-    })
+    }
 
     build(configFactory({
       input: './src/index.js',

--- a/build/rollup.config.js
+++ b/build/rollup.config.js
@@ -1,5 +1,5 @@
 const babel = require('rollup-plugin-babel')
-const uglify = require('rollup-plugin-uglify')
+const { terser } = require('rollup-plugin-terser')
 
 module.exports = (config) => {
   const { input, fileName, name } = config
@@ -13,7 +13,7 @@ module.exports = (config) => {
         babel({
           exclude: 'node_modules/**'
         }),
-        uglify()
+        terser()
       ]
     },
     output: {

--- a/build/rollup.config.js
+++ b/build/rollup.config.js
@@ -22,7 +22,8 @@ module.exports = (config) => {
       name: name || 'dayjs',
       globals: {
         dayjs: 'dayjs'
-      }
+      },
+      compact: true
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -90,11 +90,10 @@
     "ncp": "^2.0.0",
     "pre-commit": "^1.2.2",
     "prettier": "^1.16.1",
-    "rollup": "^0.57.1",
-    "rollup-plugin-babel": "^4.0.0-beta.4",
-    "rollup-plugin-uglify": "^3.0.0",
+    "rollup": "^2.45.1",
+    "rollup-plugin-babel": "^4.4.0",
+    "rollup-plugin-terser": "^7.0.2",
     "size-limit": "^0.18.0",
     "typescript": "^2.8.3"
-  },
-  "dependencies": {}
+  }
 }

--- a/src/constant.js
+++ b/src/constant.js
@@ -28,3 +28,7 @@ export const INVALID_DATE_STRING = 'Invalid Date'
 // regex
 export const REGEX_PARSE = /^(\d{4})[-/]?(\d{1,2})?[-/]?(\d{0,2})[^0-9]*(\d{1,2})?:?(\d{1,2})?:?(\d{1,2})?[.:]?(\d+)?$/
 export const REGEX_FORMAT = /\[([^\]]+)]|Y{1,4}|M{1,4}|D{1,2}|d{1,4}|H{1,2}|h{1,2}|a|A|m{1,2}|s{1,2}|Z{1,2}|SSS/g
+
+// used by plugins/utc
+export const REGEX_VALID_OFFSET_FORMAT = /[+-]\d\d(?::?\d\d)?/g
+export const REGEX_OFFSET_HOURS_MINUTES_FORMAT = /([+-]|\d\d)/g

--- a/src/plugin/utc/index.js
+++ b/src/plugin/utc/index.js
@@ -1,7 +1,4 @@
-import { MILLISECONDS_A_MINUTE, MIN } from '../../constant'
-
-export const REGEX_VALID_OFFSET_FORMAT = /[+-]\d\d(?::?\d\d)?/g
-export const REGEX_OFFSET_HOURS_MINUTES_FORMAT = /([+-]|\d\d)/g
+import { MILLISECONDS_A_MINUTE, MIN, REGEX_VALID_OFFSET_FORMAT, REGEX_OFFSET_HOURS_MINUTES_FORMAT } from '../../constant'
 
 function offsetFromString(value = '') {
   const offset = value.match(REGEX_VALID_OFFSET_FORMAT)


### PR DESCRIPTION
I was playing around with using dayjs from the `dev` branch with #1450 and Node.JS, and I noticed that the `dayjs/plugin/utc` was broken, as the plugin was instead exported under the `default` key.

```console
> const dayjs = require("."); const utc = require("./plugin/utc"); dayjs.extend(utc);
Uncaught TypeError: t is not a function
    at Function.v.extend (/tmp/dayjs/dayjs.min.js:1:6319)
> console.log(utc);
{
  REGEX_VALID_OFFSET_FORMAT: /[+-]\d\d(?::?\d\d)?/g,
  REGEX_OFFSET_HOURS_MINUTES_FORMAT: /([+-]|\d\d)/g,
  default: [Function]
}
```

It looks like Rollup does not like mixing together named exports and default exports: <https://rollupjs.org/guide/en/#default-export>

## Updating Rollup

I updated Rollup to the latest version, which fixed an error with running `npm install --dev` on NPM@v7, and also added the following warning:

```console
me@me:/tmp/dayjs$ npm run build

> dayjs@0.0.0-development build
> cross-env BABEL_ENV=build node build && npm run size

Entry module "src/plugin/utc/index.js" is using named and default exports together. Consumers of your bundle will have to use `dayjs_plugin_utc["default"]` to access the default export, which may not be what you want. Use `output.exports: "named"` to disable this warning

> dayjs@0.0.0-development size
> size-limit && gzip-size dayjs.min.js


  Package size: 2.6 KB
  Size limit:   2.99 KB
  With all dependencies, minified and gzipped

2.86 kB
```

The new rollup is create a `gzip` file that is 31 bytes larger than the old `gzip` size. It seems like it's mainly due to the addition of `globalThis`, so this should also fix #1060, but I haven't tested it.

I also changed `build/index.js` to run rollup sequentially, since otherwise it uses up more than 16 GB of RAM on my computer, which makes it freeze.

## Fixing `plugins/utc`

Finally, to fix plugins/utc, I moved the two regex named exports to the `constant.js` file. Normally this would be a breaking change, but since there hasn't been a release since the PR that added these exports (#1395), it should be fine.

### New bundle sizes

Created by running `for file in {plugin/*.js,dayjs.min.js}; do echo "$file: $(npx gzip-size --raw "$file")"; done`
As can be seen, all the bundles have increased in size by about 15-30 bytes (mainly due to adding `globalThis`), except for the utc plugin, which decreases in size since it no longer has the extra exports.

I think it's still worth it though, since the old `rollup` version that is being used is from [2018-03-17](https://github.com/rollup/rollup/blob/master/CHANGELOG.md#0571), so it is quite out-of-date.

| file | old size | new size |
| ----------------------------------- | --- | --- |
| plugin/advancedFormat.js | 583 | 602 |
| plugin/arraySupport.js | 315 | 337 |
| plugin/badMutable.js | 387 | 407 |
| plugin/buddhistEra.js | 342 | 361 |
| plugin/calendar.js | 405 | 427 |
| plugin/customParseFormat.js | 1697 | 1729 |
| plugin/dayOfYear.js | 242 | 263 |
| plugin/devHelper.js | 610 | 631 |
| plugin/duration.js | 1586 | 1616 |
| plugin/isBetween.js | 273 | 294 |
| plugin/isLeapYear.js | 207 | 230 |
| plugin/isMoment.js | 184 | 202 |
| plugin/isoWeek.js | 461 | 481 |
| plugin/isoWeeksInYear.js | 234 | 253 |
| plugin/isSameOrAfter.js | 195 | 215 |
| plugin/isSameOrBefore.js | 197 | 218 |
| plugin/isToday.js | 212 | 234 |
| plugin/isTomorrow.js | 226 | 247 |
| plugin/isYesterday.js | 229 | 249 |
| plugin/localeData.js | 683 | 705 |
| plugin/localizedFormat.js | 435 | 454 |
| plugin/minMax.js | 323 | 343 |
| plugin/objectSupport.js | 584 | 613 |
| plugin/pluralGetSet.js | 264 | 286 |
| plugin/preParsePostFormat.js | 396 | 414 |
| plugin/quarterOfYear.js | 384 | 403 |
| plugin/relativeTime.js | 718 | 737 |
| plugin/timezone.js | 1051 | 1069 |
| plugin/toArray.js | 201 | 224 |
| plugin/toObject.js | 230 | 250 |
| plugin/updateLocale.js | 230 | 251 |
| **plugin/utc.js** | **1022** | **967** |
| plugin/weekday.js | 251 | 269 |
| plugin/weekOfYear.js | 419 | 440 |
| plugin/weekYear.js | 231 | 251 |
| **dayjs.min.js** | **2829** | **2860** |
