### PR TITLE
Add format object type to index.d.ts

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -15,7 +15,9 @@ declare namespace dayjs {
 
   export type ConfigType = ConfigTypeMap[keyof ConfigTypeMap]
 
-  export type OptionType = { locale?: string, format?: string, utc?: boolean } | string | string[]
+  export interface FormatObject { locale?: string, format?: string, utc?: boolean }
+
+  export type OptionType = FormatObject | string | string[]
 
   export type UnitTypeShort = 'd' | 'M' | 'y' | 'h' | 'm' | 's' | 'ms'
 


### PR DESCRIPTION
Hi. Dayjs is a super flexible library. I love working with it, writing plugins, and contributing to it. We can change anything with plugins but the typing part does not come along well enough. ``Using interface and not using type aliases`` will improve typing for plugin authors so much better. I changed one of the more important ones in this PR.
```
dayjs(new Date(), { multipleLocales: [] })
```
or any other example. the point is more flexibility in typing for plugin authors. 
**if there is a way to solve this problem currently or any planning for changing the whole typing system(v2 doesn't hit that), let me know <333**