### PR TITLE
fix: +00:00 timezone bug

### DIFF
--- a/src/plugin/utc/index.js
+++ b/src/plugin/utc/index.js
@@ -114,7 +114,8 @@ export default (option, Dayjs, dayjs) => {
 
   proto.valueOf = function () {
     const addedOffset = !this.$utils().u(this.$offset)
-      ? this.$offset + (this.$x.$localOffset || (new Date()).getTimezoneOffset()) : 0
+      ? this.$offset + ((this.$x.$localOffset === null || this.$x.$localOffset === undefined)
+        ? new Date().getTimezoneOffset() : this.$x.$localOffset) : 0
     return this.$d.valueOf() - (addedOffset * MILLISECONDS_A_MINUTE)
   }
 


### PR DESCRIPTION
When we have +00:00 timezone offset like 'Europe/London" dayjs gets users timezone offset, which causes incorrect time showing in different cases.

**Example**

Current behavior:
`dayjs('2021-10-31T15:00:00+00:00').tz('Europe/Moscow').format() // 2020-12-20T23:30:00Z`

Behavior after fix:
`dayjs('2021-10-31T15:00:00+00:00').tz('Europe/Moscow').format() // 2021-10-31T23:30:00+00:00`