### PR TITLE
fix 1788- parsing negative Iso for duration correctly

### DIFF
--- a/src/plugin/duration/index.js
+++ b/src/plugin/duration/index.js
@@ -83,8 +83,9 @@ class Duration {
     if (typeof input === 'string') {
       const d = input.match(durationRegex)
       if (d) {
+        const sign = d[1] === '-' ? -1 : 1
         const properties = d.slice(2)
-        const numberD = properties.map(value => (value != null ? Number(value) : 0));
+        const numberD = properties.map(value => (value != null ? Number(value) * sign : 0));
         [
           this.$d.years,
           this.$d.months,

--- a/test/plugin/duration.test.js
+++ b/test/plugin/duration.test.js
@@ -76,6 +76,12 @@ describe('Parse ISO string', () => {
   it('Part ISO string', () => {
     expect(dayjs.duration('PT2777H46M40S').toISOString()).toBe('PT2777H46M40S')
   })
+  it('Negative ISO string', () => {
+    const durationString = dayjs.duration(-1000).toISOString()
+    expect(durationString).toEqual('-PT1S')
+    const actual = dayjs.duration(durationString)
+    expect(actual.asSeconds()).toEqual(-1) // this used to fail !!! results in +1
+  })
   it('Formatting missing components', () => {
     expect(dayjs.duration('PT1H').format('YYYY-MM-DDTHH:mm:ss')).toBe('0000-00-00T01:00:00')
   })


### PR DESCRIPTION
currently negative ISO8601 duration strings are not handled properly. this quick fix attempt to resolve this.  
#1788 
