### PR TITLE
[Typescript] Fix ManipulateType type

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -29,7 +29,7 @@ declare namespace dayjs {
 
   export type OpUnitType = UnitType | "week" | "weeks" | 'w';
   export type QUnitType = UnitType | "quarter" | "quarters" | 'Q';
-  export type ManipulateType = Omit<OpUnitType, 'date' | 'dates'>;
+  export type ManipulateType = Exclude<OpUnitType, 'date' | 'dates'>;
   class Dayjs {
     constructor (config?: ConfigType)
     /**


### PR DESCRIPTION
Should be [`Exclude`](https://www.typescriptlang.org/docs/handbook/utility-types.html#excludetype-excludedunion) rather than [`Omit`](https://www.typescriptlang.org/docs/handbook/utility-types.html#omittype-keys) as the latter works on objects while former works on unions.