### PR TITLE
Fix dayjs/esm type definitions

### DIFF
--- a/build/esm.js
+++ b/build/esm.js
@@ -5,10 +5,7 @@ const { ncp } = require('ncp')
 
 const { promisify } = util
 
-const typeFileExt = '.d.ts'
-const localeDir = path.join(process.env.PWD, 'esm/locale')
-const pluginDir = path.join(process.env.PWD, 'esm/plugin')
-const localeTypePath = path.join(process.env.PWD, 'esm/locale', `index${typeFileExt}`);
+const localeDir = path.join(__dirname, '../esm/locale');
 
 (async () => {
   try {
@@ -20,24 +17,7 @@ const localeTypePath = path.join(process.env.PWD, 'esm/locale', `index${typeFile
       await promisify(fs.writeFile)(filePath, result, 'utf8')
     })
 
-    await promisify(ncp)('./types/', './esm')
-
-    const readLocaleFile = await promisify(fs.readFile)(localeTypePath, 'utf8')
-    const localResult = readLocaleFile.replace("'dayjs", "'dayjs/esm")
-    await promisify(fs.writeFile)(localeTypePath, localResult, 'utf8')
-
-    const readPluginDir = await promisify(fs.readdir)(pluginDir)
-    readPluginDir.forEach(async (p) => {
-      if (p.includes(typeFileExt)) {
-        const pluginName = p.replace(typeFileExt, '')
-        const filePath = path.join(pluginDir, p)
-        const targetPath = path.join(pluginDir, pluginName, `index${typeFileExt}`)
-        const readFile = await promisify(fs.readFile)(filePath, 'utf8')
-        const result = readFile.replace(/'dayjs'/g, "'dayjs/esm'")
-        await promisify(fs.writeFile)(targetPath, result, 'utf8')
-        await promisify(fs.unlink)(filePath)
-      }
-    })
+    await promisify(ncp)('./types/esm/', './esm')
   } catch (e) {
     console.error(e) // eslint-disable-line no-console
   }

--- a/build/index.js
+++ b/build/index.js
@@ -14,6 +14,8 @@ const promisifyWriteFile = promisify(fs.writeFile)
 const localeNameRegex = /\/\/ (.*) \[/
 const formatName = n => n.replace(/\.js/, '').replace('-', '_')
 
+const filterEsmTypes = source => !(fs.lstatSync(source).isDirectory() && source.endsWith(`${path.sep}esm`))
+
 const localePath = path.join(__dirname, '../src/locale')
 
 async function build(option) {
@@ -62,7 +64,7 @@ async function listLocaleJson(localeArr) {
       fileName: './dayjs.min.js'
     }))
 
-    await promisify(ncp)('./types/', './')
+    await promisify(ncp)('./types/', './', { filter: filterEsmTypes })
 
     // list locales
     await listLocaleJson(locales)

--- a/types/esm/constant.d.ts
+++ b/types/esm/constant.d.ts
@@ -1,0 +1,25 @@
+export var SECONDS_A_MINUTE: number
+export var SECONDS_A_HOUR: number
+export var SECONDS_A_DAY: number
+export var SECONDS_A_WEEK: number
+export var MILLISECONDS_A_SECOND: number
+export var MILLISECONDS_A_MINUTE: number
+export var MILLISECONDS_A_HOUR: number
+export var MILLISECONDS_A_DAY: number
+export var MILLISECONDS_A_WEEK: number
+
+export var MS: string
+export var S: string
+export var MIN: string
+export var H: string
+export var D: string
+export var W: string
+export var M: string
+export var Q: string
+export var Y: string
+export var DATE: string
+export var FORMAT_DEFAULT: string
+export var INVALID_DATE_STRING: string
+
+export var REGEX_PARSE: RegExp
+export var REGEX_FORMAT: RegExp

--- a/types/esm/index.d.ts
+++ b/types/esm/index.d.ts
@@ -1,0 +1,415 @@
+/// <reference path="./locale/index.d.ts" />
+
+export default dayjs
+
+export function dayjs (date?: ConfigType, format?: OptionType, locale?: string, strict?: boolean): dayjs.Dayjs
+export function dayjs (date?: ConfigType, format?: OptionType, strict?: boolean): dayjs.Dayjs
+
+export namespace dayjs {
+  export class Dayjs {
+    constructor (config?: ConfigType)
+    /**
+     * All Day.js objects are immutable. Still, `dayjs#clone` can create a clone of the current object if you need one.
+     * ```
+     * dayjs().clone()// => Dayjs
+     * dayjs(dayjs('2019-01-25')) // passing a Dayjs object to a constructor will also clone it
+     * ```
+     * Docs: https://day.js.org/docs/en/parse/dayjs-clone
+     */
+    clone(): Dayjs
+    /**
+     * This returns a `boolean` indicating whether the Day.js object contains a valid date or not.
+     * ```
+     * dayjs().isValid()// => boolean
+     * ```
+     * Docs: https://day.js.org/docs/en/parse/is-valid
+     */
+    isValid(): boolean
+    /**
+     * Get the year.
+     * ```
+     * dayjs().year()// => 2020
+     * ```
+     * Docs: https://day.js.org/docs/en/get-set/year
+     */
+    year(): number
+    /**
+     * Set the year.
+     * ```
+     * dayjs().year(2000)// => Dayjs
+     * ```
+     * Docs: https://day.js.org/docs/en/get-set/year
+     */
+    year(value: number): Dayjs
+    /**
+     * Get the month.
+     *
+     * Months are zero indexed, so January is month 0.
+     * ```
+     * dayjs().month()// => 0-11
+     * ```
+     * Docs: https://day.js.org/docs/en/get-set/month
+     */
+    month(): number
+    /**
+     * Set the month.
+     *
+     * Months are zero indexed, so January is month 0.
+     *
+     * Accepts numbers from 0 to 11. If the range is exceeded, it will bubble up to the year.
+     * ```
+     * dayjs().month(0)// => Dayjs
+     * ```
+     * Docs: https://day.js.org/docs/en/get-set/month
+     */
+    month(value: number): Dayjs
+    /**
+     * Get the date of the month.
+     * ```
+     * dayjs().date()// => 1-31
+     * ```
+     * Docs: https://day.js.org/docs/en/get-set/date
+     */
+    date(): number
+    /**
+     * Set the date of the month.
+     *
+     * Accepts numbers from 1 to 31. If the range is exceeded, it will bubble up to the months.
+     * ```
+     * dayjs().date(1)// => Dayjs
+     * ```
+     * Docs: https://day.js.org/docs/en/get-set/date
+     */
+    date(value: number): Dayjs
+    /**
+     * Get the day of the week.
+     *
+     * Returns numbers from 0 (Sunday) to 6 (Saturday).
+     * ```
+     * dayjs().day()// 0-6
+     * ```
+     * Docs: https://day.js.org/docs/en/get-set/day
+     */
+    day(): number
+    /**
+     * Set the day of the week.
+     *
+     * Accepts numbers from 0 (Sunday) to 6 (Saturday). If the range is exceeded, it will bubble up to other weeks.
+     * ```
+     * dayjs().day(0)// => Dayjs
+     * ```
+     * Docs: https://day.js.org/docs/en/get-set/day
+     */
+    day(value: number): Dayjs
+    /**
+     * Get the hour.
+     * ```
+     * dayjs().hour()// => 0-23
+     * ```
+     * Docs: https://day.js.org/docs/en/get-set/hour
+     */
+    hour(): number
+    /**
+     * Set the hour.
+     *
+     * Accepts numbers from 0 to 23. If the range is exceeded, it will bubble up to the day.
+     * ```
+     * dayjs().hour(12)// => Dayjs
+     * ```
+     * Docs: https://day.js.org/docs/en/get-set/hour
+     */
+    hour(value: number): Dayjs
+    /**
+     * Get the minutes.
+     * ```
+     * dayjs().minute()// => 0-59
+     * ```
+     * Docs: https://day.js.org/docs/en/get-set/minute
+     */
+    minute(): number
+    /**
+     * Set the minutes.
+     *
+     * Accepts numbers from 0 to 59. If the range is exceeded, it will bubble up to the hour.
+     * ```
+     * dayjs().minute(59)// => Dayjs
+     * ```
+     * Docs: https://day.js.org/docs/en/get-set/minute
+     */
+    minute(value: number): Dayjs
+    /**
+     * Get the seconds.
+     * ```
+     * dayjs().second()// => 0-59
+     * ```
+     * Docs: https://day.js.org/docs/en/get-set/second
+     */
+    second(): number
+    /**
+     * Set the seconds.
+     *
+     * Accepts numbers from 0 to 59. If the range is exceeded, it will bubble up to the minutes.
+     * ```
+     * dayjs().second(1)// Dayjs
+     * ```
+     */
+    second(value: number): Dayjs
+    /**
+     * Get the milliseconds.
+     * ```
+     * dayjs().millisecond()// => 0-999
+     * ```
+     * Docs: https://day.js.org/docs/en/get-set/millisecond
+     */
+    millisecond(): number
+    /**
+     * Set the milliseconds.
+     *
+     * Accepts numbers from 0 to 999. If the range is exceeded, it will bubble up to the seconds.
+     * ```
+     * dayjs().millisecond(1)// => Dayjs
+     * ```
+     * Docs: https://day.js.org/docs/en/get-set/millisecond
+     */
+    millisecond(value: number): Dayjs
+    /**
+     * Generic setter, accepting unit as first argument, and value as second, returns a new instance with the applied changes.
+     *
+     * In general:
+     * ```
+     * dayjs().set(unit, value) === dayjs()[unit](value)
+     * ```
+     * Units are case insensitive, and support plural and short forms.
+     * ```
+     * dayjs().set('date', 1)
+     * dayjs().set('month', 3) // April
+     * dayjs().set('second', 30)
+     * ```
+     * Docs: https://day.js.org/docs/en/get-set/set
+     */
+    set(unit: UnitType, value: number): Dayjs
+    /**
+     * String getter, returns the corresponding information getting from Day.js object.
+     *
+     * In general:
+     * ```
+     * dayjs().get(unit) === dayjs()[unit]()
+     * ```
+     * Units are case insensitive, and support plural and short forms.
+     * ```
+     * dayjs().get('year')
+     * dayjs().get('month') // start 0
+     * dayjs().get('date')
+     * ```
+     * Docs: https://day.js.org/docs/en/get-set/get
+     */
+    get(unit: UnitType): number
+    /**
+     * Returns a cloned Day.js object with a specified amount of time added.
+     * ```
+     * dayjs().add(7, 'day')// => Dayjs
+     * ```
+     * Units are case insensitive, and support plural and short forms.
+     *
+     * Docs: https://day.js.org/docs/en/manipulate/add
+     */
+    add(value: number, unit?: OpUnitType): Dayjs
+    /**
+     * Returns a cloned Day.js object with a specified amount of time subtracted.
+     * ```
+     * dayjs().subtract(7, 'year')// => Dayjs
+     * ```
+     * Units are case insensitive, and support plural and short forms.
+     *
+     * Docs: https://day.js.org/docs/en/manipulate/subtract
+     */
+    subtract(value: number, unit?: OpUnitType): Dayjs
+    /**
+     * Returns a cloned Day.js object and set it to the start of a unit of time.
+     * ```
+     * dayjs().startOf('year')// => Dayjs
+     * ```
+     * Units are case insensitive, and support plural and short forms.
+     *
+     * Docs: https://day.js.org/docs/en/manipulate/start-of
+     */
+    startOf(unit: OpUnitType): Dayjs
+    /**
+     * Returns a cloned Day.js object and set it to the end of a unit of time.
+     * ```
+     * dayjs().endOf('month')// => Dayjs
+     * ```
+     * Units are case insensitive, and support plural and short forms.
+     *
+     * Docs: https://day.js.org/docs/en/manipulate/end-of
+     */
+    endOf(unit: OpUnitType): Dayjs
+    /**
+     * Get the formatted date according to the string of tokens passed in.
+     *
+     * To escape characters, wrap them in square brackets (e.g. [MM]).
+     * ```
+     * dayjs().format()// => current date in ISO8601, without fraction seconds e.g. '2020-04-02T08:02:17-05:00'
+     * dayjs('2019-01-25').format('[YYYYescape] YYYY-MM-DDTHH:mm:ssZ[Z]')// 'YYYYescape 2019-01-25T00:00:00-02:00Z'
+     * dayjs('2019-01-25').format('DD/MM/YYYY') // '25/01/2019'
+     * ```
+     * Docs: https://day.js.org/docs/en/display/format
+     */
+    format(template?: string): string
+    /**
+     * This indicates the difference between two date-time in the specified unit.
+     *
+     * To get the difference in milliseconds, use `dayjs#diff`
+     * ```
+     * const date1 = dayjs('2019-01-25')
+     * const date2 = dayjs('2018-06-05')
+     * date1.diff(date2) // 20214000000 default milliseconds
+     * ```
+     * To get the difference in another unit of measurement, pass that measurement as the second argument.
+     * ```
+     * const date1 = dayjs('2019-01-25')
+     * date1.diff('2018-06-05', 'month') // 7
+     * ```
+     * Units are case insensitive, and support plural and short forms.
+     *
+     * Docs: https://day.js.org/docs/en/display/difference
+     */
+    diff(date: ConfigType, unit?: QUnitType | OpUnitType, float?: boolean): number
+    /**
+     * This returns the number of **milliseconds** since the Unix Epoch of the Day.js object.
+     * ```
+     * dayjs('2019-01-25').valueOf() // 1548381600000
+     * +dayjs(1548381600000) // 1548381600000
+     * ```
+     * To get a Unix timestamp (the number of seconds since the epoch) from a Day.js object, you should use Unix Timestamp `dayjs#unix()`.
+     *
+     * Docs: https://day.js.org/docs/en/display/unix-timestamp-milliseconds
+     */
+    valueOf(): number
+    /**
+     * This returns the Unix timestamp (the number of **seconds** since the Unix Epoch) of the Day.js object.
+     * ```
+     * dayjs('2019-01-25').unix() // 1548381600
+     * ```
+     * This value is floored to the nearest second, and does not include a milliseconds component.
+     *
+     * Docs: https://day.js.org/docs/en/display/unix-timestamp
+     */
+    unix(): number
+    /**
+     * Get the number of days in the current month.
+     * ```
+     * dayjs('2019-01-25').daysInMonth() // 31
+     * ```
+     * Docs: https://day.js.org/docs/en/display/days-in-month
+     */
+    daysInMonth(): number
+    /**
+     * To get a copy of the native `Date` object parsed from the Day.js object use `dayjs#toDate`.
+     * ```
+     * dayjs('2019-01-25').toDate()// => Date
+     * ```
+     */
+    toDate(): Date
+    /**
+     * To serialize as an ISO 8601 string.
+     * ```
+     * dayjs('2019-01-25').toJSON() // '2019-01-25T02:00:00.000Z'
+     * ```
+     * Docs: https://day.js.org/docs/en/display/as-json
+     */
+    toJSON(): string
+    /**
+     * To format as an ISO 8601 string.
+     * ```
+     * dayjs('2019-01-25').toISOString() // '2019-01-25T02:00:00.000Z'
+     * ```
+     * Docs: https://day.js.org/docs/en/display/as-iso-string
+     */
+    toISOString(): string
+    /**
+     * Returns a string representation of the date.
+     * ```
+     * dayjs('2019-01-25').toString() // 'Fri, 25 Jan 2019 02:00:00 GMT'
+     * ```
+     * Docs: https://day.js.org/docs/en/display/as-string
+     */
+    toString(): string
+    /**
+     * Get the UTC offset in minutes.
+     * ```
+     * dayjs().utcOffset()
+     * ```
+     * Docs: https://day.js.org/docs/en/manipulate/utc-offset
+     */
+    utcOffset(): number
+    /**
+     * This indicates whether the Day.js object is before the other supplied date-time.
+     * ```
+     * dayjs().isBefore(dayjs('2011-01-01')) // default milliseconds
+     * ```
+     * If you want to limit the granularity to a unit other than milliseconds, pass it as the second parameter.
+     * ```
+     * dayjs().isBefore('2011-01-01', 'year')// => boolean
+     * ```
+     * Units are case insensitive, and support plural and short forms.
+     *
+     * Docs: https://day.js.org/docs/en/query/is-before
+     */
+    isBefore(date: ConfigType, unit?: OpUnitType): boolean
+    /**
+     * This indicates whether the Day.js object is the same as the other supplied date-time.
+     * ```
+     * dayjs().isSame(dayjs('2011-01-01')) // default milliseconds
+     * ```
+     * If you want to limit the granularity to a unit other than milliseconds, pass it as the second parameter.
+     * ```
+     * dayjs().isSame('2011-01-01', 'year')// => boolean
+     * ```
+     * Docs: https://day.js.org/docs/en/query/is-same
+     */
+    isSame(date: ConfigType, unit?: OpUnitType): boolean
+    /**
+     * This indicates whether the Day.js object is after the other supplied date-time.
+     * ```
+     * dayjs().isAfter(dayjs('2011-01-01')) // default milliseconds
+     * ```
+     * If you want to limit the granularity to a unit other than milliseconds, pass it as the second parameter.
+     * ```
+     * dayjs().isAfter('2011-01-01', 'year')// => boolean
+     * ```
+     * Units are case insensitive, and support plural and short forms.
+     *
+     * Docs: https://day.js.org/docs/en/query/is-after
+     */
+    isAfter(date: ConfigType, unit?: OpUnitType): boolean
+
+    locale(): string
+
+    locale(preset: string | ILocale, object?: Partial<ILocale>): Dayjs
+  }
+
+  export const Ls: { [key: string] :  ILocale }
+
+  function extend<T = unknown>(plugin: PluginFunc<T>, option?: T): Dayjs
+  function locale(preset?: string | ILocale, object?: Partial<ILocale>, isLocal?: boolean): string
+  function isDayjs(d: any): d is Dayjs
+  function unix(t: number): Dayjs
+}
+
+export interface ConfigTypeMap {
+  default: string | number | Date | dayjs.Dayjs
+}
+
+export type ConfigType = ConfigTypeMap[keyof ConfigTypeMap]
+
+export type OptionType = { locale?: string, format?: string, utc?: boolean } | string | string[]
+
+export type UnitTypeShort = 'd' | 'M' | 'y' | 'h' | 'm' | 's' | 'ms'
+export type UnitTypeLong = 'millisecond' | 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year' | 'date'
+export type UnitTypeLongPlural = 'milliseconds' | 'seconds' | 'minutes' | 'hours' | 'days' | 'months' | 'years' | 'dates'
+export type UnitType = UnitTypeLong | UnitTypeLongPlural | UnitTypeShort
+export type OpUnitType = UnitType | "week" | "weeks" | 'w'
+export type QUnitType = UnitType | "quarter" | "quarters" | 'Q'
+
+export type PluginFunc<T = unknown> = (option: T, c: dayjs.Dayjs, d: typeof dayjs) => void

--- a/types/esm/locale/index.d.ts
+++ b/types/esm/locale/index.d.ts
@@ -1,0 +1,11 @@
+/// <reference path="./types.d.ts" />
+
+declare module 'dayjs/esm/locale/*' {
+  export namespace locale {
+    export interface Locale extends ILocale {}
+  }
+
+  export const locale: locale.Locale
+
+  export default locale
+}

--- a/types/esm/locale/types.d.ts
+++ b/types/esm/locale/types.d.ts
@@ -1,0 +1,33 @@
+declare interface ILocale {
+  name: string
+  weekdays?: string[]
+  months?: string[]
+  weekStart?: number
+  weekdaysShort?: string[]
+  monthsShort?: string[]
+  weekdaysMin?: string[]
+  ordinal?: (n: number) => number | string
+  formats: Partial<{
+    LT: string
+    LTS: string
+    L: string
+    LL: string
+    LLL: string
+    LLLL: string
+  }>
+  relativeTime: Partial<{
+    future: string
+    past: string
+    s: string
+    m: string
+    mm: string
+    h: string
+    hh: string
+    d: string
+    dd: string
+    M: string
+    MM: string
+    y: string
+    yy: string
+  }>
+}

--- a/types/esm/package.json
+++ b/types/esm/package.json
@@ -1,0 +1,7 @@
+{
+  "main": "index.js",
+  "name": "dayjs",
+  "type": "module",
+  "version": "0.0.0-development",
+  "description": "placeholder for the package.json from dayjs project root with type=module and main=index.js"
+}

--- a/types/esm/plugin/advancedFormat/index.d.ts
+++ b/types/esm/plugin/advancedFormat/index.d.ts
@@ -1,0 +1,4 @@
+import { PluginFunc } from 'dayjs/esm'
+
+declare const plugin: PluginFunc
+export default plugin

--- a/types/esm/plugin/arraySupport/index.d.ts
+++ b/types/esm/plugin/arraySupport/index.d.ts
@@ -1,0 +1,10 @@
+import { PluginFunc } from 'dayjs/esm'
+
+declare const plugin: PluginFunc
+export default plugin
+
+declare module 'dayjs/esm' {
+  interface ConfigTypeMap {
+    arraySupport: [number?, number?, number?, number?, number?, number?, number?]
+  }
+}

--- a/types/esm/plugin/badMutable/index.d.ts
+++ b/types/esm/plugin/badMutable/index.d.ts
@@ -1,0 +1,4 @@
+import { PluginFunc } from 'dayjs/esm'
+
+declare const plugin: PluginFunc
+export default plugin

--- a/types/esm/plugin/buddhistEra/index.d.ts
+++ b/types/esm/plugin/buddhistEra/index.d.ts
@@ -1,0 +1,4 @@
+import { PluginFunc } from 'dayjs/esm'
+
+declare const plugin: PluginFunc
+export default plugin

--- a/types/esm/plugin/calendar/index.d.ts
+++ b/types/esm/plugin/calendar/index.d.ts
@@ -1,0 +1,12 @@
+import { PluginFunc } from 'dayjs/esm'
+
+declare const plugin: PluginFunc
+export default plugin
+
+declare module 'dayjs/esm' {
+  namespace dayjs {
+    interface Dayjs {
+      calendar(referenceTime?: ConfigType, formats?: object): string
+    }
+  }
+}

--- a/types/esm/plugin/customParseFormat/index.d.ts
+++ b/types/esm/plugin/customParseFormat/index.d.ts
@@ -1,0 +1,8 @@
+import { PluginFunc } from 'dayjs/esm'
+
+declare interface PluginOptions {
+    parseTwoDigitYear?: (yearString: string) => number
+}
+
+declare const plugin: PluginFunc<PluginOptions>
+export default plugin

--- a/types/esm/plugin/dayOfYear/index.d.ts
+++ b/types/esm/plugin/dayOfYear/index.d.ts
@@ -1,0 +1,13 @@
+import { PluginFunc } from 'dayjs/esm'
+
+declare const plugin: PluginFunc
+export default plugin
+
+declare module 'dayjs/esm' {
+  namespace dayjs {
+    interface Dayjs {
+      dayOfYear(): number
+      dayOfYear(value: number): Dayjs
+    }
+  }
+}

--- a/types/esm/plugin/devHelper/index.d.ts
+++ b/types/esm/plugin/devHelper/index.d.ts
@@ -1,0 +1,4 @@
+import { PluginFunc } from 'dayjs/esm'
+
+declare const plugin: PluginFunc
+export default plugin

--- a/types/esm/plugin/duration/index.d.ts
+++ b/types/esm/plugin/duration/index.d.ts
@@ -1,0 +1,96 @@
+import { PluginFunc } from 'dayjs/esm'
+
+declare const plugin: PluginFunc
+export default plugin
+
+  /**
+   * Definition is here just to ensure backward compatibility
+   */
+   declare namespace plugin {
+}
+
+declare module 'dayjs/esm' {
+  /**
+   * @deprecated Please use more strict types
+   */
+  export type DurationInputType = string | number | object
+
+  /**
+   * @deprecated Please use more strict types
+   */
+  export type DurationAddType = number | object | dayjs.Duration
+
+  export type DurationUnitsObjectType = Partial<{
+    [unit in Exclude<UnitTypeLongPlural, "dates"> | "weeks"]: number
+  }>
+
+  export type DurationUnitType = Exclude<OpUnitType, "date" | "dates">
+
+  export type CreateDurationType =
+    ((units: DurationUnitsObjectType) => dayjs.Duration)
+    & ((time: number, unit?: DurationUnitType) => dayjs.Duration)
+    & ((ISO_8601: string) => dayjs.Duration)
+
+  export type AddDurationType = CreateDurationType & ((duration: dayjs.Duration) => dayjs.Duration)
+
+  namespace dayjs {
+    export class Duration {
+      new (input: string | number | object, unit?: string, locale?: string): Duration
+
+      clone(): Duration
+
+      humanize(withSuffix?: boolean): string
+
+      milliseconds(): number
+      asMilliseconds(): number
+
+      seconds(): number
+      asSeconds(): number
+
+      minutes(): number
+      asMinutes(): number
+
+      hours(): number
+      asHours(): number
+
+      days(): number
+      asDays(): number
+
+      weeks(): number
+      asWeeks(): number
+
+      months(): number
+      asMonths(): number
+
+      years(): number
+      asYears(): number
+
+      as(unit: DurationUnitType): number
+
+      get(unit: DurationUnitType): number
+
+      add: AddDurationType
+      subtract: AddDurationType
+
+      toJSON(): string
+
+      toISOString(): string
+
+      format(formatStr?: string): string
+
+      locale(locale: string): Duration
+    }
+
+    export function isDuration(d: any): boolean
+
+    /**
+     * @param time - If unit is not present, time is treated as number of milliseconds
+     */
+    export const duration: CreateDurationType
+
+    interface Dayjs {
+      add(duration: Duration): Dayjs
+      subtract(duration: Duration): Dayjs
+    }
+  }
+}

--- a/types/esm/plugin/isBetween/index.d.ts
+++ b/types/esm/plugin/isBetween/index.d.ts
@@ -1,0 +1,12 @@
+import { PluginFunc } from 'dayjs/esm'
+
+declare const plugin: PluginFunc
+export default plugin
+
+declare module 'dayjs/esm' {
+  namespace dayjs {
+    interface Dayjs {
+      isBetween(a: ConfigType, b: ConfigType, c?: OpUnitType | null, d?: '()' | '[]' | '[)' | '(]'): boolean
+    }
+  }
+}

--- a/types/esm/plugin/isLeapYear/index.d.ts
+++ b/types/esm/plugin/isLeapYear/index.d.ts
@@ -1,0 +1,12 @@
+import { PluginFunc } from 'dayjs/esm'
+
+declare const plugin: PluginFunc
+export default plugin
+
+declare module 'dayjs/esm' {
+  namespace dayjs {
+    interface Dayjs {
+      isLeapYear(): boolean
+    }
+  }
+}

--- a/types/esm/plugin/isMoment/index.d.ts
+++ b/types/esm/plugin/isMoment/index.d.ts
@@ -1,0 +1,10 @@
+import { PluginFunc } from 'dayjs/esm'
+
+declare const plugin: PluginFunc
+export default plugin
+
+declare module 'dayjs/esm' {
+  namespace dayjs {
+    export function isMoment(input: any): boolean
+  }
+}

--- a/types/esm/plugin/isSameOrAfter/index.d.ts
+++ b/types/esm/plugin/isSameOrAfter/index.d.ts
@@ -1,0 +1,12 @@
+import { PluginFunc } from 'dayjs/esm'
+
+declare const plugin: PluginFunc
+export default plugin
+
+declare module 'dayjs/esm' {
+  namespace dayjs {
+    interface Dayjs {
+      isSameOrAfter(date: ConfigType, unit?: OpUnitType): boolean
+    }
+  }
+}

--- a/types/esm/plugin/isSameOrBefore/index.d.ts
+++ b/types/esm/plugin/isSameOrBefore/index.d.ts
@@ -1,0 +1,12 @@
+import { PluginFunc } from 'dayjs/esm'
+
+declare const plugin: PluginFunc
+export default plugin
+
+declare module 'dayjs/esm' {
+  namespace dayjs {
+    interface Dayjs {
+      isSameOrBefore(date: ConfigType, unit?: OpUnitType): boolean
+    }
+  }
+}

--- a/types/esm/plugin/isToday/index.d.ts
+++ b/types/esm/plugin/isToday/index.d.ts
@@ -1,0 +1,12 @@
+import { PluginFunc } from 'dayjs/esm'
+
+declare const plugin: PluginFunc
+export default plugin
+
+declare module 'dayjs/esm' {
+  namespace dayjs {
+    interface Dayjs {
+      isToday(): boolean
+    }
+  }
+}

--- a/types/esm/plugin/isTomorrow/index.d.ts
+++ b/types/esm/plugin/isTomorrow/index.d.ts
@@ -1,0 +1,12 @@
+import { PluginFunc } from 'dayjs/esm'
+
+declare const plugin: PluginFunc
+export default plugin
+
+declare module 'dayjs/esm' {
+  namespace dayjs {
+    interface Dayjs {
+      isTomorrow(): boolean
+    }
+  }
+}

--- a/types/esm/plugin/isYesterday/index.d.ts
+++ b/types/esm/plugin/isYesterday/index.d.ts
@@ -1,0 +1,12 @@
+import { PluginFunc } from 'dayjs/esm'
+
+declare const plugin: PluginFunc
+export default plugin
+
+declare module 'dayjs/esm' {
+  namespace dayjs {
+    interface Dayjs {
+      isYesterday(): boolean
+    }
+  }
+}

--- a/types/esm/plugin/isoWeek/index.d.ts
+++ b/types/esm/plugin/isoWeek/index.d.ts
@@ -1,0 +1,27 @@
+import { PluginFunc } from 'dayjs/esm'
+
+declare const plugin: PluginFunc
+export default plugin
+
+
+declare module 'dayjs/esm' {
+  export type ISOUnitType = OpUnitType | 'isoWeek'
+
+  namespace dayjs {
+    interface Dayjs {
+      isoWeekYear(): number
+      isoWeek(): number
+      isoWeek(value: number): Dayjs
+
+      isoWeekday(): number
+      isoWeekday(value: number): Dayjs
+
+      startOf(unit: ISOUnitType): Dayjs
+      endOf(unit: ISOUnitType): Dayjs
+
+      isSame(date: ConfigType, unit?: ISOUnitType): boolean
+      isBefore(date: ConfigType, unit?: ISOUnitType): boolean
+      isAfter(date: ConfigType, unit?: ISOUnitType): boolean
+    }
+  }
+}

--- a/types/esm/plugin/isoWeeksInYear/index.d.ts
+++ b/types/esm/plugin/isoWeeksInYear/index.d.ts
@@ -1,0 +1,12 @@
+import { PluginFunc } from 'dayjs/esm'
+
+declare const plugin: PluginFunc
+export default plugin
+
+declare module 'dayjs/esm' {
+  namespace dayjs {
+    interface Dayjs {
+      isoWeeksInYear(): number
+    }
+  }
+}

--- a/types/esm/plugin/localeData/index.d.ts
+++ b/types/esm/plugin/localeData/index.d.ts
@@ -1,0 +1,45 @@
+import { PluginFunc } from 'dayjs/esm'
+
+declare const plugin: PluginFunc
+export default plugin
+
+declare module 'dayjs/esm' {
+  type WeekdayNames = [string, string, string, string, string, string, string]
+  type MonthNames = [string, string, string, string, string, string, string, string, string, string, string, string]
+
+  namespace dayjs {
+
+    interface InstanceLocaleDataReturn {
+      firstDayOfWeek(): number
+      weekdays(instance?: Dayjs): WeekdayNames
+      weekdaysShort(instance?: Dayjs): WeekdayNames
+      weekdaysMin(instance?: Dayjs): WeekdayNames
+      months(instance?: Dayjs): MonthNames
+      monthsShort(instance?: Dayjs): MonthNames
+      longDateFormat(format: string): string
+      meridiem(hour?: number, minute?: number, isLower?: boolean): string
+    }
+
+    interface GlobalLocaleDataReturn {
+      firstDayOfWeek(): number
+      weekdays(): WeekdayNames
+      weekdaysShort(): WeekdayNames
+      weekdaysMin(): WeekdayNames
+      months(): MonthNames
+      monthsShort(): MonthNames
+      longDateFormat(format: string): string
+      meridiem(hour?: number, minute?: number, isLower?: boolean): string
+    }
+
+    interface Dayjs {
+      localeData(): InstanceLocaleDataReturn
+    }
+
+    export function weekdays(localOrder?: boolean): WeekdayNames
+    export function weekdaysShort(localOrder?: boolean): WeekdayNames
+    export function weekdaysMin(localOrder?: boolean): WeekdayNames
+    export function monthsShort(): MonthNames
+    export function months(): MonthNames
+    export function localeData(): GlobalLocaleDataReturn
+  }
+}

--- a/types/esm/plugin/localizedFormat/index.d.ts
+++ b/types/esm/plugin/localizedFormat/index.d.ts
@@ -1,0 +1,4 @@
+import { PluginFunc } from 'dayjs/esm'
+
+declare const plugin: PluginFunc
+export default plugin

--- a/types/esm/plugin/minMax/index.d.ts
+++ b/types/esm/plugin/minMax/index.d.ts
@@ -1,0 +1,13 @@
+import { PluginFunc } from 'dayjs/esm'
+
+declare const plugin: PluginFunc
+export default plugin
+
+declare module 'dayjs/esm' {
+  namespace dayjs {
+    export function max(dayjs: Dayjs[]): Dayjs
+    export function max(...dayjs: Dayjs[]): Dayjs
+    export function min(dayjs: Dayjs[]): Dayjs
+    export function min(...dayjs: Dayjs[]): Dayjs
+  }
+}

--- a/types/esm/plugin/objectSupport/index.d.ts
+++ b/types/esm/plugin/objectSupport/index.d.ts
@@ -1,0 +1,14 @@
+import { PluginFunc } from 'dayjs/esm'
+
+declare const plugin: PluginFunc
+export default plugin
+
+declare module 'dayjs/esm' {
+  namespace dayjs {
+    interface Dayjs {
+      set(argument: object): Dayjs
+      add(argument: object): Dayjs
+      subtract(argument: object): Dayjs
+    }
+  }
+}

--- a/types/esm/plugin/pluralGetSet/index.d.ts
+++ b/types/esm/plugin/pluralGetSet/index.d.ts
@@ -1,0 +1,37 @@
+import { PluginFunc } from 'dayjs/esm'
+
+declare const plugin: PluginFunc
+export default plugin
+
+declare module 'dayjs/esm' {
+  namespace dayjs {
+    interface Dayjs {
+      years(): number
+      years(value: number): Dayjs
+
+      months(): number
+      months(value: number): Dayjs
+
+      dates(): number
+      dates(value: number): Dayjs
+
+      weeks(): number
+      weeks(value: number): Dayjs
+
+      days(): number
+      days(value: number): Dayjs
+
+      hours(): number
+      hours(value: number): Dayjs
+
+      minutes(): number
+      minutes(value: number): Dayjs
+
+      seconds(): number
+      seconds(value: number): Dayjs
+
+      milliseconds(): number
+      milliseconds(value: number): Dayjs
+    }
+  }
+}

--- a/types/esm/plugin/preParsePostFormat/index.d.ts
+++ b/types/esm/plugin/preParsePostFormat/index.d.ts
@@ -1,0 +1,4 @@
+import { PluginFunc } from 'dayjs/esm'
+
+declare const plugin: PluginFunc
+export default plugin

--- a/types/esm/plugin/quarterOfYear/index.d.ts
+++ b/types/esm/plugin/quarterOfYear/index.d.ts
@@ -1,0 +1,23 @@
+import { PluginFunc } from 'dayjs/esm'
+
+declare const plugin: PluginFunc
+export default plugin
+
+declare module 'dayjs/esm' {
+  namespace dayjs {
+    interface Dayjs {
+      quarter(): number
+      quarter(quarter: number): Dayjs
+
+      add(value: number, unit: QUnitType): Dayjs
+      subtract(value: number, unit: QUnitType): Dayjs
+
+      startOf(unit: QUnitType): Dayjs
+      endOf(unit: QUnitType): Dayjs
+
+      isSame(date: ConfigType, unit?: QUnitType): boolean
+      isBefore(date: ConfigType, unit?: QUnitType): boolean
+      isAfter(date: ConfigType, unit?: QUnitType): boolean
+    }
+  }
+}

--- a/types/esm/plugin/relativeTime/index.d.ts
+++ b/types/esm/plugin/relativeTime/index.d.ts
@@ -1,0 +1,26 @@
+import { PluginFunc } from 'dayjs/esm'
+
+export interface RelativeTimeThreshold {
+  l: string
+  r?: number
+  d?: string
+}
+
+export interface RelativeTimeOptions {
+  rounding?: (num: number) => number
+  thresholds?: RelativeTimeThreshold[]
+}
+
+declare const plugin: PluginFunc<RelativeTimeOptions>
+export default plugin
+
+declare module 'dayjs/esm' {
+  namespace dayjs {
+    interface Dayjs {
+      fromNow(withoutSuffix?: boolean): string
+      from(compared: ConfigType, withoutSuffix?: boolean): string
+      toNow(withoutSuffix?: boolean): string
+      to(compared: ConfigType, withoutSuffix?: boolean): string
+    }
+  }
+}

--- a/types/esm/plugin/timezone/index.d.ts
+++ b/types/esm/plugin/timezone/index.d.ts
@@ -1,0 +1,22 @@
+import { PluginFunc } from 'dayjs/esm'
+
+declare const plugin: PluginFunc
+export default plugin
+
+declare module 'dayjs/esm' {
+  namespace dayjs {
+    interface Dayjs {
+      tz(timezone?: string, keepLocalTime?: boolean): Dayjs
+      offsetName(type?: 'short' | 'long'): string | undefined
+    }
+
+    interface DayjsTimezone {
+      (date: ConfigType, timezone?: string): Dayjs
+      (date: ConfigType, format: string, timezone?: string): Dayjs
+      guess(): string
+      setDefault(timezone?: string): void
+    }
+
+    const tz: DayjsTimezone
+  }
+}

--- a/types/esm/plugin/toArray/index.d.ts
+++ b/types/esm/plugin/toArray/index.d.ts
@@ -1,0 +1,12 @@
+import { PluginFunc } from 'dayjs/esm'
+
+declare const plugin: PluginFunc
+export default plugin
+
+declare module 'dayjs/esm' {
+  namespace dayjs {
+    interface Dayjs {
+      toArray(): number[]
+    }
+  }
+}

--- a/types/esm/plugin/toObject/index.d.ts
+++ b/types/esm/plugin/toObject/index.d.ts
@@ -1,0 +1,22 @@
+import { PluginFunc } from 'dayjs/esm'
+
+declare const plugin: PluginFunc
+export default plugin
+
+declare module 'dayjs/esm' {
+  namespace dayjs {
+    interface DayjsObject {
+      years: number
+      months: number
+      date: number
+      hours: number
+      minutes: number
+      seconds: number
+      milliseconds: number
+    }
+
+    interface Dayjs {
+      toObject(): DayjsObject
+    }
+  }
+}

--- a/types/esm/plugin/updateLocale/index.d.ts
+++ b/types/esm/plugin/updateLocale/index.d.ts
@@ -1,0 +1,10 @@
+import { PluginFunc } from 'dayjs/esm'
+
+declare const plugin: PluginFunc
+export default plugin
+
+declare module 'dayjs/esm' {
+  namespace dayjs {
+    export function updateLocale(localeName: String, customConfig: Object): any
+  }
+}

--- a/types/esm/plugin/utc/index.d.ts
+++ b/types/esm/plugin/utc/index.d.ts
@@ -1,0 +1,17 @@
+import { PluginFunc } from 'dayjs/esm'
+
+declare const plugin: PluginFunc
+export default plugin
+
+declare module 'dayjs/esm' {
+  namespace dayjs {
+    interface Dayjs {
+      utc(keepLocalTime?: boolean): Dayjs
+      local(): Dayjs
+      isUTC(): boolean
+      utcOffset(offset: number, keepLocalTime?: boolean): Dayjs
+    }
+  
+    export function utc(config?: ConfigType, format?: string, strict?: boolean): Dayjs
+  }
+}

--- a/types/esm/plugin/utc/index.d.ts
+++ b/types/esm/plugin/utc/index.d.ts
@@ -12,6 +12,7 @@ declare module 'dayjs/esm' {
       utcOffset(offset: number, keepLocalTime?: boolean): Dayjs
     }
   
-    export function utc(config?: ConfigType, format?: string, strict?: boolean): Dayjs
+    export function utc(date?: ConfigType, format?: OptionType, locale?: string, strict?: boolean): Dayjs
+    export function utc(date?: ConfigType, format?: OptionType, strict?: boolean): Dayjs
   }
 }

