### PR TITLE
fix: dayjs ConfigTypeMap

### DIFF
--- a/test/parse.test.js
+++ b/test/parse.test.js
@@ -89,11 +89,14 @@ describe('Parse', () => {
     expect(ds.millisecond()).toEqual(ms.millisecond())
   })
 
-  it('String Other, Null and isValid', () => {
+  it('String Other, Undefined and Null and isValid', () => {
     global.console.warn = jest.genMockFunction()// moment.js otherString will throw warn
     expect(dayjs('otherString').toString().toLowerCase()).toBe(moment('otherString').toString().toLowerCase())
+    expect(dayjs(undefined).toDate()).toEqual(moment(undefined).toDate())
     expect(dayjs().isValid()).toBe(true)
+    expect(dayjs(undefined).isValid()).toBe(true)
     expect(dayjs('').isValid()).toBe(false)
+    expect(dayjs(null).isValid()).toBe(false)
     expect(dayjs('otherString').isValid()).toBe(false)
     expect(dayjs(null).toString().toLowerCase()).toBe(moment(null).toString().toLowerCase())
   })

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -10,7 +10,7 @@ declare function dayjs (date?: dayjs.ConfigType, format?: dayjs.OptionType, loca
 
 declare namespace dayjs {
   interface ConfigTypeMap {
-    default: string | number | Date | Dayjs
+    default: string | number | Date | Dayjs | null | undefined
   }
 
   export type ConfigType = ConfigTypeMap[keyof ConfigTypeMap]

--- a/types/plugin/isBetween.d.ts
+++ b/types/plugin/isBetween.d.ts
@@ -5,6 +5,6 @@ export = plugin
 
 declare module 'dayjs' {
   interface Dayjs {
-    isBetween(a: ConfigType, b: ConfigType, c?: OpUnitType | null, d?: '()' | '[]' | '[)'): boolean
+    isBetween(a: ConfigType, b: ConfigType, c?: OpUnitType | null, d?: '()' | '[]' | '[)' | '(]'): boolean
   }
 }

--- a/types/plugin/isBetween.d.ts
+++ b/types/plugin/isBetween.d.ts
@@ -5,6 +5,6 @@ export = plugin
 
 declare module 'dayjs' {
   interface Dayjs {
-    isBetween(a: ConfigType, b: ConfigType, c?: OpUnitType | null, d?: string): boolean
+    isBetween(a: ConfigType, b: ConfigType, c?: OpUnitType | null, d?: '()' | '[]' | '[)'): boolean
   }
 }


### PR DESCRIPTION
- #1558
- fix dayjs ConfigTypeMap for Typescript
- add test case in `parse.test.ts`