### PR TITLE
Update farsi locale

### DIFF
--- a/src/locale/fa.js
+++ b/src/locale/fa.js
@@ -1,23 +1,42 @@
 // Persian [fa]
 import dayjs from 'dayjs'
 
+const months = 'ژانویه_فوریه_مارس_آوریل_مه_ژوئن_ژوئیه_اوت_سپتامبر_اکتبر_نوامبر_دسامبر'.split('_')
+const symbolMap = {
+  1: '١',
+  2: '٢',
+  3: '٣',
+  4: '٤',
+  5: '٥',
+  6: '٦',
+  7: '٧',
+  8: '٨',
+  9: '٩',
+  0: '٠'
+}
+
+const numberMap = {
+  '١': '1',
+  '٢': '2',
+  '٣': '3',
+  '٤': '4',
+  '٥': '5',
+  '٦': '6',
+  '٧': '7',
+  '٨': '8',
+  '٩': '9',
+  '٠': '0'
+}
+
 const locale = {
   name: 'fa',
-  weekdays: 'یک‌شنبه_دوشنبه_سه‌شنبه_چهارشنبه_پنج‌شنبه_جمعه_شنبه'.split('_'),
+  weekdays: 'یک\u200cشنبه_دوشنبه_سه\u200cشنبه_چهارشنبه_پنج\u200cشنبه_جمعه_شنبه'.split('_'),
   weekdaysShort: 'یک\u200cشنبه_دوشنبه_سه\u200cشنبه_چهارشنبه_پنج\u200cشنبه_جمعه_شنبه'.split('_'),
   weekdaysMin: 'ی_د_س_چ_پ_ج_ش'.split('_'),
+  months,
+  monthsShort: months,
   weekStart: 6,
-  months: 'ژانویه_فوریه_مارس_آوریل_مه_ژوئن_ژوئیه_اوت_سپتامبر_اکتبر_نوامبر_دسامبر'.split('_'),
-  monthsShort: 'ژانویه_فوریه_مارس_آوریل_مه_ژوئن_ژوئیه_اوت_سپتامبر_اکتبر_نوامبر_دسامبر'.split('_'),
-  ordinal: n => n,
-  formats: {
-    LT: 'HH:mm',
-    LTS: 'HH:mm:ss',
-    L: 'DD/MM/YYYY',
-    LL: 'D MMMM YYYY',
-    LLL: 'D MMMM YYYY HH:mm',
-    LLLL: 'dddd, D MMMM YYYY HH:mm'
-  },
+  yearStart: 4,
   relativeTime: {
     future: 'در %s',
     past: '%s پیش',
@@ -32,7 +51,31 @@ const locale = {
     MM: '%d ماه',
     y: 'یک سال',
     yy: '%d سال'
-  }
+  },
+  meridiem: hour => (hour > 12 ? 'ص' : 'ع'),
+  preparse(string) {
+    return string
+      .replace(
+        /[١٢٣٤٥٦٧٨٩٠]/g,
+        match => numberMap[match]
+      )
+      .replace(/،/g, ',')
+  },
+  postformat(string) {
+    return string
+      .replace(/\d/g, match => symbolMap[match])
+      .replace(/,/g, '،')
+  },
+  ordinal: n => n,
+  formats: {
+    LT: 'HH:mm',
+    LTS: 'HH:mm:ss',
+    L: 'DD/MM/YYYY',
+    LL: 'D MMMM YYYY',
+    LLL: 'D MMMM YYYY HH:mm',
+    LLLL: 'dddd, D MMMM YYYY HH:mm'
+  },
+ 
 }
 
 dayjs.locale(locale, null, true)


### PR DESCRIPTION
adds:
- meridiem
- number maps
- yearStart
Use this with  https://day.js.org/docs/en/plugin/preparse-postformat plugin to get the localized numbers (١٢٣٤٥٦٧٨٩٠)