### PR TITLE
Replaced Past value with more appropriate word

### DIFF
--- a/src/locale/pa-in.js
+++ b/src/locale/pa-in.js
@@ -19,7 +19,7 @@ const locale = {
   },
   relativeTime: {
     future: '%s ਵਿੱਚ',
-    past: '%s ਪਿਛਲੇ',
+    past: '%s ਪਹਿਲਾਂ',
     s: 'ਕੁਝ ਸਕਿੰਟ',
     m: 'ਇਕ ਮਿੰਟ',
     mm: '%d ਮਿੰਟ',


### PR DESCRIPTION
Fix: Replaced value of `past` in `relativeTime` object with more appropriate word of punjabi language. Example: It make more sense reading 12 ਦਿਨ ਪਹਿਲਾਂ instead of 12 ਦਿਨ ਪਿਛਲੇ.

Usually in Punjabi language, ਪਿਛਲੇ is used for **Last** and ਪਹਿਲਾਂ is used for **ago**.