### PR TITLE
Fixed past in relative time of Galician Language

### DIFF
--- a/src/locale/gl.js
+++ b/src/locale/gl.js
@@ -20,7 +20,7 @@ const locale = {
   },
   relativeTime: {
     future: 'en %s',
-    past: 'fai %s',
+    past: 'hai %s',
     s: 'uns segundos',
     m: 'un minuto',
     mm: '%d minutos',


### PR DESCRIPTION
I've fixed the past in the relative time of Galician language. The correct word is 'hai' not 'fai'.

As seen in [https://github.com/iamkun/dayjs/pull/1800](https://github.com/iamkun/dayjs/pull/1800) by [nuno-andre](https://github.com/nuno-andre)