### PR TITLE
Fix incomplete German locales

### DIFF
--- a/src/locale/de-at.js
+++ b/src/locale/de-at.js
@@ -1,6 +1,28 @@
 // German (Austria) [de-at]
 import dayjs from 'dayjs'
 
+const texts = {
+  s: 'ein paar Sekunden',
+  m: ['eine Minute', 'einer Minute'],
+  mm: '%d Minuten',
+  h: ['eine Stunde', 'einer Stunde'],
+  hh: '%d Stunden',
+  d: ['ein Tag', 'einem Tag'],
+  dd: ['%d Tage', '%d Tagen'],
+  M: ['ein Monat', 'einem Monat'],
+  MM: ['%d Monate', '%d Monaten'],
+  y: ['ein Jahr', 'einem Jahr'],
+  yy: ['%d Jahre', '%d Jahren']
+}
+
+function relativeTimeFormatter(number, withoutSuffix, key) {
+  let l = texts[key]
+  if (Array.isArray(l)) {
+    l = l[withoutSuffix ? 0 : 1]
+  }
+  return l.replace('%d', number)
+}
+
 const locale = {
   name: 'de-at',
   weekdays: 'Sonntag_Montag_Dienstag_Mittwoch_Donnerstag_Freitag_Samstag'.split('_'),
@@ -21,17 +43,17 @@ const locale = {
   relativeTime: {
     future: 'in %s',
     past: 'vor %s',
-    s: 'ein paar Sekunden',
-    m: 'einer Minute',
-    mm: '%d Minuten',
-    h: 'einer Stunde',
-    hh: '%d Stunden',
-    d: 'einem Tag',
-    dd: '%d Tagen',
-    M: 'einem Monat',
-    MM: '%d Monaten',
-    y: 'einem Jahr',
-    yy: '%d Jahren'
+    s: relativeTimeFormatter,
+    m: relativeTimeFormatter,
+    mm: relativeTimeFormatter,
+    h: relativeTimeFormatter,
+    hh: relativeTimeFormatter,
+    d: relativeTimeFormatter,
+    dd: relativeTimeFormatter,
+    M: relativeTimeFormatter,
+    MM: relativeTimeFormatter,
+    y: relativeTimeFormatter,
+    yy: relativeTimeFormatter
   }
 }
 

--- a/src/locale/de-ch.js
+++ b/src/locale/de-ch.js
@@ -1,15 +1,37 @@
 // German (Switzerland) [de-ch]
 import dayjs from 'dayjs'
 
+const texts = {
+  s: 'ein paar Sekunden',
+  m: ['eine Minute', 'einer Minute'],
+  mm: '%d Minuten',
+  h: ['eine Stunde', 'einer Stunde'],
+  hh: '%d Stunden',
+  d: ['ein Tag', 'einem Tag'],
+  dd: ['%d Tage', '%d Tagen'],
+  M: ['ein Monat', 'einem Monat'],
+  MM: ['%d Monate', '%d Monaten'],
+  y: ['ein Jahr', 'einem Jahr'],
+  yy: ['%d Jahre', '%d Jahren']
+}
+
+function relativeTimeFormatter(number, withoutSuffix, key) {
+  let l = texts[key]
+  if (Array.isArray(l)) {
+    l = l[withoutSuffix ? 0 : 1]
+  }
+  return l.replace('%d', number)
+}
+
 const locale = {
   name: 'de-ch',
   weekdays: 'Sonntag_Montag_Dienstag_Mittwoch_Donnerstag_Freitag_Samstag'.split('_'),
-  months: 'Januar_Februar_März_April_Mai_Juni_Juli_August_September_Oktober_November_Dezember'.split('_'),
-  weekStart: 1,
   weekdaysShort: 'So_Mo_Di_Mi_Do_Fr_Sa'.split('_'),
-  monthsShort: 'Jan._Feb._März_Apr._Mai_Juni_Juli_Aug._Sep._Okt._Nov._Dez.'.split('_'),
   weekdaysMin: 'So_Mo_Di_Mi_Do_Fr_Sa'.split('_'),
-  ordinal: n => n,
+  months: 'Januar_Februar_März_April_Mai_Juni_Juli_August_September_Oktober_November_Dezember'.split('_'),
+  monthsShort: 'Jan._Feb._März_Apr._Mai_Juni_Juli_Aug._Sep._Okt._Nov._Dez.'.split('_'),
+  ordinal: n => `${n}.`,
+  weekStart: 1,
   formats: {
     LT: 'HH:mm',
     LTS: 'HH:mm:ss',
@@ -17,10 +39,24 @@ const locale = {
     LL: 'D. MMMM YYYY',
     LLL: 'D. MMMM YYYY HH:mm',
     LLLL: 'dddd, D. MMMM YYYY HH:mm'
+  },
+  relativeTime: {
+    future: 'in %s',
+    past: 'vor %s',
+    s: relativeTimeFormatter,
+    m: relativeTimeFormatter,
+    mm: relativeTimeFormatter,
+    h: relativeTimeFormatter,
+    hh: relativeTimeFormatter,
+    d: relativeTimeFormatter,
+    dd: relativeTimeFormatter,
+    M: relativeTimeFormatter,
+    MM: relativeTimeFormatter,
+    y: relativeTimeFormatter,
+    yy: relativeTimeFormatter
   }
 }
 
 dayjs.locale(locale, null, true)
 
 export default locale
-

--- a/test/locale/de.test.js
+++ b/test/locale/de.test.js
@@ -3,6 +3,8 @@ import moment from 'moment'
 import dayjs from '../../src'
 import relativeTime from '../../src/plugin/relativeTime'
 import '../../src/locale/de'
+import '../../src/locale/de-at'
+import '../../src/locale/de-ch'
 
 dayjs.extend(relativeTime)
 
@@ -39,11 +41,15 @@ it('German locale relative time in past and future with suffix', () => {
     [4, 'y', 'in 4 Jahren'],
     [-4, 'y', 'vor 4 Jahren']
   ]
-  cases.forEach((c) => {
-    expect(dayjs().add(c[0], c[1]).locale('de').fromNow())
-      .toBe(c[2])
-    expect(dayjs().add(c[0], c[1]).locale('de').fromNow())
-      .toBe(moment().add(c[0], c[1]).locale('de').fromNow())
+
+  const locales = ['de', 'de-at', 'de-ch']
+  locales.forEach((locale) => {
+    cases.forEach((c) => {
+      expect(dayjs().add(c[0], c[1]).locale(locale).fromNow())
+        .toBe(c[2])
+      expect(dayjs().add(c[0], c[1]).locale(locale).fromNow())
+        .toBe(moment().add(c[0], c[1]).locale(locale).fromNow())
+    })
   })
 })
 
@@ -70,10 +76,27 @@ it('German locale relative time in past and future without suffix', () => {
     [4, 'y', '4 Jahre'],
     [-4, 'y', '4 Jahre']
   ]
-  cases.forEach((c) => {
-    expect(dayjs().add(c[0], c[1]).locale('de').fromNow(true))
-      .toBe(c[2])
-    expect(dayjs().add(c[0], c[1]).locale('de').fromNow(true))
-      .toBe(moment().add(c[0], c[1]).locale('de').fromNow(true))
+
+  const locales = ['de', 'de-at', 'de-ch']
+  locales.forEach((locale) => {
+    cases.forEach((c) => {
+      expect(dayjs().add(c[0], c[1]).locale(locale).fromNow(true))
+        .toBe(c[2])
+      expect(dayjs().add(c[0], c[1]).locale(locale).fromNow(true))
+        .toBe(moment().add(c[0], c[1]).locale(locale).fromNow(true))
+    })
+  })
+})
+
+it('German locales use region specific names', () => {
+  const locales = [
+    { locale: 'de', expectedFormattedDate: 'Mi., 19. Januar 2022' },
+    { locale: 'de-at', expectedFormattedDate: 'Mi., 19. Jänner 2022' },
+    { locale: 'de-ch', expectedFormattedDate: 'Mi, 19. Januar 2022' }
+  ]
+
+  locales.forEach((locale) => {
+    const dayjsWithLocale = dayjs('2022-01-19').locale(locale.locale)
+    expect(dayjsWithLocale.format('ddd, D. MMMM YYYY')).toEqual(locale.expectedFormattedDate)
   })
 })


### PR DESCRIPTION
The locale definitions for the German regions Switzerland (de-ch) and Austria (de-at) were incomplete and wrong. This commit makes the definition complete, corrects the error regarding the setting "ordinal" for de-ch and introduces tests which verify the region specific identifiers.