### PR TITLE
Update de.js

### DIFF
--- a/src/locale/de.js
+++ b/src/locale/de.js
@@ -29,7 +29,7 @@ const locale = {
   weekdaysShort: 'So._Mo._Di._Mi._Do._Fr._Sa.'.split('_'),
   weekdaysMin: 'So_Mo_Di_Mi_Do_Fr_Sa'.split('_'),
   months: 'Januar_Februar_März_April_Mai_Juni_Juli_August_September_Oktober_November_Dezember'.split('_'),
-  monthsShort: 'Jan_Feb_März_Apr_Mai_Juni_Juli_Aug_Sept_Okt_Nov_Dez'.split('_'),
+  monthsShort: 'Jan._Feb._März_Apr._Mai_Juni_Juli_Aug._Sep._Okt._Nov._Dez.'.split('_'),
   ordinal: n => `${n}.`,
   weekStart: 1,
   yearStart: 4,


### PR DESCRIPTION
Updating the monthsShort value in the de.js locale to match the German standard like de-at and de-ch where there is a period to abbreviate the necessary months.