### PR TITLE
Update hr.js

### DIFF
--- a/src/locale/hr.js
+++ b/src/locale/hr.js
@@ -25,24 +25,24 @@ const locale = {
   formats: {
     LT: 'H:mm',
     LTS: 'H:mm:ss',
-    L: 'DD.MM.YYYY',
-    LL: 'D. MMMM YYYY',
-    LLL: 'D. MMMM YYYY H:mm',
-    LLLL: 'dddd, D. MMMM YYYY H:mm'
+    L: 'D. M. YYYY.',
+    LL: 'D. MMMM YYYY.',
+    LLL: 'D. MMMM YYYY., H:mm',
+    LLLL: 'dddd, D. MMMM YYYY., H:mm'
   },
   relativeTime: {
     future: 'za %s',
     past: 'prije %s',
-    s: 'sekunda',
-    m: 'minuta',
+    s: 'nekoliko sekunda',
+    m: 'jedna minuta',
     mm: '%d minuta',
-    h: 'sat',
+    h: 'jedan sat',
     hh: '%d sati',
-    d: 'dan',
+    d: 'jedan dan',
     dd: '%d dana',
-    M: 'mjesec',
+    M: 'jedan mjesec',
     MM: '%d mjeseci',
-    y: 'godina',
+    y: 'jedna godina',
     yy: '%d godine'
   },
   ordinal: n => `${n}.`


### PR DESCRIPTION
- remove 2-digits (leading zeros) dates and months - line 28
- Change month names with capital letters - line 5
- add "space" character between date, month and year (Croatian orthography) - line 28 (ideally non-breaking space (NBSP) should be used, so the whole string does not break at line endings!) - line 28
- add "period" (fullstop) after year (Croatian orthography, years are ordinal numbers) - lines 28, 29, 30, 31
- add "comma" as separator after date string (better separation of date and time) - lines 30, 31
- corrections in "relativeTime" section - lines 36, 37, 39, 41, 43, 45

I'm not a programmer, and do not know how to implement non-breaking (NBSP) space into the strings.
I also do not know how to implement plural forms – but it should be similar to Serbian (latin script).

Also, if possible, use non-breaking space (NBSP) in the following instances:
    L: 'D.(NBSP)M.(NBSP)YYYY.', - line 28
    LL: 'D.(NBSP)MMMM YYYY.', - line 29
    LLL: 'D.(NBSP)MMMM YYYY., H:mm', - line 30
    LLLL: 'dddd, D.(NBSP)MMMM YYYY., H:mm' - line 31

Sorry for listing so many changes in one issue.