### PR TITLE
fix: fix plugin/LocaleData type definitions

### DIFF
--- a/types/plugin/localeData.d.ts
+++ b/types/plugin/localeData.d.ts
@@ -9,17 +9,34 @@ declare module 'dayjs' {
 
   interface InstanceLocaleDataReturn {
     firstDayOfWeek(): number;
+
     weekdays(instance: Dayjs): string;
+    weekdays(instance: undefined): WeekdayNames;
     weekdays(): WeekdayNames;
+    weekdays(instance?: Dayjs): WeekdayNames | string;
+    
     weekdaysShort(instance: Dayjs): string;
+    weekdaysShort(instance: undefined): WeekdayNames;
     weekdaysShort(): WeekdayNames;
+    weekdaysShort(instance?: Dayjs): WeekdayNames | string;
+
     weekdaysMin(instance: Dayjs): string;
+    weekdaysMin(instance: undefined): WeekdayNames;
     weekdaysMin(): WeekdayNames;
+    weekdaysMin(instance?: Dayjs): WeekdayNames | string;
+    
     months(instance: Dayjs): string;
+    months(instance: undefined): MonthNames;
     months(): MonthNames;
+    months(instance?: Dayjs): MonthNames | string;
+    
     monthsShort(instance: Dayjs): string;
+    monthsShort(instance: undefined): MonthNames;
     monthsShort(): MonthNames;
+    monthsShort(instance?: Dayjs): MonthNames | string;
+    
     longDateFormat(format: string): string;
+    
     meridiem(hour?: number, minute?: number, isLower?: boolean): string;
   }
 

--- a/types/plugin/localeData.d.ts
+++ b/types/plugin/localeData.d.ts
@@ -11,27 +11,22 @@ declare module 'dayjs' {
     firstDayOfWeek(): number;
 
     weekdays(instance: Dayjs): string;
-    weekdays(instance: undefined): WeekdayNames;
     weekdays(): WeekdayNames;
     weekdays(instance?: Dayjs): WeekdayNames | string;
     
     weekdaysShort(instance: Dayjs): string;
-    weekdaysShort(instance: undefined): WeekdayNames;
     weekdaysShort(): WeekdayNames;
     weekdaysShort(instance?: Dayjs): WeekdayNames | string;
 
     weekdaysMin(instance: Dayjs): string;
-    weekdaysMin(instance: undefined): WeekdayNames;
     weekdaysMin(): WeekdayNames;
     weekdaysMin(instance?: Dayjs): WeekdayNames | string;
     
     months(instance: Dayjs): string;
-    months(instance: undefined): MonthNames;
     months(): MonthNames;
     months(instance?: Dayjs): MonthNames | string;
     
     monthsShort(instance: Dayjs): string;
-    monthsShort(instance: undefined): MonthNames;
     monthsShort(): MonthNames;
     monthsShort(instance?: Dayjs): MonthNames | string;
     

--- a/types/plugin/localeData.d.ts
+++ b/types/plugin/localeData.d.ts
@@ -9,11 +9,16 @@ declare module 'dayjs' {
 
   interface InstanceLocaleDataReturn {
     firstDayOfWeek(): number;
-    weekdays(instance?: Dayjs): WeekdayNames;
-    weekdaysShort(instance?: Dayjs): WeekdayNames;
-    weekdaysMin(instance?: Dayjs): WeekdayNames;
-    months(instance?: Dayjs): MonthNames;
-    monthsShort(instance?: Dayjs): MonthNames;
+    weekdays(instance: Dayjs): string;
+    weekdays(): WeekdayNames;
+    weekdaysShort(instance: Dayjs): string;
+    weekdaysShort(): WeekdayNames;
+    weekdaysMin(instance: Dayjs): string;
+    weekdaysMin(): WeekdayNames;
+    months(instance: Dayjs): string;
+    months(): MonthNames;
+    monthsShort(instance: Dayjs): string;
+    monthsShort(): MonthNames;
     longDateFormat(format: string): string;
     meridiem(hour?: number, minute?: number, isLower?: boolean): string;
   }


### PR DESCRIPTION
close #1702 

The function group of `InstanceLocaleDataReturn` interface has different return type depending on the argument.

https://github.com/iamkun/dayjs/blob/dev/src/plugin/localeData/index.js