### PR TITLE
Fix/ fix some bug of utcOffset

### DIFF
--- a/src/plugin/utc/index.js
+++ b/src/plugin/utc/index.js
@@ -94,8 +94,7 @@ export default (option, Dayjs, dayjs) => {
       return ins
     }
     if (input !== 0) {
-      const localTimezoneOffset = this.$u
-        ? this.toDate().getTimezoneOffset() : -1 * this.utcOffset()
+      const localTimezoneOffset = this.toDate().getTimezoneOffset()
       ins = this.local().add(offset + localTimezoneOffset, MIN)
       ins.$offset = offset
       ins.$x.$localOffset = localTimezoneOffset

--- a/src/plugin/utc/index.js
+++ b/src/plugin/utc/index.js
@@ -53,7 +53,7 @@ export default (option, Dayjs, dayjs) => {
 
   const oldInit = proto.init
   proto.init = function () {
-    if (this.$u) {
+    if (this.$u && this.$utils().u(this.$offset)) {
       const { $d } = this
       this.$y = $d.getUTCFullYear()
       this.$M = $d.getUTCMonth()

--- a/src/plugin/utc/index.js
+++ b/src/plugin/utc/index.js
@@ -87,7 +87,7 @@ export default (option, Dayjs, dayjs) => {
       }
     }
     const offset = Math.abs(input) <= 16 ? input * 60 : input
-    let ins = this
+    let ins = this.clone()
     if (keepLocalTime) {
       ins.$offset = offset
       ins.$u = input === 0

--- a/test/plugin/utc.test.js
+++ b/test/plugin/utc.test.js
@@ -301,6 +301,13 @@ describe('UTC Offset', () => {
     expect(daysJS.utcOffset()).toEqual(0)
     expect(daysJS.utcOffset()).toEqual(momentJS.utcOffset())
   })
+
+  it('change utc offset to zero with keepLocalTime and clone it', () => {
+    const d1 = dayjs('2022-02-22 22:22:22').utcOffset(0, true)
+    const d2 = d1.clone()
+    expect(d1.valueOf()).toEqual(d2.valueOf())
+    expect(d1.format()).toEqual(d2.format())
+  })
 })
 
 describe('Diff', () => {

--- a/test/plugin/utc.test.js
+++ b/test/plugin/utc.test.js
@@ -308,6 +308,14 @@ describe('UTC Offset', () => {
     expect(d1.valueOf()).toEqual(d2.valueOf())
     expect(d1.format()).toEqual(d2.format())
   })
+
+  it('change utc offset continuously', () => {
+    const targetOffset = dayjs().utcOffset() + 60
+    const d1 = dayjs().utcOffset(targetOffset)
+    const d2 = d1.utcOffset(targetOffset)
+    expect(d1.valueOf()).toEqual(d2.valueOf())
+    expect(d1.format()).toEqual(d2.format())
+  })
 })
 
 describe('Diff', () => {


### PR DESCRIPTION
1. fix utc plugin when utcOffset(0, true)

before: `const d = dayjs().utcOffset(0, true)` and `d.clone().format() === d.format()` is false
after: fixed

2. fix error when set utc offset continuously
before: when i use utcOffset continuously more than two times, the value will be error
after: fixed

3. fix #1803  