### PR TITLE
Fix Lithuanian spelling for single month

### DIFF
--- a/src/locale/lt.js
+++ b/src/locale/lt.js
@@ -34,7 +34,7 @@ const locale = {
     hh: '%d valandas',
     d: 'dieną',
     dd: '%d dienas',
-    M: 'menesį',
+    M: 'mėnesį',
     MM: '%d mėnesius',
     y: 'metus',
     yy: '%d metus'


### PR DESCRIPTION
Native Lithuanian here. The word is missing a dot over letter "e". Google translate screenshot to assure:

![image](https://user-images.githubusercontent.com/1069214/129604940-48f7b121-cf4f-4593-b516-42b3bed683c6.png)
