### PR TITLE
fix: do not modify dayjs input arguments

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -28,12 +28,16 @@ const parseLocale = (preset, object, isLocal) => {
   return l || (!isLocal && L)
 }
 
+function objClone(obj) {
+  return obj instanceof Array ? [...obj] : { ...obj }
+}
+
 const dayjs = function (date, c) {
   if (isDayjs(date)) {
     return date.clone()
   }
   // eslint-disable-next-line no-nested-ternary
-  const cfg = typeof c === 'object' ? c : {}
+  const cfg = typeof c === 'object' ? objClone(c) : {}
   cfg.date = date
   cfg.args = arguments// eslint-disable-line prefer-rest-params
   return new Dayjs(cfg) // eslint-disable-line no-use-before-define

--- a/test/plugin/customParseFormat.test.js
+++ b/test/plugin/customParseFormat.test.js
@@ -313,6 +313,13 @@ describe('Strict mode', () => {
 })
 
 describe('Array format support', () => {
+  it('does not modify input array', () => {
+    const input = '2012-05-28'
+    const formats = ['YYYY', 'YYYY-MM-DD']
+    dayjs(input, formats)
+    expect(formats.date).toBe(undefined)
+    expect(formats.args).toBe(undefined)
+  })
   it('second ok', () => {
     const input = '2012-05-28'
     const format = ['YYYY', 'YYYY-MM-DD']


### PR DESCRIPTION
I noticed that when passing in an array of date formats:

"If you don't know the exact format of an input string, but know it could be one of many, you can use an array of formats."
(from https://day.js.org/docs/en/parse/string-format) it was actually modifying the input array. This seems pretty bad.

I'm not sure if your build supports the ... syntax. It could be changed to Object.assign or similar if you want.