### PR TITLE
fix(docs): typo and grammar

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,5 +20,5 @@ Our open source community strives to be nice, welcoming and professional. Instan
 ## Tests
 
 * Feel free to create a new `test/*.test.js` file if none of the existing test files suits your test case.
-* Help us keeping 100% test coverage :D.
+* Help us to keep 100% test coverage :D.
 * You can use `npm run test` before submitting a pull request.

--- a/docs/en/Plugin.md
+++ b/docs/en/Plugin.md
@@ -492,18 +492,18 @@ Template of a Day.js plugin.
 export default (option, dayjsClass, dayjsFactory) => {
   // extend dayjs()
   // e.g. add dayjs().isSameOrBefore()
-  dayjsClass.prototype.isSameOrBefore = function(arguments) {}
+  dayjsClass.prototype.isSameOrBefore = function(...args) {}
 
   // extend dayjs
   // e.g. add dayjs.utc()
-  dayjsFactory.utc = arguments => {}
+  dayjsFactory.utc = (...args) => {}
 
   // overriding existing API
   // e.g. extend dayjs().format()
   const oldFormat = dayjsClass.prototype.format
-  dayjsClass.prototype.format = function(arguments) {
+  dayjsClass.prototype.format = function(...args) {
     // original format result
-    const result = oldFormat(arguments)
+    const result = oldFormat(...args)
     // return modified result
   }
 }

--- a/docs/es-es/Plugin.md
+++ b/docs/es-es/Plugin.md
@@ -485,18 +485,18 @@ Plantilla de un complemento de Day.js.
 export default (option, dayjsClass, dayjsFactory) => {
   // extensión de dayjs()
   // p.ej.: se añade dayjs().isSameOrBefore()
-  dayjsClass.prototype.isSameOrBefore = function(arguments) {}
+  dayjsClass.prototype.isSameOrBefore = function(...args) {}
 
   // extensión de dayjs
   // p.ej.: se añade dayjs.utc()
-  dayjsFactory.utc = arguments => {}
+  dayjsFactory.utc = (...args) => {}
 
   // sobrescritura de la API existente
   // p.ej.: extensión de dayjs().format()
   const oldFormat = dayjsClass.prototype.format
-  dayjsClass.prototype.format = function(arguments) {
+  dayjsClass.prototype.format = function(...args) {
     // result contiene el formato original
-    const result = oldFormat(arguments)
+    const result = oldFormat(...args)
     // se ha de devolver result modificado
   }
 }

--- a/docs/ja/Plugin.md
+++ b/docs/ja/Plugin.md
@@ -494,18 +494,18 @@ dayjs.updateLocale('en', {
 export default (option, dayjsClass, dayjsFactory) => {
   // dayjs() を拡張する
   // 例) dayjs().isSameOrBefore() を追加
-  dayjsClass.prototype.isSameOrBefore = function(arguments) {}
+  dayjsClass.prototype.isSameOrBefore = function(...args) {}
 
   // dayjs() を拡張する
   // 例) dayjs().utc() を追加
-  dayjsFactory.utc = arguments => {}
+  dayjsFactory.utc = (...args) => {}
 
   // 既存 API の上書き
   // 例) dayjs().format() を拡張
   const oldFormat = dayjsClass.prototype.format
-  dayjsClass.prototype.format = function(arguments) {
+  dayjsClass.prototype.format = function(...args) {
     // 既存のフォーマット
-    const result = oldFormat(arguments)
+    const result = oldFormat(...args)
     // 変更後のフォーマット
   }
 }

--- a/docs/ko/I18n.md
+++ b/docs/ko/I18n.md
@@ -115,7 +115,7 @@ const localeObject = {
   months: 'Enero_Febrero ... '.split('_'), // months Array
   monthsShort: 'Jan_F'.split('_'), // OPTIONAL, short months Array, use first three letters if not provided
   ordinal: n => `${n}º`, // ordinal Function (number) => return number + output
-  relativeTime = { // relative time format strings, keep %s %d as the same
+  relativeTime: { // relative time format strings, keep %s %d as the same
     future: 'in %s', // e.g. in 2 hours, %s been replaced with 2hours
     past: '%s ago',
     s: 'a few seconds',

--- a/docs/ko/Plugin.md
+++ b/docs/ko/Plugin.md
@@ -486,18 +486,18 @@ Day.js 플러그인 템플릿
 export default (option, dayjsClass, dayjsFactory) => {
   // extend dayjs()
   // e.g. add dayjs().isSameOrBefore()
-  dayjsClass.prototype.isSameOrBefore = function(arguments) {}
+  dayjsClass.prototype.isSameOrBefore = function(...args) {}
 
   // extend dayjs
   // e.g. add dayjs.utc()
-  dayjsFactory.utc = arguments => {}
+  dayjsFactory.utc = (...args) => {}
 
   // overriding existing API
   // e.g. extend dayjs().format()
   const oldFormat = dayjsClass.prototype.format
-  dayjsClass.prototype.format = function(arguments) {
+  dayjsClass.prototype.format = function(...args) {
     // original format result
-    const result = oldFormat(arguments)
+    const result = oldFormat(...args)
     // return modified result
   }
 }

--- a/docs/pt-br/Plugin.md
+++ b/docs/pt-br/Plugin.md
@@ -485,18 +485,18 @@ Modelo de um plugin Day.js.
 export default (option, dayjsClass, dayjsFactory) => {
   // estender dayjs()
   // ex: adicionar dayjs().isSameOrBefore()
-  dayjsClass.prototype.isSameOrBefore = function(arguments) {}
+  dayjsClass.prototype.isSameOrBefore = function(...args) {}
 
   // estender dayjs
   // ex: adicionar dayjs.utc()
-  dayjsFactory.utc = arguments => {}
+  dayjsFactory.utc = (...args) => {}
 
   // sobrescrever API existente
   // ex: estender dayjs().format()
   const formatoAntigo = dayjsClass.prototype.format
-  dayjsClass.prototype.format = function(arguments) {
+  dayjsClass.prototype.format = function(...args) {
     // original
-    const result = formatoAntigo(arguments)
+    const result = formatoAntigo(...args)
     // retornar modificado
   }
 }

--- a/docs/zh-cn/I18n.md
+++ b/docs/zh-cn/I18n.md
@@ -98,7 +98,7 @@ dayjs()
 
 你可以使用 [`UpdateLocale`](./Plugin.md#updateLocale) 插件来更新语言配置
 
-你还可以根据需要自由的编写一个 Day.js 语言配置
+你还可以根据需要自由地编写一个 Day.js 语言配置
 
 同时欢迎提交 PR 与大家分享你的语言配置
 

--- a/docs/zh-cn/Plugin.md
+++ b/docs/zh-cn/Plugin.md
@@ -478,7 +478,7 @@ dayjs.updateLocale('en', {
 
 ## 自定义
 
-你可以根据需要自由的编写一个 Day.js 插件
+你可以根据需要自由地编写一个 Day.js 插件
 
 欢迎提交 PR 与大家分享你的插件
 
@@ -488,18 +488,18 @@ Day.js 插件模版
 export default (option, dayjsClass, dayjsFactory) => {
   // 扩展 dayjs() 实例
   // 例：添加 dayjs().isSameOrBefore() 实例方法
-  dayjsClass.prototype.isSameOrBefore = function(arguments) {}
+  dayjsClass.prototype.isSameOrBefore = function(...args) {}
 
   // 扩展 dayjs 类
   // 例：添加 dayjs.utc() 类方法
-  dayjsFactory.utc = arguments => {}
+  dayjsFactory.utc = (...args) => {}
 
   // 覆盖已存在的 API
   // 例：扩展 dayjs().format() 方法
   const oldFormat = dayjsClass.prototype.format
-  dayjsClass.prototype.format = function(arguments) {
+  dayjsClass.prototype.format = function(...args) {
     // 原始format结果
-    const result = oldFormat(arguments)
+    const result = oldFormat(...args)
     // 返回修改后结果
   }
 }

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -24,7 +24,7 @@ declare namespace dayjs {
   export type UnitTypeLong = 'millisecond' | 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year' | 'date'
 
   export type UnitTypeLongPlural = 'milliseconds' | 'seconds' | 'minutes' | 'hours' | 'days' | 'months' | 'years' | 'dates'
-  
+
   export type UnitType = UnitTypeLong | UnitTypeLongPlural | UnitTypeShort;
 
   export type OpUnitType = UnitType | "week" | "weeks" | 'w';
@@ -80,7 +80,7 @@ declare namespace dayjs {
      *
      * Months are zero indexed, so January is month 0.
      *
-     * Accepts numbers from 0 to 11. If the range is exceeded, it will bubble up to the next year.
+     * Accept numbers from 0 to 11. If the range is exceeded, it will bubble up to the next year.
      * ```
      * dayjs().month(0)// => Dayjs
      * ```
@@ -108,7 +108,7 @@ declare namespace dayjs {
     /**
      * Get the day of the week.
      *
-     * Returns numbers from 0 (Sunday) to 6 (Saturday).
+     * Return numbers from 0 (Sunday) to 6 (Saturday).
      * ```
      * dayjs().day()// 0-6
      * ```
@@ -118,7 +118,7 @@ declare namespace dayjs {
     /**
      * Set the day of the week.
      *
-     * Accepts numbers from 0 (Sunday) to 6 (Saturday). If the range is exceeded, it will bubble up to next weeks.
+     * Accept numbers from 0 (Sunday) to 6 (Saturday). If the range is exceeded, it will bubble up to next weeks.
      * ```
      * dayjs().day(0)// => Dayjs
      * ```
@@ -136,7 +136,7 @@ declare namespace dayjs {
     /**
      * Set the hour.
      *
-     * Accepts numbers from 0 to 23. If the range is exceeded, it will bubble up to the next day.
+     * Accept numbers from 0 to 23. If the range is exceeded, it will bubble up to the next day.
      * ```
      * dayjs().hour(12)// => Dayjs
      * ```
@@ -154,7 +154,7 @@ declare namespace dayjs {
     /**
      * Set the minutes.
      *
-     * Accepts numbers from 0 to 59. If the range is exceeded, it will bubble up to the next hour.
+     * Accept numbers from 0 to 59. If the range is exceeded, it will bubble up to the next hour.
      * ```
      * dayjs().minute(59)// => Dayjs
      * ```
@@ -172,7 +172,7 @@ declare namespace dayjs {
     /**
      * Set the seconds.
      *
-     * Accepts numbers from 0 to 59. If the range is exceeded, it will bubble up to the next minutes.
+     * Accept numbers from 0 to 59. If the range is exceeded, it will bubble up to the next minutes.
      * ```
      * dayjs().second(1)// Dayjs
      * ```
@@ -189,7 +189,7 @@ declare namespace dayjs {
     /**
      * Set the milliseconds.
      *
-     * Accepts numbers from 0 to 999. If the range is exceeded, it will bubble up to the next seconds.
+     * Accept numbers from 0 to 999. If the range is exceeded, it will bubble up to the next seconds.
      * ```
      * dayjs().millisecond(1)// => Dayjs
      * ```


### PR DESCRIPTION
When I read the documentation for day.js, I noticed the following sample code:

```javascript
dayjsClass.prototype.format = function(arguments) {
    // original format result
    const result = oldFormat(arguments)
    // return modified result
}
```

I think it should make some changes.

1. `arguments` is a reserved word and may have compatibility issues in some special scenarios.

2. Some parameters of the function in the example are not only one. For example, `isSameOrBefore` accepts two parameters, and only the first one can be obtained by the method in the example.

So I did the refactoring using ES6's spread operator.

---

Also, I've fixed some syntax errors (either code, or text) in the documentation that I've seen.