### PR TITLE
fix: add config type definition to objectSupport plugin

### DIFF
--- a/types/plugin/objectSupport.d.ts
+++ b/types/plugin/objectSupport.d.ts
@@ -9,4 +9,10 @@ declare module 'dayjs' {
         add(argument: object): Dayjs
         subtract(argument: object): Dayjs
     }
+
+    interface ConfigTypeMap {
+        objectSupport: {
+            [key in UnitType]?: number;
+        }
+    }
 }


### PR DESCRIPTION
Currently Typescript gives an error when using a date in object notation as provided by the `objectSupport` plugin. 

For example this will give a TypeScript error: 

```ts
dayjs.utc({
  y: 2021,
  M: 10,
  d: 1,
});
```

This PR fixes it.