### PR TITLE
Document argumentless diff

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -286,7 +286,9 @@ declare namespace dayjs {
      * const date1 = dayjs('2019-01-25')
      * const date2 = dayjs('2018-06-05')
      * date1.diff(date2) // 20214000000 default milliseconds
+     * date1.diff() // milliseconds to current time
      * ```
+     *
      * To get the difference in another unit of measurement, pass that measurement as the second argument.
      * ```
      * const date1 = dayjs('2019-01-25')
@@ -296,7 +298,7 @@ declare namespace dayjs {
      *
      * Docs: https://day.js.org/docs/en/display/difference
      */
-    diff(date: ConfigType, unit?: QUnitType | OpUnitType, float?: boolean): number
+    diff(date?: ConfigType, unit?: QUnitType | OpUnitType, float?: boolean): number
     /**
      * This returns the number of **milliseconds** since the Unix Epoch of the Day.js object.
      * ```


### PR DESCRIPTION
dayjs.diff() calculates the diff to current time.