### PR TITLE
fix: allow dayjs.tz()

### DIFF
--- a/types/plugin/timezone.d.ts
+++ b/types/plugin/timezone.d.ts
@@ -10,7 +10,7 @@ declare module 'dayjs' {
   }
 
   interface DayjsTimezone {
-    (date: ConfigType, timezone?: string): Dayjs
+    (date?: ConfigType, timezone?: string): Dayjs
     (date: ConfigType, format: string, timezone?: string): Dayjs
     guess(): string
     setDefault(timezone?: string): void


### PR DESCRIPTION
Allow empty params for `dayjs.tz()` since we're currently already allowing `undefined` for `ConfigType`