### PR TITLE
fix: replaces monthShort format for 'de' locale

### DIFF
--- a/src/locale/de.js
+++ b/src/locale/de.js
@@ -29,7 +29,7 @@ const locale = {
   weekdaysShort: 'So._Mo._Di._Mi._Do._Fr._Sa.'.split('_'),
   weekdaysMin: 'So_Mo_Di_Mi_Do_Fr_Sa'.split('_'),
   months: 'Januar_Februar_März_April_Mai_Juni_Juli_August_September_Oktober_November_Dezember'.split('_'),
-  monthsShort: 'Jan_Feb_März_Apr_Mai_Juni_Juli_Aug_Sept_Okt_Nov_Dez'.split('_'),
+  monthsShort: 'Jan._Feb._März_Apr._Mai_Juni_Juli_Aug._Sep._Okt._Nov._Dez.'.split('_'),
   ordinal: n => `${n}.`,
   weekStart: 1,
   yearStart: 4,

--- a/test/plugin/localeData.test.js
+++ b/test/plugin/localeData.test.js
@@ -2,6 +2,7 @@ import MockDate from 'mockdate'
 import moment from 'moment'
 import dayjs from '../../src'
 import '../../src/locale/fr'
+import '../../src/locale/de'
 import '../../src/locale/ru'
 import '../../src/locale/zh-cn'
 import localeData from '../../src/plugin/localeData'
@@ -19,7 +20,7 @@ afterEach(() => {
 })
 
 describe('Instance localeData', () => {
-  ['zh-cn', 'en', 'fr'].forEach((lo) => {
+  ['zh-cn', 'en', 'fr', 'de'].forEach((lo) => {
     it(`Locale: ${lo}`, () => {
       dayjs.locale(lo)
       moment.locale(lo)
@@ -50,7 +51,7 @@ describe('Instance localeData', () => {
 
 
 it('Global localeData', () => {
-  ['zh-cn', 'en', 'fr'].forEach((lo) => {
+  ['zh-cn', 'en', 'fr', 'de'].forEach((lo) => {
     dayjs.locale(lo)
     moment.locale(lo)
     const dayjsLocaleData = dayjs.localeData()
@@ -70,7 +71,7 @@ it('Global localeData', () => {
 
 
 it('Listing the months and weekdays', () => {
-  ['zh-cn', 'en', 'fr'].forEach((lo) => {
+  ['zh-cn', 'en', 'fr', 'de'].forEach((lo) => {
     dayjs.locale(lo)
     moment.locale(lo)
     expect(dayjs.months()).toEqual(moment.months())


### PR DESCRIPTION
`de` locale abbreviations for monthsShort differ from Moment.js since a dot is missing at the end of months with more than 4 letters.

This PR fixes `monthShort` format for `de` locale.

See issue https://github.com/iamkun/dayjs/issues/1693