### PR TITLE
fix: parseDate stop the js Date behavior that maps 2 digit years to 1900 - 1999

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -65,14 +65,24 @@ const parseDate = (cfg) => {
   if (typeof date === 'string' && !/Z$/i.test(date)) {
     const d = date.match(C.REGEX_PARSE)
     if (d) {
+      let dObj = null
+      const y = d[1]
       const m = d[2] - 1 || 0
       const ms = (d[7] || '0').substring(0, 3)
+      const dParams = [y, m, d[3] || 1, d[4] || 0, d[5] || 0, d[6] || 0, ms]
       if (utc) {
-        return new Date(Date.UTC(d[1], m, d[3]
-          || 1, d[4] || 0, d[5] || 0, d[6] || 0, ms))
+        dObj = new Date(Date.UTC(...dParams))
+      } else {
+        dObj = new Date(...dParams)
       }
-      return new Date(d[1], m, d[3]
-          || 1, d[4] || 0, d[5] || 0, d[6] || 0, ms)
+
+      // by default the js Date maps 2-digit years 0 - 99 to 1900 – 1999
+      // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date#interpretation_of_two-digit_years
+      // and the setFullYear method could set the exact year, ex:
+      // const date = new Date(98, 1) => Sun Feb 01 1998 00:00:00
+      // date.setFullYear(98)         => Sat Feb 01 0098 00:00:00
+      dObj.setFullYear(y)
+      return dObj
     }
   }
 

--- a/test/parse.test.js
+++ b/test/parse.test.js
@@ -40,6 +40,14 @@ describe('Parse', () => {
     expect(dayjs(d).format()).toBe(moment(d).format()) // not recommend
     d = '2018-05-02T11:12:13Z' // should go direct to new Date() rather our regex
     expect(dayjs(d).format()).toBe(moment(d).format()) // not recommend
+    d = '8-05-02'
+    expect(dayjs(d).valueOf()).toBe(moment(d).valueOf())
+    d = '08-05-02'
+    expect(dayjs(d).valueOf()).toBe(moment(d).valueOf())
+    d = '008-05-02'
+    expect(dayjs(d).valueOf()).toBe(moment(d).valueOf())
+    d = '0008-05-02'
+    expect(dayjs(d).valueOf()).toBe(moment(d).valueOf())
   })
 
   it('String ISO 8601 date, time and zone', () => {


### PR DESCRIPTION
This is the fix of the issue https://github.com/iamkun/dayjs/issues/1237

To achieve this, I just call the `setFullYear` method of the Date object to force the date object to have the exact year.

plus after reading the tests code, I've understood that one of the goals of the `parseDate` method is to align with momentjs, so in my opinion this fix would reinforce the alignment.