### PR TITLE
fix(parse): fix parsing milliseconds less than three digits

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -61,7 +61,7 @@ const parseDate = (cfg) => {
     const d = date.match(C.REGEX_PARSE)
     if (d) {
       const m = d[2] - 1 || 0
-      const ms = (d[7] || '0').substring(0, 3)
+      const ms = (d[7] || '0').substring(0, 3).padEnd(3, '0')
       if (utc) {
         return new Date(Date.UTC(d[1], m, d[3]
           || 1, d[4] || 0, d[5] || 0, d[6] || 0, ms))

--- a/test/parse.test.js
+++ b/test/parse.test.js
@@ -100,6 +100,39 @@ describe('Parse', () => {
     expect(dayjs('otherString').isValid()).toBe(false)
     expect(dayjs(null).toString().toLowerCase()).toBe(moment(null).toString().toLowerCase())
   })
+
+  describe('should correctly parse milliseconds less than three digits', () => {
+    it('should correctly parse hundreds of milliseconds without trailing zeros', () => {
+      const testCases = []
+      for (let i = 0; i < 30; i += 1) {
+        const base = '2022-01-25T09:54:22.'
+        const hundreds = Math.ceil(Math.random() * 9)
+        testCases.push({
+          input: `${base}${hundreds}`,
+          expectedOutput: new Date(`${base}${hundreds}`)
+        })
+      }
+      testCases.forEach((testCase) => {
+        expect(dayjs(testCase.input).toISOString()).toEqual(testCase.expectedOutput.toISOString())
+      })
+    })
+
+    it('should correctly parse tens of milliseconds without trailing zeros', () => {
+      const base = '2022-01-25T09:54:22.'
+      const testCases = []
+      for (let i = 0; i < 30; i += 1) {
+        const hundreds = Math.ceil(Math.random() * 9)
+        const tens = Math.ceil(Math.random() * 9)
+        testCases.push({
+          input: `${base}${hundreds}${tens}`,
+          expectedOutput: new Date(`${base}${hundreds}${tens}`)
+        })
+      }
+      testCases.forEach((testCase) => {
+        expect(dayjs(testCase.input).toISOString()).toEqual(testCase.expectedOutput.toISOString())
+      })
+    })
+  })
 })
 
 it('Unix Timestamp Number (milliseconds) 1523520536000', () => {


### PR DESCRIPTION
Currently strings without timezone and with milliseconds less than three digits (and without trailing zeros) are being parsed incorrectly.

For example (pay attention to milliseconds):
* String `2022-01-25T09:54:22.5` expected to be parsed as `2022-01-25T09:54:22.500`, but instead it's treated as `2022-01-25T09:54:22.005`.
* String `2022-01-25T09:54:22.42` expected to be parsed as `2022-01-25T09:54:22.420`, but instead it's treated as `2022-01-25T09:54:22.042`.

This PR proposes a solution for this issue, by padding milliseconds with zeros to three characters (if less).

The proposed changes are covered by randomized tests.