### PR TITLE
Fix esm plugin typings and add test.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,6 @@ locale.json
 
 #dev
 demo.js
+
+#tsc
+*.tsbuildinfo

--- a/build/esm.js
+++ b/build/esm.js
@@ -33,7 +33,9 @@ const localeTypePath = path.join(process.env.PWD, 'esm/locale', `index${typeFile
         const filePath = path.join(pluginDir, p)
         const targetPath = path.join(pluginDir, pluginName, `index${typeFileExt}`)
         const readFile = await promisify(fs.readFile)(filePath, 'utf8')
-        const result = readFile.replace(/'dayjs'/g, "'dayjs/esm'")
+        const result = readFile
+          .replace('"../index"', "'../../index'")
+          .replace(/'dayjs'/g, "'dayjs/esm'")
         await promisify(fs.writeFile)(targetPath, result, 'utf8')
         await promisify(fs.unlink)(filePath)
       }

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "test-tz": "date && jest test/timezone.test --coverage=false",
     "lint": "./node_modules/.bin/eslint src/* test/* build/*",
     "prettier": "prettier --write \"docs/**/*.md\"",
-    "babel": "cross-env BABEL_ENV=build babel src --out-dir esm --copy-files && node build/esm",
+    "babel": "cross-env BABEL_ENV=build babel src --out-dir esm --copy-files && node build/esm && tsc -b ./type-test/tsconfig.build.json",
     "build": "cross-env BABEL_ENV=build node build && npm run size",
     "sauce": "npx karma start karma.sauce.conf.js",
     "test:sauce": "npm run sauce -- 0 && npm run sauce -- 1 && npm run sauce -- 2  && npm run sauce -- 3",
@@ -66,11 +66,10 @@
     "url": "https://github.com/iamkun/dayjs.git"
   },
   "devDependencies": {
-    "@babel/cli": "^7.0.0-beta.44",
-    "@babel/core": "^7.0.0-beta.44",
-    "@babel/node": "^7.0.0-beta.44",
-    "@babel/preset-env": "^7.0.0-beta.44",
-    "babel-core": "^7.0.0-bridge.0",
+    "@babel/cli": "^7.0.0",
+    "@babel/core": "^7.0.0",
+    "@babel/node": "^7.0.0",
+    "@babel/preset-env": "^7.0.0",
     "babel-jest": "^22.4.3",
     "babel-plugin-external-helpers": "^6.22.0",
     "cross-env": "^5.1.6",
@@ -94,6 +93,6 @@
     "rollup-plugin-babel": "^4.4.0",
     "rollup-plugin-terser": "^7.0.2",
     "size-limit": "^0.18.0",
-    "typescript": "^2.8.3"
+    "typescript": "^4.3.4"
   }
 }

--- a/type-test/esModuleInterop.ts
+++ b/type-test/esModuleInterop.ts
@@ -1,0 +1,11 @@
+import dayjs from 'dayjs/esm';
+
+import customParseFormat from 'dayjs/esm/plugin/customParseFormat';
+import duration from 'dayjs/esm/plugin/duration';
+import relativeTime from 'dayjs/esm/plugin/relativeTime';
+
+new dayjs.Dayjs();
+
+dayjs.extend(customParseFormat);
+dayjs.extend(duration);
+dayjs.extend(relativeTime);

--- a/type-test/tsconfig.allowSyntethicDefault.json
+++ b/type-test/tsconfig.allowSyntethicDefault.json
@@ -1,0 +1,11 @@
+{
+  "extends": "./tsconfig.base.json",
+  "compilerOptions": {
+    "composite": true,
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true
+  },
+  "files": [
+    "./esModuleInterop.ts"
+  ]
+}

--- a/type-test/tsconfig.base.json
+++ b/type-test/tsconfig.base.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "noEmit": true,
+    "paths": {
+      "dayjs/*": [
+        "../*"
+      ]
+    },
+    "module": "CommonJS",
+    "target": "ES6"
+  }
+}

--- a/type-test/tsconfig.build.json
+++ b/type-test/tsconfig.build.json
@@ -1,0 +1,12 @@
+{
+  "extends": "./tsconfig.base.json",
+  "references": [
+    {
+      "path": "./tsconfig.allowSyntethicDefault.json"
+    },
+    {
+      "path": "./tsconfig.esModuleInterop.json"
+    }
+  ],
+  "files": []
+}

--- a/type-test/tsconfig.esModuleInterop.json
+++ b/type-test/tsconfig.esModuleInterop.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.base.json",
+  "compilerOptions": {
+    "composite": true,
+    "esModuleInterop": true
+  },
+  "files": [
+    "./esModuleInterop.ts"
+  ]
+}

--- a/type-test/tsconfig.json
+++ b/type-test/tsconfig.json
@@ -1,0 +1,6 @@
+{
+  "extends": "./tsconfig.base.json",
+  "compilerOptions": {
+    "esModuleInterop": true
+  }
+}


### PR DESCRIPTION
Generated esm plugins are generated as `plugin/duration/index.js`, but import still points to `import dayjs from '../index'`, but it should be `import dayjs from '../../index'`.

- Fix imports.
- Add tests.