### PR TITLE
fix: when parsing duration from ISO string, set missing components to 0 instead of NaN

### DIFF
--- a/src/plugin/duration/index.js
+++ b/src/plugin/duration/index.js
@@ -84,7 +84,7 @@ class Duration {
       const d = input.match(durationRegex)
       if (d) {
         const properties = d.slice(2)
-        const numberD = properties.map(value => Number(value));
+        const numberD = properties.map(value => (value != null ? Number(value) : 0));
         [
           this.$d.years,
           this.$d.months,

--- a/test/plugin/duration.test.js
+++ b/test/plugin/duration.test.js
@@ -76,6 +76,9 @@ describe('Parse ISO string', () => {
   it('Part ISO string', () => {
     expect(dayjs.duration('PT2777H46M40S').toISOString()).toBe('PT2777H46M40S')
   })
+  it('Formatting missing components', () => {
+    expect(dayjs.duration('PT1H').format('YYYY-MM-DDTHH:mm:ss')).toBe('0000-00-00T01:00:00')
+  })
   it('ISO string with week', () => {
     const d = dayjs.duration('P2M3W4D')
     expect(d.toISOString()).toBe('P2M25D')


### PR DESCRIPTION
Fixes #1521