### PR TITLE
fix: parameter type

### DIFF
--- a/types/plugin/isBetween.d.ts
+++ b/types/plugin/isBetween.d.ts
@@ -5,6 +5,6 @@ export = plugin
 
 declare module 'dayjs' {
   interface Dayjs {
-    isBetween(a: ConfigType, b: ConfigType, c?: OpUnitType | null, d?: '()' | '[]' | '[)'): boolean
+    isBetween(a: ConfigType, b: ConfigType, c?: OpUnitType | null, d?: '()' | '[]' | '[)' | '(]'): boolean
   }
 }

--- a/types/plugin/isBetween.d.ts
+++ b/types/plugin/isBetween.d.ts
@@ -5,6 +5,6 @@ export = plugin
 
 declare module 'dayjs' {
   interface Dayjs {
-    isBetween(a: ConfigType, b: ConfigType, c?: OpUnitType | null, d?: string): boolean
+    isBetween(a: ConfigType, b: ConfigType, c?: OpUnitType | null, d?: '()' | '[]' | '[)'): boolean
   }
 }


### PR DESCRIPTION
change parameter type of plugin `isBetween`