### PR TITLE
fix: Add type definition to `LocaleData.ordinal`

### DIFF
--- a/types/plugin/localeData.d.ts
+++ b/types/plugin/localeData.d.ts
@@ -16,6 +16,7 @@ declare module 'dayjs' {
     monthsShort(instance?: Dayjs): MonthNames;
     longDateFormat(format: string): string;
     meridiem(hour?: number, minute?: number, isLower?: boolean): string;
+    ordinal(n: number): number | string;
   }
 
   interface GlobalLocaleDataReturn {
@@ -27,6 +28,7 @@ declare module 'dayjs' {
     monthsShort(): MonthNames;
     longDateFormat(format: string): string;
     meridiem(hour?: number, minute?: number, isLower?: boolean): string;
+    ordinal(n: number): number | string;
   }
 
   interface Dayjs {


### PR DESCRIPTION
`LocaleData.ordinal` was added in #1266, but there is no TypeScript type definition.