### PR TITLE
Update Slovenian local

### DIFF
--- a/src/locale/sl.js
+++ b/src/locale/sl.js
@@ -20,17 +20,17 @@ const locale = {
   },
   relativeTime: {
     future: 'čez %s',
-    past: 'pred %s',
+    past: '%s nazaj',
     s: 'nekaj sekund',
-    m: 'minuta',
+    m: 'eno minuto',
     mm: '%d minut',
-    h: 'ura',
+    h: 'eno uro',
     hh: '%d ur',
-    d: 'dan',
+    d: 'en dan',
     dd: '%d dni',
-    M: 'mesec',
+    M: 'en mesec',
     MM: '%d mesecev',
-    y: 'leto',
+    y: 'eno leto',
     yy: '%d let'
   }
 }


### PR DESCRIPTION
Current version of relativeTime in Slovenian locale is inconsistent for future and past together, it only works for the future. Past is changed to be more like "%s ago" in english. One is added to minute, hour, day, month and year to be consistent with other languages.