--- a/types/esm/plugin/weekOfYear/index.d.ts
+++ b/types/esm/plugin/weekOfYear/index.d.ts
@@ -1,0 +1,13 @@
+import { PluginFunc } from 'dayjs/esm'
+
+declare const plugin: PluginFunc
+export default plugin
+
+declare module 'dayjs/esm' {
+  namespace dayjs {
+    interface Dayjs {
+      week(value : number): Dayjs
+      week(): number
+    }
+  }
+}

--- a/types/esm/plugin/weekYear/index.d.ts
+++ b/types/esm/plugin/weekYear/index.d.ts
@@ -1,0 +1,12 @@
+import { PluginFunc } from 'dayjs/esm'
+
+declare const plugin: PluginFunc
+export default plugin
+
+declare module 'dayjs/esm' {
+  namespace dayjs {
+    interface Dayjs {
+      weekYear(): number
+    }
+  }
+}

--- a/types/esm/plugin/weekday/index.d.ts
+++ b/types/esm/plugin/weekday/index.d.ts
@@ -1,0 +1,13 @@
+import { PluginFunc } from 'dayjs/esm'
+
+declare const plugin: PluginFunc
+export default plugin
+
+declare module 'dayjs/esm' {
+  namespace dayjs {
+    interface Dayjs {
+      weekday(value: number): Dayjs
+      weekday(): number
+    }
+  }
+}


