### PR TITLE
Fallback to language only locale + support uppercase locales

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -21,7 +21,7 @@ const parseLocale = (preset, object, isLocal) => {
       l = presetLower
     }
     const presetSplit = preset.split('-')
-    if (!l && presetSplit.length) {
+    if (!l && presetSplit.length > 1) {
       return parseLocale(presetSplit[0])
     }
   } else {

--- a/src/index.js
+++ b/src/index.js
@@ -12,12 +12,16 @@ const parseLocale = (preset, object, isLocal) => {
   let l
   if (!preset) return L
   if (typeof preset === 'string') {
-    if (Ls[preset]) {
-      l = preset
+    const presetLower = preset.toLowerCase()
+    if (Ls[presetLower]) {
+      l = presetLower
     }
     if (object) {
-      Ls[preset] = object
-      l = preset
+      Ls[presetLower] = object
+      l = presetLower
+    }
+    if (!l && preset.split('-').length > 1) {
+      return parseLocale(preset.split('-')[0])
     }
   } else {
     const { name } = preset

--- a/src/index.js
+++ b/src/index.js
@@ -20,8 +20,9 @@ const parseLocale = (preset, object, isLocal) => {
       Ls[presetLower] = object
       l = presetLower
     }
-    if (!l && preset.split('-').length > 1) {
-      return parseLocale(preset.split('-')[0])
+    const presetSplit = preset.split('-')
+    if (!l && presetSplit.length) {
+      return parseLocale(presetSplit[0])
     }
   } else {
     const { name } = preset

--- a/test/plugin/localizedFormat.test.js
+++ b/test/plugin/localizedFormat.test.js
@@ -96,6 +96,16 @@ it('Uses the localized lowercase formats if defined', () => {
   ['l', 'll', 'lll', 'llll'].forEach(option => expect(znDate.format(option)).toBe(znDate.format(znCn.formats[option])))
 })
 
+it('Uses fallback to xx if xx-yy not available', () => {
+  expect(dayjs('2019-02-01').locale('es-yy').format('L'))
+    .toBe('01/02/2019')
+})
+
+it('Uses xx-yy if xx-YY is provided', () => {
+  expect(dayjs('2019-02-01').locale('es-US').format('L'))
+    .toBe('01/02/2019')
+})
+
 it('Uses the localized uppercase formats as a base for lowercase formats, if not defined', () => {
   const date = new Date()
   const spanishDate = dayjs(date, { locale: es });

--- a/test/plugin/localizedFormat.test.js
+++ b/test/plugin/localizedFormat.test.js
@@ -97,13 +97,13 @@ it('Uses the localized lowercase formats if defined', () => {
 })
 
 it('Uses fallback to xx if xx-yy not available', () => {
-  expect(dayjs('2019-02-01').locale('es-yy').format('L'))
-    .toBe('01/02/2019')
+  expect(dayjs('2019-02-01').locale('en-yy').format('MMMM'))
+    .toBe('February')
 })
 
 it('Uses xx-yy if xx-YY is provided', () => {
-  expect(dayjs('2019-02-01').locale('es-US').format('L'))
-    .toBe('01/02/2019')
+  expect(dayjs('2019-02-01').locale('es-US').format('MMMM'))
+    .toBe('febrero')
 })
 
 it('Uses the localized uppercase formats as a base for lowercase formats, if not defined', () => {


### PR DESCRIPTION

Fallback to locale xx if xx-yy is provided and does not exist

Also support locales in uppercase such as en-GB 