### PR TITLE
refactor: replace deprecated String.prototype.substr()

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -267,7 +267,7 @@ class Dayjs {
       weekdays, months, meridiem
     } = locale
     const getShort = (arr, index, full, length) => (
-      (arr && (arr[index] || arr(this, str))) || full[index].substr(0, length)
+      (arr && (arr[index] || arr(this, str))) || full[index].slice(0, length)
     )
     const get$H = num => (
       Utils.s($H % 12 || 12, num, '0')

--- a/src/plugin/customParseFormat/index.js
+++ b/src/plugin/customParseFormat/index.js
@@ -100,7 +100,7 @@ const expressions = {
   MMM: [matchWord, function (input) {
     const months = getLocalePart('months')
     const monthsShort = getLocalePart('monthsShort')
-    const matchIndex = (monthsShort || months.map(_ => _.substr(0, 3))).indexOf(input) + 1
+    const matchIndex = (monthsShort || months.map(_ => _.slice(0, 3))).indexOf(input) + 1
     if (matchIndex < 1) {
       throw new Error()
     }
@@ -161,7 +161,7 @@ function makeParser(format) {
         start += token.length
       } else {
         const { regex, parser } = token
-        const part = input.substr(start)
+        const part = input.slice(start)
         const match = regex.exec(part)
         const value = match[0]
         parser.call(time, value)

--- a/src/plugin/localeData/index.js
+++ b/src/plugin/localeData/index.js
@@ -7,7 +7,7 @@ export default (o, c, dayjs) => { // locale needed later
     const locale = ins.name ? ins : ins.$locale()
     const targetLocale = getLocalePart(locale[target])
     const fullLocale = getLocalePart(locale[full])
-    const result = targetLocale || fullLocale.map(f => f.substr(0, num))
+    const result = targetLocale || fullLocale.map(f => f.slice(0, num))
     if (!localeOrder) return result
     const { weekStart } = locale
     return result.map((_, index) => (result[(index + (weekStart || 0)) % 7]))


### PR DESCRIPTION
[String.prototype.substr()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) is deprecated so we replace it with [String.prototype.slice()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) which works similarily but isn't deprecated.
.substr() probably isn't going away anytime soon but the change is trivial so it doesn't hurt to do it.