### PR TITLE
fix: add OpUnitType to quarterOfYear startOf/endOf types

### DIFF
--- a/types/plugin/quarterOfYear.d.ts
+++ b/types/plugin/quarterOfYear.d.ts
@@ -1,4 +1,4 @@
-import { PluginFunc, ConfigType, QUnitType } from 'dayjs'
+import { PluginFunc, ConfigType, QUnitType, OpUnitType } from 'dayjs'
 
 declare const plugin: PluginFunc
 export = plugin
@@ -13,9 +13,9 @@ declare module 'dayjs' {
 
     subtract(value: number, unit: QUnitType): Dayjs
 
-    startOf(unit: QUnitType): Dayjs
+    startOf(unit: QUnitType | OpUnitType): Dayjs
 
-    endOf(unit: QUnitType): Dayjs
+    endOf(unit: QUnitType | OpUnitType): Dayjs
 
     isSame(date: ConfigType, unit?: QUnitType): boolean
 


### PR DESCRIPTION
Fixes a type error I was getting using dayjs with the quarterOfYear plugin.

[example](https://codesandbox.io/s/dayjs-types-5umhqk)