### PR TITLE
feat: added pretty formation for duration

### DIFF
--- a/src/plugin/duration/index.js
+++ b/src/plugin/duration/index.js
@@ -235,6 +235,27 @@ class Duration {
       .fromNow(!withSuffix)
   }
 
+  pretty(o) {
+    const options = { verbose: false, ...o }
+    const p = (n, s) => (n > 1 ? `${s}s` : s)
+    let chain = [
+      [this.$d.years, 'year', 'y'],
+      [this.$d.months, 'month', 'm'],
+      [this.$d.days, 'day', 'd'],
+      [this.$d.hours, 'hour', 'h'],
+      [this.$d.minutes, 'minute', 'm'],
+      [this.$d.seconds, 'second', 's'],
+      [this.$d.milliseconds, 'millisecond', 'ms']
+    ]
+    chain = chain.filter(([t]) => !!t).map(([t, n, s]) => {
+      if (options.verbose) {
+        return `${t} ${p(t, n)}`
+      }
+      return `${t}${s}`
+    })
+    return chain.join(' ')
+  }
+
   milliseconds() { return this.get('milliseconds') }
   asMilliseconds() { return this.as('milliseconds') }
   seconds() { return this.get('seconds') }

--- a/test/plugin/duration.test.js
+++ b/test/plugin/duration.test.js
@@ -126,6 +126,21 @@ describe('Humanize', () => {
   })
 })
 
+describe('Pretty', () => {
+  it('Prettify', () => {
+    expect(dayjs.duration(1, 'minutes').pretty()).toBe('1m')
+    expect(dayjs.duration(133700).pretty()).toBe('2m 13s 700ms')
+    expect(dayjs.duration(2, 'minutes').pretty({ verbose: true })).toBe('2 minutes')
+    expect(dayjs.duration(1335669000).pretty({ verbose: true })).toBe('15 days 11 hours 1 minute 9 seconds')
+  })
+
+  it('Global Locale', () => {
+    dayjs.locale('es')
+    expect(dayjs.duration(133700).pretty({ verbose: true })).toBe('2 minutos 13 segundos 700 milisegundos ')
+    dayjs.locale('en')
+  })
+})
+
 describe('Clone', () => {
   it('Locale clone', () => {
     const d = dayjs.duration(1, 'minutes').locale('fr')


### PR DESCRIPTION
Based on: https://github.com/sindresorhus/pretty-ms

I think it would be pretty neat to have this natively into dayjs. At the moment I use both libs, but it feels like it is something for the duration plugin. It is a very simple copy of sindres version and some things are missing, would like to hear what others say.

Missing parts:

- locales for digits: year(s), month(s), etc.
- colon notation (if useful)
- include sub milliseconds like µs and ns
- more tests?