### PR TITLE
add `meridiem` function to ku locale

### DIFF
--- a/src/locale/ku.js
+++ b/src/locale/ku.js
@@ -18,6 +18,7 @@ const locale = {
     LLL: 'D MMMM YYYY HH:mm',
     LLLL: 'dddd, D MMMM YYYY HH:mm'
   },
+  meridiem: hour => (hour < 12 ? 'پ.ن' : 'د.ن'),
   relativeTime: {
     future: 'له‌ %s',
     past: '%s',

--- a/test/locale/ku.test.js
+++ b/test/locale/ku.test.js
@@ -1,0 +1,20 @@
+import MockDate from 'mockdate'
+import dayjs from '../../src'
+import '../../src/locale/ku'
+
+beforeEach(() => {
+  MockDate.set(new Date())
+})
+
+afterEach(() => {
+  MockDate.reset()
+})
+
+it('Format meridiem correctly', () => {
+  for (let i = 0; i <= 23; i += 1) {
+    const dayjsKu = dayjs()
+      .startOf('day')
+      .add(i, 'hour')
+    expect(dayjsKu.locale('ku').format('h A')).toBe(`${i % 12 || 12} ${i < 12 ? 'پ.ن' : 'د.ن'}`)
+  }
+})


### PR DESCRIPTION
Kurdish `ku` locale has it's own form of meridiem texts which are:
`AM` -> `پ.ن`
`PM` -> `د.ن`
The logic of determining which should be chosen is identical
to the main logic from the library, the only change is localized
strings for each case.
Also tests are added to the corresponding locale to ensure it
gets formatted correctly.

Closes #1724