### PR TITLE
customParseFormat: Add case insensitive search for `MMM` and `MMMM` format

### DIFF
--- a/src/plugin/customParseFormat/index.js
+++ b/src/plugin/customParseFormat/index.js
@@ -18,6 +18,17 @@ let parseTwoDigitYear = function (input) {
   return input + (input > 68 ? 1900 : 2000)
 }
 
+function getIndexInArrayCaseInsensitive(arr, value) {
+  value = value.toLowerCase()
+  for (let i = 0; i < arr.length; i += 1) {
+    if (typeof arr[i] === 'string' && arr[i].toLowerCase() === value) {
+      return i
+    }
+  }
+
+  return -1
+}
+
 function offsetFromString(string) {
   if (!string) return 0
   if (string === 'Z') return 0
@@ -99,8 +110,8 @@ const expressions = {
   MM: [match2, addInput('month')],
   MMM: [matchWord, function (input) {
     const months = getLocalePart('months')
-    const monthsShort = getLocalePart('monthsShort')
-    const matchIndex = (monthsShort || months.map(_ => _.substr(0, 3))).indexOf(input) + 1
+    const monthsShort = getLocalePart('monthsShort') || months.map(_ => _.substr(0, 3))
+    const matchIndex = getIndexInArrayCaseInsensitive(monthsShort, input) + 1
     if (matchIndex < 1) {
       throw new Error()
     }
@@ -108,7 +119,7 @@ const expressions = {
   }],
   MMMM: [matchWord, function (input) {
     const months = getLocalePart('months')
-    const matchIndex = months.indexOf(input) + 1
+    const matchIndex = getIndexInArrayCaseInsensitive(months, input) + 1
     if (matchIndex < 1) {
       throw new Error()
     }

--- a/test/plugin/customParseFormat.test.js
+++ b/test/plugin/customParseFormat.test.js
@@ -199,6 +199,12 @@ it('parse month from short string', () => {
   expect(dayjs(input, format).valueOf()).toBe(moment(input, format).valueOf())
 })
 
+it('parse month from short string with small letters', () => {
+  const input = '2018 feb 03'
+  const format = 'YYYY MMM DD'
+  expect(dayjs(input, format).valueOf()).toBe(moment(input, format).valueOf())
+})
+
 it('parse month from string with locale in config', () => {
   const input = '2018 лютий 03'
   const format = 'YYYY MMMM DD'

--- a/test/plugin/customParseFormat.test.js
+++ b/test/plugin/customParseFormat.test.js
@@ -184,6 +184,15 @@ it('parse month from string', () => {
   expect(dayjs(input2, format2).valueOf()).toBe(moment(input2, format2).valueOf())
 })
 
+it('parse month from string with small letters', () => {
+  const input = '2018 february 03'
+  const format = 'YYYY MMMM DD'
+  expect(dayjs(input, format).valueOf()).toBe(moment(input, format).valueOf())
+  const input2 = '21-december-18'
+  const format2 = 'D-MMMM-YY'
+  expect(dayjs(input2, format2).valueOf()).toBe(moment(input2, format2).valueOf())
+})
+
 it('parse month from short string', () => {
   const input = '2018 Feb 03'
   const format = 'YYYY MMM DD'


### PR DESCRIPTION
Parsing date inputs such as `21-December-18` (MMMM) and `2018 Feb 03` (MMM) works just fine, however as soon as the user enters inputs such as `21-december-18` or `2018 Feb 03`, the date will not be parsed.

This PR implements a method which searches through the months with case insensitive.

Motivation for this PR: Was working on a application which parses user dates, but it would fail when users typed months using only small letters.

Initially wanted to implement case insensitive search only if `strict` mode is off, however it appears that case insensitivity is already handled in strict mode as well (see `recognizes midnight in small letters` test).