### PR TITLE
fix: daysJS.extend returns typeof dayJS, not an instance

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -417,7 +417,7 @@ declare namespace dayjs {
 
   export type PluginFunc<T = unknown> = (option: T, c: typeof Dayjs, d: typeof dayjs) => void
 
-  export function extend<T = unknown>(plugin: PluginFunc<T>, option?: T): Dayjs
+  export function extend<T = unknown>(plugin: PluginFunc<T>, option?: T): typeof Dayjs
 
   export function locale(preset?: string | ILocale, object?: Partial<ILocale>, isLocal?: boolean): string
 


### PR DESCRIPTION
Title pretty much says it all.
Refer to source code: https://github.com/iamkun/dayjs/blob/dev/src/index.js#L390

Proper typing enables extend chaining in typescript

e.g.
dayjs.extend(foo).extend(bar)

Should result in a "patch" update. Technically type change would be a major, but considering the current is incorrect, it is unreasonable to assume anyone is using it as-typed and would therefore have a broken process.