### PR TITLE
fix(locale-pt-and-pt-br): set correct weekdays and months

### DIFF
--- a/src/locale/pt-br.js
+++ b/src/locale/pt-br.js
@@ -3,11 +3,11 @@ import dayjs from 'dayjs'
 
 const locale = {
   name: 'pt-br',
-  weekdays: 'Domingo_Segunda-feira_Terça-feira_Quarta-feira_Quinta-feira_Sexta-feira_Sábado'.split('_'),
-  weekdaysShort: 'Dom_Seg_Ter_Qua_Qui_Sex_Sáb'.split('_'),
+  weekdays: 'domingo_segunda-feira_terça-feira_quarta-feira_quinta-feira_sexta-feira_sábado'.split('_'),
+  weekdaysShort: 'dom_seg_ter_qua_qui_sex_sáb'.split('_'),
   weekdaysMin: 'Do_2ª_3ª_4ª_5ª_6ª_Sá'.split('_'),
-  months: 'Janeiro_Fevereiro_Março_Abril_Maio_Junho_Julho_Agosto_Setembro_Outubro_Novembro_Dezembro'.split('_'),
-  monthsShort: 'Jan_Fev_Mar_Abr_Mai_Jun_Jul_Ago_Set_Out_Nov_Dez'.split('_'),
+  months: 'janeiro_fevereiro_março_abril_maio_junho_julho_agosto_setembro_outubro_novembro_dezembro'.split('_'),
+  monthsShort: 'jan_fev_mar_abr_mai_jun_jul_ago_set_out_nov_dez'.split('_'),
   ordinal: n => `${n}º`,
   formats: {
     LT: 'HH:mm',

--- a/src/locale/pt.js
+++ b/src/locale/pt.js
@@ -3,11 +3,11 @@ import dayjs from 'dayjs'
 
 const locale = {
   name: 'pt',
-  weekdays: 'Domingo_Segunda-feira_Terça-feira_Quarta-feira_Quinta-feira_Sexta-feira_Sábado'.split('_'),
-  weekdaysShort: 'Dom_Seg_Ter_Qua_Qui_Sex_Sab'.split('_'),
+  weekdays: 'domingo_segunda-feira_terça-feira_quarta-feira_quinta-feira_sexta-feira_sábado'.split('_'),
+  weekdaysShort: 'dom_seg_ter_qua_qui_sex_sab'.split('_'),
   weekdaysMin: 'Do_2ª_3ª_4ª_5ª_6ª_Sa'.split('_'),
-  months: 'Janeiro_Fevereiro_Março_Abril_Maio_Junho_Julho_Agosto_Setembro_Outubro_Novembro_Dezembro'.split('_'),
-  monthsShort: 'Jan_Fev_Mar_Abr_Mai_Jun_Jul_Ago_Set_Out_Nov_Dez'.split('_'),
+  months: 'janeiro_fevereiro_março_abril_maio_junho_julho_agosto_setembro_outubro_novembro_dezembro'.split('_'),
+  monthsShort: 'jan_fev_mar_abr_mai_jun_jul_ago_set_out_nov_dez'.split('_'),
   ordinal: n => `${n}º`,
   weekStart: 1,
   yearStart: 4,


### PR DESCRIPTION
Based on https://github.com/iamkun/dayjs/pull/275, in this case for `pt` and `pt-br`.

Fixes https://github.com/iamkun/dayjs/issues/1696