### PR TITLE
fix: isBetween for invalid date

### DIFF
--- a/src/plugin/isBetween/index.js
+++ b/src/plugin/isBetween/index.js
@@ -2,6 +2,9 @@ export default (o, c, d) => {
   c.prototype.isBetween = function (a, b, u, i) {
     const dA = d(a)
     const dB = d(b)
+    if (!dA.isValid() || !dB.isValid()) {
+      return false
+    }
     i = i || '()'
     const dAi = i[0] === '('
     const dBi = i[1] === ')'

--- a/test/plugin/isBetween.test.js
+++ b/test/plugin/isBetween.test.js
@@ -534,6 +534,52 @@ test('is between without units inclusivity', () => {
   expect(+m).toEqual(+mCopy, 'isBetween millisecond should not change moment')
 })
 
+test('is between with invalid date', () => {
+  const m = dayjs(new Date(2011, 3, 2, 3, 4, 5, 10))
+
+  expect(m.isBetween(
+    null,
+    null,
+    null,
+    '[]'
+  )).toBe(false, 'start and end are null inclusive, is not between')
+
+  expect(m.isBetween(
+    null,
+    null,
+    null,
+    '()'
+  )).toBe(false, 'start and end are null exclusive, is not between')
+
+  expect(m.isBetween(
+    null,
+    dayjs(new Date(2012, 3, 2, 3, 4, 5, 10)),
+    null,
+    '[]'
+  )).toBe(false, 'start is null and end is not null inclusive, is not between')
+
+  expect(m.isBetween(
+    null,
+    dayjs(new Date(2012, 3, 2, 3, 4, 5, 10)),
+    null,
+    '()'
+  )).toBe(false, 'start is null and end is not null exclusive, is not between')
+
+  expect(m.isBetween(
+    dayjs(new Date(2010, 3, 2, 3, 4, 5, 10)),
+    null,
+    null,
+    '[]'
+  )).toBe(false, 'start is not null and end is null inclusive, is not between')
+
+  expect(m.isBetween(
+    dayjs(new Date(2010, 3, 2, 3, 4, 5, 10)),
+    null,
+    null,
+    '()'
+  )).toBe(false, 'start is not null and end is null exclusive, is not between')
+})
+
 test('is between milliseconds inclusivity', () => {
   const m = dayjs(new Date(2011, 3, 2, 3, 4, 5, 10))
   const mCopy = dayjs(m)


### PR DESCRIPTION
## Describe the bug

On isBetween plugin with invalid date, inclusive returns true, but exclusive returns false.
```
> dayjs('2021-01-01').isBetween(null, null, 'date', '[]')
true
> dayjs('2021-01-01').isBetween(null, null, 'date', '()')
false
```

## Expected behavior

This behavior is very strange compared to moments (return false if either argument is invalid date).
```
> moment('2021-01-01').isBetween(null, null, 'date', '[]')
false
> moment('2021-01-01').isBetween(null, null, 'date', '()')
false
> moment('2021-01-01').isBetween('2020-01-01', null, 'date', '[]')
false
> moment('2021-01-01').isBetween(null, '2022-01-01', 'date', '[]')
false
```

This is because `!d.isBefore`/`!d.isAfter` for invalid date always returns true.
I think it would be better to make this behavior the same as moment.js.