### PR TITLE
Fixed utc.valueOf not taking DST into account

### DIFF
--- a/src/plugin/utc/index.js
+++ b/src/plugin/utc/index.js
@@ -114,7 +114,7 @@ export default (option, Dayjs, dayjs) => {
 
   proto.valueOf = function () {
     const addedOffset = !this.$utils().u(this.$offset)
-      ? this.$offset + (this.$x.$localOffset || (new Date()).getTimezoneOffset()) : 0
+      ? this.$offset + (this.$x.$localOffset || this.$d.getTimezoneOffset()) : 0
     return this.$d.valueOf() - (addedOffset * MILLISECONDS_A_MINUTE)
   }
 


### PR DESCRIPTION
Use the current date to determine internal timezone offset instead of using a new Date instance, since the new Date returns a different offset based on whenever DST is in effect at the moment.

This PR fixes https://github.com/iamkun/dayjs/issues/1804