### PR TITLE
fix: Meridiem afternoon check logic

### DIFF
--- a/src/plugin/customParseFormat/index.js
+++ b/src/plugin/customParseFormat/index.js
@@ -43,16 +43,22 @@ const getLocalePart = (name) => {
     part.indexOf ? part : part.s.concat(part.f)
   )
 }
-const meridiemMatch = (input, isLowerCase) => {
+const meridiemMatch = (input, hours, minutes, isLowerCase) => {
   let isAfternoon
   const { meridiem } = locale
+
   if (!meridiem) {
+    // case: don't have meridiem
     isAfternoon = input === (isLowerCase ? 'pm' : 'PM')
+  } else if (hours !== undefined) {
+    // case: has meridiem(), hours
+    const matched = input === meridiem(hours, (minutes || 0), isLowerCase)
+    isAfternoon = matched ? hours > 11 : (hours + 12) > 11
   } else {
-    for (let i = 1; i <= 24; i += 1) {
-      // todo: fix input === meridiem(i, 0, isLowerCase)
+    // case: has only meridiem()
+    for (let i = 0; i < 24; i += 1) {
       if (input.indexOf(meridiem(i, 0, isLowerCase)) > -1) {
-        isAfternoon = i > 11
+        isAfternoon = i > 11 // AM(0~11), PM(12~23)
         break
       }
     }
@@ -61,10 +67,10 @@ const meridiemMatch = (input, isLowerCase) => {
 }
 const expressions = {
   A: [matchWord, function (input) {
-    this.afternoon = meridiemMatch(input, false)
+    this.afternoon = meridiemMatch(input, this.hours, this.minutes, false)
   }],
   a: [matchWord, function (input) {
-    this.afternoon = meridiemMatch(input, true)
+    this.afternoon = meridiemMatch(input, this.hours, this.minutes, true)
   }],
   S: [match1, function (input) {
     this.milliseconds = +input * 100

--- a/src/plugin/customParseFormat/index.js
+++ b/src/plugin/customParseFormat/index.js
@@ -52,7 +52,7 @@ const meridiemMatch = (input, isLowerCase) => {
     for (let i = 1; i <= 24; i += 1) {
       // todo: fix input === meridiem(i, 0, isLowerCase)
       if (input.indexOf(meridiem(i, 0, isLowerCase)) > -1) {
-        isAfternoon = i > 12
+        isAfternoon = i > 11
         break
       }
     }

--- a/test/plugin/customParseFormat.test.js
+++ b/test/plugin/customParseFormat.test.js
@@ -4,6 +4,7 @@ import dayjs from '../../src'
 import '../../src/locale/ru'
 import uk from '../../src/locale/uk'
 import '../../src/locale/zh-cn'
+import '../../src/locale/ko'
 import customParseFormat from '../../src/plugin/customParseFormat'
 import advancedFormat from '../../src/plugin/advancedFormat'
 import localizedFormats from '../../src/plugin/localizedFormat'
@@ -339,11 +340,41 @@ describe('meridiem locale', () => {
     const input = '2018-05-02 01:02:03'
     const date = dayjs(input).locale('zh-cn').format(format)
     expect(dayjs(date, format, 'zh-cn').format(format2)).toBe(input)
+    expect(dayjs(input, format2).locale('zh-cn').format(format)).toBe(date)
   })
   it('PM', () => {
     const input = '2018-05-02 20:02:03'
     const date = dayjs(input).locale('zh-cn').format(format)
     expect(dayjs(date, format, 'zh-cn').format(format2)).toBe(input)
+    expect(dayjs(input, format2).locale('zh-cn').format(format2)).toBe(input)
+  })
+})
+
+describe('meridiem translation', () => {
+  const format = 'HH:mm'
+  const am = '09:00'
+  const pm = '21:00'
+  it('en', () => {
+    const formatEn = 'h:mm A'
+    const amEn = '9:00 AM'
+    const pmEn = '9:00 PM'
+    // am
+    expect(dayjs(am, format).format(formatEn)).toEqual(amEn)
+    expect(dayjs(amEn, formatEn).format(format)).toEqual(am)
+    // pm
+    expect(dayjs(pm, format).format(formatEn)).toEqual(pmEn)
+    expect(dayjs(pmEn, formatEn).format(format)).toEqual(pm)
+  })
+  it('ko', () => {
+    const formatKo = 'A h시mm분'
+    const amKo = '오전 9시00분'
+    const pmKo = '오후 9시00분'
+    // am
+    expect(dayjs(am, format).locale('ko').format(formatKo)).toEqual(amKo)
+    expect(dayjs(amKo, formatKo, 'ko').format(format)).toEqual(am)
+    // pm
+    expect(dayjs(pm, format).locale('ko').format(formatKo)).toEqual(pmKo)
+    expect(dayjs(pmKo, formatKo, 'ko').format(format)).toEqual(pm)
   })
 })
 

--- a/test/plugin/customParseFormat.test.js
+++ b/test/plugin/customParseFormat.test.js
@@ -351,30 +351,17 @@ describe('meridiem locale', () => {
 })
 
 describe('meridiem translation', () => {
-  const format = 'HH:mm'
-  const am = '09:00'
-  const pm = '21:00'
-  it('en', () => {
-    const formatEn = 'h:mm A'
-    const amEn = '9:00 AM'
-    const pmEn = '9:00 PM'
-    // am
-    expect(dayjs(am, format).format(formatEn)).toEqual(amEn)
-    expect(dayjs(amEn, formatEn).format(format)).toEqual(am)
-    // pm
-    expect(dayjs(pm, format).format(formatEn)).toEqual(pmEn)
-    expect(dayjs(pmEn, formatEn).format(format)).toEqual(pm)
+  it('zh-cn', () => {
+    const tests = ['1:30 凌晨', '8:30 早上', '10:30 上午', '11:30 中午', '12:30 中午', '4:30 下午', '11:30 晚上']
+    tests.forEach(test => expect(dayjs(test, 'h:mm A', 'zh-cn', true).format('h:mm A')).toEqual(test))
   })
   it('ko', () => {
-    const formatKo = 'A h시mm분'
-    const amKo = '오전 9시00분'
-    const pmKo = '오후 9시00분'
-    // am
-    expect(dayjs(am, format).locale('ko').format(formatKo)).toEqual(amKo)
-    expect(dayjs(amKo, formatKo, 'ko').format(format)).toEqual(am)
-    // pm
-    expect(dayjs(pm, format).locale('ko').format(formatKo)).toEqual(pmKo)
-    expect(dayjs(pmKo, formatKo, 'ko').format(format)).toEqual(pm)
+    const tests = ['오전 12:00', '오전 3:30', '오후 12:00', '오후 3:30']
+    tests.forEach(test => expect(dayjs(test, 'A h:mm', 'ko', true).format('A h:mm')).toEqual(test))
+  })
+  it('ru', () => {
+    const tests = ['1:30 ночи', '11:30 утра', '12:30 дня', '9:30 вечера']
+    tests.forEach(test => expect(dayjs(test, 'h:mm A', 'ru', true).format('h:mm A')).toEqual(test))
   })
 })
 


### PR DESCRIPTION
fix: #1373 

**Before :** 
(h:mm A) -> translated time (O, works)
translate time -> (h:mm A) (X, has problem)

**What Changed:** 
- Added meridiem translation test on customParseFormat.test.js
- Changed checking meridiem logic on customParseFormat.js

Basically, 00:00 is 12:00AM and 12:00 is 12:00PM.
Because of this, most of language has meridiem like ```meridiem: hour => (hour < 12 ? '午前' : '午後'),```
So I changed ```isAfternoon = i > 12```  to ```isAfternoon = i > 11 ``` at customParseFormat.

Also, I found 'zh-cn' and 'ru' have a little bit different logic.
so I added logic for this with its hours and minutes.
