### PR TITLE
Add parsing ASP.NET style time duration for Duration plugin

### DIFF
--- a/src/plugin/duration/index.js
+++ b/src/plugin/duration/index.js
@@ -12,7 +12,7 @@ const MILLISECONDS_A_MONTH = MILLISECONDS_A_DAY * 30
 
 const durationRegex = /^(-|\+)?P(?:([-+]?[0-9,.]*)Y)?(?:([-+]?[0-9,.]*)M)?(?:([-+]?[0-9,.]*)W)?(?:([-+]?[0-9,.]*)D)?(?:T(?:([-+]?[0-9,.]*)H)?(?:([-+]?[0-9,.]*)M)?(?:([-+]?[0-9,.]*)S)?)?$/
 
-const aspNetRegex = /^(-|\+)?(?:(\d*)[. ])?(\d+):(\d+)(?::(\d+)(\.\d*)?)?$/
+const aspNetRegex = /^(-|\+)?(?:(\d*)[. ])?(\d+):(\d+)(?::(\d+))?$/
 
 const unitToMS = {
   years: MILLISECONDS_A_YEAR,
@@ -100,7 +100,7 @@ class Duration {
         return this
       }
       const aspNetD = input.match(aspNetRegex)
-      if(aspNetD) {
+      if (aspNetD) {
         const properties = aspNetD.slice(2)
         const numberD = properties.map(value => Number(value));
         [

--- a/src/plugin/duration/index.js
+++ b/src/plugin/duration/index.js
@@ -12,6 +12,8 @@ const MILLISECONDS_A_MONTH = MILLISECONDS_A_DAY * 30
 
 const durationRegex = /^(-|\+)?P(?:([-+]?[0-9,.]*)Y)?(?:([-+]?[0-9,.]*)M)?(?:([-+]?[0-9,.]*)W)?(?:([-+]?[0-9,.]*)D)?(?:T(?:([-+]?[0-9,.]*)H)?(?:([-+]?[0-9,.]*)M)?(?:([-+]?[0-9,.]*)S)?)?$/
 
+const aspNetRegex = /^(-|\+)?(?:(\d*)[. ])?(\d+):(\d+)(?::(\d+)(\.\d*)?)?$/
+
 const unitToMS = {
   years: MILLISECONDS_A_YEAR,
   months: MILLISECONDS_A_MONTH,
@@ -89,6 +91,19 @@ class Duration {
           this.$d.years,
           this.$d.months,
           this.$d.weeks,
+          this.$d.days,
+          this.$d.hours,
+          this.$d.minutes,
+          this.$d.seconds
+        ] = numberD
+        this.calMilliseconds()
+        return this
+      }
+      const aspNetD = input.match(aspNetRegex)
+      if(aspNetD) {
+        const properties = aspNetD.slice(2)
+        const numberD = properties.map(value => Number(value));
+        [
           this.$d.days,
           this.$d.hours,
           this.$d.minutes,

--- a/test/plugin/duration.test.js
+++ b/test/plugin/duration.test.js
@@ -87,6 +87,26 @@ describe('Parse ISO string', () => {
   })
 })
 
+describe('Parse ASP string', () => {
+  it('Full ASP string', () => {
+    expect(dayjs.duration('0.00:00:34').asMilliseconds()).toBe(34000)
+    expect(dayjs.duration('1.00:00:07').asMilliseconds()).toBe(86407000)
+    expect(dayjs.duration('1 00:00:07').asMilliseconds()).toBe(86407000)
+  })
+  it('Part ASP string', () => {
+    expect(dayjs.duration('00:00:34').asMilliseconds()).toBe(34000)
+  })
+  it('ASP string with day', () => {
+    expect(dayjs.duration('1 00:00:00').asDays()).toBe(1)
+    expect(dayjs.duration('00:00:00').asDays()).toBe(0)
+  })
+  it('ASP string with hour/minute/second', () => {
+    expect(dayjs.duration('01:00:00').asHours()).toBe(1)
+    expect(dayjs.duration('00:01:00').asMinutes()).toBe(1)
+    expect(dayjs.duration('00:00:01').asSeconds()).toBe(1)
+  })
+})
+
 it('Is duration', () => {
   expect(dayjs.isDuration(dayjs.duration())).toBe(true)
   expect(dayjs.isDuration(dayjs.duration(1))).toBe(true)


### PR DESCRIPTION
The format is an hour, minute, second string separated by colons like `23:59:59`. The number of days can be prefixed with a dot or  a space separator like so `7.23:59:59` or `7 23:59:59`. Partial seconds are supported as well `23:59:59`.
```
dayjs.duration('23:59:59');
dayjs.duration('7.23:59:59');
dayjs.duration('7 23:59:59');
dayjs.duration('23:59');
```
**Note**: This usage method depends on `Duration` plugin
