### PR TITLE
Remove-hardcoded-en-US-locale-issue-#1383

### DIFF
--- a/src/plugin/timezone/index.js
+++ b/src/plugin/timezone/index.js
@@ -17,7 +17,7 @@ const getDateTimeFormat = (timezone, options = {}) => {
   const key = `${timezone}|${timeZoneName}`
   let dtf = dtfCache[key]
   if (!dtf) {
-    dtf = new Intl.DateTimeFormat('en-US', {
+    dtf = new Intl.DateTimeFormat(undefined, {
       hour12: false,
       timeZone: timezone,
       year: 'numeric',


### PR DESCRIPTION
Hard coding the locale here causes presumably unintended incorrect timezone formatting for users outside of the US.  Issue described in #1383, I propose removing the en-US in favour of the browser's default, or what is specified elsewhere.