### PR DESCRIPTION
Make the code in the 'dayjs/esm' folder published on npmjs usable with typescript.

This pr should kind of include the modifications from pr #751 (what still remains true is the [comment](https://github.com/iamkun/dayjs/pull/751#issuecomment-657888852) of @sullvn, but pr  #751 does not solve this major rework of dayjs anyway).

This pr should be an answer to the problems described in issue #1281.

**What my pr here does**

Update the type definitions in the 'dayjs/esm' folder of the code published to npmjs, so that dayjs can be used with plain typescript and esm and without namespace imports (`import * as x`) and without any settings like `esModuleInterop` or `allowSyntheticDefaultImports`. A working sample project based on this pr and with tests for all packages can be found on [github](https://github.com/BePo65/dayjs-esm-v2-demo).

The pr contains a small modification to the 'esm.js' build script:

I used `__dirname + '../'` as replacement for `process.env.PWD` to be consistent with the 'index.js' build script (and to make it possible to run this script on my windows machine).

**What remains to be done**

I did not find the script to update package.json during publishing, so I have to stay with a placeholder file in 'dayjs/esm'. I suppose that in this script the version tag in package.json is updated.

Part of the solution of the problem with using dayjs as an esm package was adding a copy of the package.json to the folder 'dayjs/esm' with `type=module` and `main=index.js` in it. The rest of the content should come from the package.json in 'dayjs'. This is something that still has to be done and is not part of this pull request.

