### PR TITLE
fix: incorrect startOf/endOf behavior with +00:00 timezone

### DIFF
--- a/src/plugin/timezone/index.js
+++ b/src/plugin/timezone/index.js
@@ -114,17 +114,6 @@ export default (o, c, d) => {
     return result && result.value
   }
 
-  const oldStartOf = proto.startOf
-  proto.startOf = function (units, startOf) {
-    if (!this.$x || !this.$x.$timezone) {
-      return oldStartOf.call(this, units, startOf)
-    }
-
-    const withoutTz = d(this.format('YYYY-MM-DD HH:mm:ss:SSS'))
-    const startOfWithoutTz = oldStartOf.call(withoutTz, units, startOf)
-    return startOfWithoutTz.tz(this.$x.$timezone, true)
-  }
-
   d.tz = function (input, arg1, arg2) {
     const parseFormat = arg2 && arg1
     const timezone = arg2 || arg1 || defaultTimezone

--- a/test/plugin/timezone.test.js
+++ b/test/plugin/timezone.test.js
@@ -21,6 +21,7 @@ const NY = 'America/New_York'
 const VAN = 'America/Vancouver'
 const DEN = 'America/Denver'
 const TOKYO = 'Asia/Tokyo'
+const LONDON = 'Europe/London'
 
 describe('Guess', () => {
   it('return string', () => {
@@ -298,11 +299,27 @@ describe('startOf and endOf', () => {
     const originalDay = dayjs.tz('2010-01-01 00:00:00', NY)
     const startOfDay = originalDay.startOf('day')
     expect(startOfDay.valueOf()).toEqual(originalDay.valueOf())
+    expect(startOfDay.format()).toEqual(originalDay.format())
   })
 
   it('corrects for timezone offset in endOf', () => {
     const originalDay = dayjs.tz('2009-12-31 23:59:59.999', NY)
     const endOfDay = originalDay.endOf('day')
     expect(endOfDay.valueOf()).toEqual(originalDay.valueOf())
+    expect(endOfDay.format()).toEqual(originalDay.format())
+  })
+
+  it('corrects for +00:00 timezone offset in startOf', () => {
+    const originalDay = dayjs.tz('2021-05-10 00:00:00', LONDON)
+    const startOfDay = originalDay.startOf('day')
+    expect(startOfDay.valueOf()).toEqual(originalDay.valueOf())
+    expect(startOfDay.format()).toEqual(originalDay.format())
+  })
+
+  it('corrects for +00:00 timezone offset in endOf', () => {
+    const originalDay = dayjs.tz('2021-05-10 23:59:59.999', LONDON)
+    const endOfDay = originalDay.endOf('day')
+    expect(endOfDay.valueOf()).toEqual(originalDay.valueOf())
+    expect(endOfDay.format()).toEqual(originalDay.format())
   })
 })


### PR DESCRIPTION
assume I'm in +08:00, when I parse time string with any regions in +00:00(like `UTC`, `Africa/Abidjan`), got the incorrect result

example: 
incorrect in dayjs:
```js
dayjs.tz('2021-04-01', 'Asia/Hong_Kong').endOf('day').format()
// "2021-04-01T23:59:59+08:00"
dayjs.tz('2021-04-01', 'Africa/Abidjan').endOf('day').format()
// "2021-04-01T15:59:59Z"
dayjs.tz('2021-04-01', 'UTC').endOf('day').format()
// "2021-04-01T15:59:59Z"
```
expect work like moment
```js
moment.tz('2021-04-01', 'Asia/Hong_Kong').endOf('day').format()
// "2021-04-01T23:59:59+08:00"
moment.tz('2021-04-01', 'Africa/Abidjan').endOf('day').format()
// "2021-04-01T23:59:59Z"
moment.tz('2021-04-01', 'UTC').endOf('day').format()
// "2021-04-01T23:59:59Z"
```

clone form #1493 
related: #1493 #1503 