### PR TITLE
fix: Fix DayOfYear plugin when using BadMutable plugin

### DIFF
--- a/src/plugin/dayOfYear/index.js
+++ b/src/plugin/dayOfYear/index.js
@@ -1,7 +1,8 @@
-export default (o, c) => {
+export default (o, c, d) => {
   const proto = c.prototype
   proto.dayOfYear = function (input) {
-    const dayOfYear = Math.round((this.startOf('day') - this.startOf('year')) / 864e5) + 1
+    // d(this) is for badMutable
+    const dayOfYear = Math.round((d(this).startOf('day') - d(this).startOf('year')) / 864e5) + 1
     return input == null ? dayOfYear : this.add(input - dayOfYear, 'day')
   }
 }

--- a/test/plugin/badMutable.test.js
+++ b/test/plugin/badMutable.test.js
@@ -2,10 +2,12 @@ import MockDate from 'mockdate'
 import moment from 'moment'
 import dayjs from '../../src'
 import badMutable from '../../src/plugin/badMutable'
+import dayOfYear from '../../src/plugin/dayOfYear'
 import weekOfYear from '../../src/plugin/weekOfYear'
 import '../../src/locale/zh-cn'
 
 dayjs.extend(badMutable)
+dayjs.extend(dayOfYear)
 dayjs.extend(weekOfYear)
 
 beforeEach(() => {
@@ -188,7 +190,14 @@ it('isAfter isBefore isSame', () => {
   expect(d.isAfter()).toBe(false)
 })
 
-it('WeekOfYear get week won"t change instance', () => {
+it('DayOfYear get day won\'t change instance', () => {
+  const d = dayjs()
+  const format = d.format()
+  d.dayOfYear()
+  expect(d.format()).toBe(format)
+})
+
+it('WeekOfYear get week won\'t change instance', () => {
   const d = dayjs()
   const format = d.format()
   d.week()


### PR DESCRIPTION
Fixes https://github.com/iamkun/dayjs/issues/1407
Very similar to a previous fix for WeekOfYear: https://github.com/iamkun/dayjs/pull/884

To reproduce:
```
var badMutable = require('dayjs/plugin/badMutable');
var dayOfYear = require('dayjs/plugin/dayOfYear');

dayjs.extend(badMutable);
dayjs.extend(dayOfYear);
dayjs('02.25.2020').dayOfYear(); // Should return 56, but returns 1 instead
```