### PR TITLE
Update nb.js `yearStart`

### DIFF
--- a/src/locale/nb.js
+++ b/src/locale/nb.js
@@ -10,6 +10,7 @@ const locale = {
   monthsShort: 'jan._feb._mars_april_mai_juni_juli_aug._sep._okt._nov._des.'.split('_'),
   ordinal: n => `${n}.`,
   weekStart: 1,
+  yearStart: 4,
   formats: {
     LT: 'HH:mm',
     LTS: 'HH:mm:ss',


### PR DESCRIPTION
Norway (Norwegian Bokmål) follows ISO 8601 weeks.
So adding `yearStart: 4` should help display correct week with `weekOfYear` plugin (`.week()` function).