### PR TITLE
startOf is off when using timezones

### DIFF
--- a/src/plugin/utc/index.js
+++ b/src/plugin/utc/index.js
@@ -89,8 +89,11 @@ export default (option, Dayjs, dayjs) => {
     const offset = Math.abs(input) <= 16 ? input * 60 : input
     let ins = this
     if (keepLocalTime) {
+      const localTimezoneOffset = this.$u
+        ? this.toDate().getTimezoneOffset() : -1 * this.utcOffset()
       ins.$offset = offset
       ins.$u = input === 0
+      ins.$x.$localOffset = localTimezoneOffset
       return ins
     }
     if (input !== 0) {

--- a/test/timezone.test.js
+++ b/test/timezone.test.js
@@ -15,6 +15,15 @@ afterEach(() => {
   MockDate.reset()
 })
 
+it('Parse timezones', () => {
+  expect(dayjs('2021-07-07').tz('Europe/London').startOf('week').format('HH:mm')).toBe('00:00')
+  expect(dayjs('2021-12-12').tz('Europe/London').startOf('week').format('HH:mm')).toBe('00:00')
+
+  expect(dayjs('2013-11-18 11:00').tz('Europe/London').add(-300, 'minute').valueOf()).toBe(dayjs('2013-11-18 11:00').add(-300, 'minute').valueOf())
+  expect(dayjs('2013-11-18 11:00').tz('Europe/London').format('HH:mm')).toBe('16:00')
+  expect(dayjs('2013-11-18 11:00').tz('Europe/London').add(-300, 'minute').format('HH:mm')).toBe('11:00')
+})
+
 it('Add Time days (DST)', () => {
   // change timezone before running test
   // New Zealand (-720)


### PR DESCRIPTION
#1437 

This fix does seem to fix some already failing unit tests as well. I'm not sure that it takes care of all the edge cases though especially the change in the utcOffset() which was added because utc.valueOf was returning the wrong value since it was using the  (new Date()).getTimezoneOffset() since no $localOffset was set and Date.now() could have a different offset than the date we want because of DST