### PR TITLE
Finland Swedish locale

### DIFF
--- a/src/locale/sv-fi.js
+++ b/src/locale/sv-fi.js
@@ -1,0 +1,50 @@
+// Finland Swedish [sv-fi]
+import dayjs from 'dayjs'
+
+const locale = {
+  name: 'sv-fi',
+  weekdays: 'söndag_måndag_tisdag_onsdag_torsdag_fredag_lördag'.split('_'),
+  weekdaysShort: 'sön_mån_tis_ons_tor_fre_lör'.split('_'),
+  weekdaysMin: 'sö_må_ti_on_to_fr_lö'.split('_'),
+  months: 'januari_februari_mars_april_maj_juni_juli_augusti_september_oktober_november_december'.split('_'),
+  monthsShort: 'jan_feb_mar_apr_maj_jun_jul_aug_sep_okt_nov_dec'.split('_'),
+  weekStart: 1,
+  yearStart: 4,
+  ordinal: (n) => {
+    const b = n % 10
+    const o = (b === 1) || (b === 2) ? 'a' : 'e'
+    return `[${n}${o}]`
+  },
+  formats: {
+    LT: 'HH.mm',
+    LTS: 'HH.mm.ss',
+    L: 'DD.MM.YYYY',
+    LL: 'D. MMMM YYYY',
+    LLL: 'D. MMMM YYYY, [kl.] HH.mm',
+    LLLL: 'dddd, D. MMMM YYYY, [kl.] HH.mm',
+    l: 'D.M.YYYY',
+    ll: 'D. MMM YYYY',
+    lll: 'D. MMM YYYY, [kl.] HH.mm',
+    llll: 'ddd, D. MMM YYYY, [kl.] HH.mm'
+  },
+  relativeTime: {
+    future: 'om %s',
+    past: 'för %s sedan',
+    s: 'några sekunder',
+    m: 'en minut',
+    mm: '%d minuter',
+    h: 'en timme',
+    hh: '%d timmar',
+    d: 'en dag',
+    dd: '%d dagar',
+    M: 'en månad',
+    MM: '%d månader',
+    y: 'ett år',
+    yy: '%d år'
+  }
+}
+
+dayjs.locale(locale, null, true)
+
+export default locale
+

--- a/test/locale/sv-fi.test.js
+++ b/test/locale/sv-fi.test.js
@@ -29,7 +29,7 @@ it('Finland Swedish locale', () => {
     .toBe('lördag, 12. juni 2021, kl. 17.30')
   // short
   expect(dayjs('2019-03-01 12:30').locale('sv-fi').format('lll'))
-    .toBe('1. mar 2019  , kl. 12.30')
+    .toBe('1. mar 2019, kl. 12.30')
   expect(dayjs('2021-06-01 17:30').locale('sv-fi').format('llll'))
     .toBe('tis, 1. jun 2021, kl. 17.30')
 })

--- a/test/locale/sv-fi.test.js
+++ b/test/locale/sv-fi.test.js
@@ -1,0 +1,35 @@
+import dayjs from '../../src'
+import localizedFormat from '../../src/plugin/localizedFormat'
+import '../../src/locale/sv-fi'
+
+dayjs.extend(localizedFormat)
+
+it('Finland Swedish locale', () => {
+  // time
+  expect(dayjs('2019-02-01 12:34:56').locale('sv-fi').format('LT'))
+    .toBe('12.34')
+  expect(dayjs('2019-02-01 23:45:56').locale('sv-fi').format('LTS'))
+    .toBe('23.45.56')
+
+  // date
+  expect(dayjs('2019-02-01').locale('sv-fi').format('L'))
+    .toBe('01.02.2019')
+  expect(dayjs('2019-12-15').locale('sv-fi').format('LL'))
+    .toBe('15. december 2019')
+  // short
+  expect(dayjs('2019-02-01').locale('sv-fi').format('l'))
+    .toBe('1.2.2019')
+  expect(dayjs('2019-12-15').locale('sv-fi').format('ll'))
+    .toBe('15. dec 2019')
+
+  // date and time
+  expect(dayjs('2019-03-01 12:30').locale('sv-fi').format('LLL'))
+    .toBe('1. mars 2019, kl. 12.30')
+  expect(dayjs('2021-06-12 17:30').locale('sv-fi').format('LLLL'))
+    .toBe('lördag, 12. juni 2021, kl. 17.30')
+  // short
+  expect(dayjs('2019-03-01 12:30').locale('sv-fi').format('lll'))
+    .toBe('1. mar 2019  , kl. 12.30')
+  expect(dayjs('2021-06-01 17:30').locale('sv-fi').format('llll'))
+    .toBe('tis, 1. jun 2021, kl. 17.30')
+})


### PR DESCRIPTION
Swedish is an official language in Finland. They expect Swedish translations of months and days and Finnish formats