### PR TITLE
fix: make setDefaultTimezone a global default timezone (#1227)

### DIFF
--- a/src/plugin/timezone/index.js
+++ b/src/plugin/timezone/index.js
@@ -1,4 +1,4 @@
-import { MIN, MS } from '../../constant'
+import { MILLISECONDS_A_MINUTE, MILLISECONDS_A_SECOND, MIN, MS } from '../../constant'
 
 const typeToPos = {
   year: 0,
@@ -33,7 +33,7 @@ const getDateTimeFormat = (timezone, options = {}) => {
   return dtf
 }
 
-export default (o, c, d) => {
+export default (option, Dayjs, dayjs) => {
   let defaultTimezone
 
   const makeFormatParts = (timestamp, timezone, options = {}) => {
@@ -59,11 +59,11 @@ export default (o, c, d) => {
     /* istanbul ignore next */
     const fixedHour = hour === 24 ? 0 : hour
     const utcString = `${filled[0]}-${filled[1]}-${filled[2]} ${fixedHour}:${filled[4]}:${filled[5]}:000`
-    const utcTs = d.utc(utcString).valueOf()
+    const utcTs = dayjs.utc(utcString).valueOf()
     let asTS = +timestamp
-    const over = asTS % 1000
+    const over = asTS % MILLISECONDS_A_SECOND
     asTS -= over
-    return (utcTs - asTS) / (60 * 1000)
+    return (utcTs - asTS) / MILLISECONDS_A_MINUTE
   }
 
   // find the right offset a given local time. The o input is our guess, which determines which
@@ -71,7 +71,7 @@ export default (o, c, d) => {
   // https://github.com/moment/luxon/blob/master/src/datetime.js#L76
   const fixOffset = (localTS, o0, tz) => {
     // Our UTC time is just a guess because our offset is just a guess
-    let utcGuess = localTS - (o0 * 60 * 1000)
+    let utcGuess = localTS - (o0 * MILLISECONDS_A_MINUTE)
     // Test whether the zone matches the offset for this ts
     const o2 = tzOffset(utcGuess, tz)
     // If so, offset didn't change and we're done
@@ -79,7 +79,7 @@ export default (o, c, d) => {
       return [utcGuess, o0]
     }
     // If not, change the ts by the difference in the offset
-    utcGuess -= (o2 - o0) * 60 * 1000
+    utcGuess -= (o2 - o0) * MILLISECONDS_A_MINUTE
     // If that gives us the local time we want, we're done
     const o3 = tzOffset(utcGuess, tz)
     if (o2 === o3) {
@@ -87,17 +87,17 @@ export default (o, c, d) => {
     }
     // If it's different, we're in a hole time.
     // The offset has changed, but the we don't adjust the time
-    return [localTS - (Math.min(o2, o3) * 60 * 1000), Math.max(o2, o3)]
+    return [localTS - (Math.min(o2, o3) * MILLISECONDS_A_MINUTE), Math.max(o2, o3)]
   }
 
-  const proto = c.prototype
+  const proto = Dayjs.prototype
 
   proto.tz = function (timezone = defaultTimezone, keepLocalTime) {
     const oldOffset = this.utcOffset()
     const date = this.toDate()
     const target = date.toLocaleString('en-US', { timeZone: timezone })
-    const diff = Math.round((date - new Date(target)) / 1000 / 60)
-    let ins = d(target).$set(MS, this.$ms)
+    const diff = Math.round((date - new Date(target)) / MILLISECONDS_A_MINUTE)
+    let ins = dayjs(target).$set(MS, this.$ms)
       .utcOffset((-Math.round(date.getTimezoneOffset() / 15) * 15) - diff, true)
     if (keepLocalTime) {
       const newOffset = ins.utcOffset()
@@ -109,7 +109,7 @@ export default (o, c, d) => {
 
   proto.offsetName = function (type) {
     // type: short(default) / long
-    const zone = this.$x.$timezone || d.tz.guess()
+    const zone = this.$x.$timezone || dayjs.tz.guess()
     const result = makeFormatParts(this.valueOf(), zone, { timeZoneName: type }).find(m => m.type.toLowerCase() === 'timezonename')
     return result && result.value
   }
@@ -120,31 +120,48 @@ export default (o, c, d) => {
       return oldStartOf.call(this, units, startOf)
     }
 
-    const withoutTz = d(this.format('YYYY-MM-DD HH:mm:ss:SSS'))
+    const withoutTz = dayjs.utc(this.format('YYYY-MM-DD HH:mm:ss:SSS'))
     const startOfWithoutTz = oldStartOf.call(withoutTz, units, startOf)
     return startOfWithoutTz.tz(this.$x.$timezone, true)
   }
 
-  d.tz = function (input, arg1, arg2) {
+  dayjs.tz = function (input, arg1, arg2) {
     const parseFormat = arg2 && arg1
     const timezone = arg2 || arg1 || defaultTimezone
-    const previousOffset = tzOffset(+d(), timezone)
+    const previousOffset = tzOffset(+new Date(), timezone)
     if (typeof input !== 'string') {
       // timestamp number || js Date || Day.js
-      return d(input).tz(timezone)
+      return dayjs(input).tz(timezone)
     }
-    const localTs = d.utc(input, parseFormat).valueOf()
+    const localTs = dayjs.utc(input, parseFormat).valueOf()
     const [targetTs, targetOffset] = fixOffset(localTs, previousOffset, timezone)
-    const ins = d(targetTs).utcOffset(targetOffset)
+    const ins = dayjs(targetTs).utcOffset(targetOffset)
     ins.$x.$timezone = timezone
     return ins
   }
 
-  d.tz.guess = function () {
+  dayjs.tz.guess = function () {
     return Intl.DateTimeFormat().resolvedOptions().timeZone
   }
 
-  d.tz.setDefault = function (timezone) {
+  dayjs.tz.setDefault = function (timezone) {
     defaultTimezone = timezone
+  }
+
+  const oldParse = proto.parse
+  proto.parse = function (cfg) {
+    oldParse.call(this, cfg)
+    if (cfg.utc || typeof cfg.date === 'number' || cfg.date instanceof Date) {
+      return
+    }
+    const date = this.toDate()
+    const target = date.toLocaleString('en-US', { timeZone: defaultTimezone })
+    const diff = Math.round((date - new Date(target)) / MILLISECONDS_A_MINUTE)
+    const offset = (-Math.round(date.getTimezoneOffset() / 15) * 15) - diff
+    this.$d = date
+    this.init()
+    this.$offset = offset
+    this.$u = offset === 0
+    this.$x.$timezone = defaultTimezone
   }
 }

--- a/test/plugin/timezone.test.js
+++ b/test/plugin/timezone.test.js
@@ -259,6 +259,19 @@ describe('set Default', () => {
     expect(tokyo.format('Z')).toBe('+09:00')
     expect(tokyo.valueOf()).toBe(1401591600000)
   })
+
+  it('setDefaultTimezone changes global default timezone', () => {
+    dayjs.tz.setDefault(NY)
+    const ny = dayjs('2014-06-01 12:00')
+    dayjs.tz.setDefault(TOKYO)
+    const tokyo = dayjs('2014-06-01 12:00')
+    expect(ny.format()).toBe('2014-06-01T12:00:00-04:00')
+    expect(ny.format('Z')).toBe('-04:00')
+    expect(ny.valueOf()).toBe(1401638400000)
+    expect(tokyo.format()).toBe('2014-06-01T12:00:00+09:00')
+    expect(tokyo.format('Z')).toBe('+09:00')
+    expect(tokyo.valueOf()).toBe(1401591600000)
+  })
 })
 
 describe('keepLocalTime', () => {


### PR DESCRIPTION
close #1227 

before:
the `dayjs.tz.setDefaultTimezone` in plugin/timezone only changed the timezone of `dayjs.tz()`.
after:
the `dayjs.tz.setDefaultTimezone` in plugin/timezone will changed the timezone of `dayjs()` too.