### PR TITLE
fix: correctly parse ISO-8601 string in timezone

### DIFF
--- a/src/plugin/timezone/index.js
+++ b/src/plugin/timezone/index.js
@@ -133,6 +133,10 @@ export default (o, c, d) => {
       // timestamp number || js Date || Day.js
       return d(input).tz(timezone)
     }
+    if (/Z$/i.test(input)) {
+      // ISO_8601 string
+      return d.utc(input).tz(timezone)
+    }
     const localTs = d.utc(input, parseFormat).valueOf()
     const [targetTs, targetOffset] = fixOffset(localTs, previousOffset, timezone)
     const ins = d(targetTs).utcOffset(targetOffset)

--- a/test/plugin/timezone.test.js
+++ b/test/plugin/timezone.test.js
@@ -54,6 +54,14 @@ describe('Parse', () => {
     expect(Tmoment.format()).toBe(result)
   })
 
+  it('parse ISO_8601 string', () => {
+    const isoString = '2020-08-07T04:00:00.000Z'
+    const dateTz = dayjs.tz(isoString, NY)
+    const MdateTz = moment.tz(isoString, NY)
+    expect(dateTz.format()).toBe('2020-08-07T00:00:00-04:00')
+    expect(dateTz.format()).toBe(MdateTz.format())
+  })
+
   it('parse and convert between timezones', () => {
     const newYork = dayjs.tz('2014-06-01 12:00', NY)
     expect(newYork.tz('America/Los_Angeles').format()).toBe('2014-06-01T09:00:00-07:00')


### PR DESCRIPTION
fixes #1687 