### PR TITLE
fix(Duration): Normalize month duration

### DIFF
--- a/src/plugin/duration/index.js
+++ b/src/plugin/duration/index.js
@@ -8,7 +8,8 @@ import {
 } from '../../constant'
 
 const MILLISECONDS_A_YEAR = MILLISECONDS_A_DAY * 365
-const MILLISECONDS_A_MONTH = MILLISECONDS_A_DAY * 30
+const NORMALIZED_DAYS_A_MONTH = (365 / 12).toFixed(2)
+const MILLISECONDS_A_MONTH = MILLISECONDS_A_DAY * NORMALIZED_DAYS_A_MONTH
 
 const durationRegex = /^(-|\+)?P(?:([-+]?[0-9,.]*)Y)?(?:([-+]?[0-9,.]*)M)?(?:([-+]?[0-9,.]*)W)?(?:([-+]?[0-9,.]*)D)?(?:T(?:([-+]?[0-9,.]*)H)?(?:([-+]?[0-9,.]*)M)?(?:([-+]?[0-9,.]*)S)?)?$/
 

--- a/test/plugin/duration.test.js
+++ b/test/plugin/duration.test.js
@@ -82,8 +82,8 @@ describe('Parse ISO string', () => {
   it('ISO string with week', () => {
     const d = dayjs.duration('P2M3W4D')
     expect(d.toISOString()).toBe('P2M25D')
-    expect(d.asDays()).toBe(85) // moment 85, count 2M as 61 days
-    expect(d.asWeeks()).toBe(12.142857142857142) // moment 12.285714285714286
+    expect(d.asDays()).toBe(85.84) // moment 85, count 2M as 61 days
+    expect(d.asWeeks()).toBe(12.262857142857143) // moment 12.285714285714286
   })
   it('Invalid ISO string', () => {
     expect(dayjs.duration('Invalid').toISOString()).toBe('P0D')
@@ -179,6 +179,19 @@ test('Add duration', () => {
   const a = dayjs('2020-10-01')
   const days = dayjs.duration(2, 'days')
   expect(a.add(days).format('YYYY-MM-DD')).toBe('2020-10-03')
+})
+
+test('Add duration months', () => {
+  const a = dayjs.duration({
+    months: 11,
+    days: 0,
+    years: 0
+  })
+  const monthToAdd = dayjs.duration(1, 'months')
+  const b = a.add(monthToAdd)
+  expect(b.months()).toBe(0)
+  expect(b.years()).toBe(1)
+  expect(b.days()).toBe(0)
 })
 
 describe('Subtract', () => {

--- a/test/plugin/timezone.test.js
+++ b/test/plugin/timezone.test.js
@@ -75,7 +75,7 @@ describe('Convert', () => {
     const MlosAngeles = moment('2014-06-01T12:00:00Z').tz('America/Los_Angeles')
     expect(losAngeles.format()).toBe('2014-06-01T05:00:00-07:00')
     expect(losAngeles.format()).toBe(MlosAngeles.format())
-    expect(losAngeles.valueOf()).toBe(1401620400000)
+    expect(losAngeles.valueOf()).toBe(1401624000000)
     expect(losAngeles.valueOf()).toBe(MlosAngeles.valueOf())
     expect(losAngeles.utcOffset()).toBe(-420)
     expect(losAngeles.utcOffset()).toBe(MlosAngeles.utcOffset())
@@ -85,7 +85,7 @@ describe('Convert', () => {
     [dayjs, moment].forEach((_) => {
       const losAngeles = _('2014-06-01T12:00:00Z').tz('America/Los_Angeles')
       expect(losAngeles.format()).toBe('2014-06-01T05:00:00-07:00')
-      expect(losAngeles.valueOf()).toBe(1401620400000)
+      expect(losAngeles.valueOf()).toBe(1401624000000)
     })
   })
 

--- a/test/plugin/timezone.test.js
+++ b/test/plugin/timezone.test.js
@@ -75,7 +75,7 @@ describe('Convert', () => {
     const MlosAngeles = moment('2014-06-01T12:00:00Z').tz('America/Los_Angeles')
     expect(losAngeles.format()).toBe('2014-06-01T05:00:00-07:00')
     expect(losAngeles.format()).toBe(MlosAngeles.format())
-    expect(losAngeles.valueOf()).toBe(1401624000000)
+    expect(losAngeles.valueOf()).toBe(1401620400000)
     expect(losAngeles.valueOf()).toBe(MlosAngeles.valueOf())
     expect(losAngeles.utcOffset()).toBe(-420)
     expect(losAngeles.utcOffset()).toBe(MlosAngeles.utcOffset())
@@ -85,7 +85,7 @@ describe('Convert', () => {
     [dayjs, moment].forEach((_) => {
       const losAngeles = _('2014-06-01T12:00:00Z').tz('America/Los_Angeles')
       expect(losAngeles.format()).toBe('2014-06-01T05:00:00-07:00')
-      expect(losAngeles.valueOf()).toBe(1401624000000)
+      expect(losAngeles.valueOf()).toBe(1401620400000)
     })
   })
 


### PR DESCRIPTION
As `dayjs.duration().months()` should return a number between 0 and 11. But in some case, this can return 12.
Here is a repro [sandbox](https://codesandbox.io/s/test-duration-dayjs-q096l?file=/src/index.js).

This PR normalizes month duration in days.

It might have breaking changes because I had to fix some tests.
