### PR TITLE
fix: startOf get error when use mutable & timezone & UTC

### DIFF
--- a/src/plugin/badMutable/index.js
+++ b/src/plugin/badMutable/index.js
@@ -11,14 +11,14 @@ export default (o, c) => { // locale needed later
 
   const oldStartOf = proto.startOf
   proto.startOf = function (units, startOf) {
-    this.$d = oldStartOf.bind(this)(units, startOf).toDate()
+    this.$d = oldStartOf.bind(this)(units, startOf).$d
     this.init()
     return this
   }
 
   const oldAdd = proto.add
   proto.add = function (number, units) {
-    this.$d = oldAdd.bind(this)(number, units).toDate()
+    this.$d = oldAdd.bind(this)(number, units).$d
     this.init()
     return this
   }

--- a/test/plugin/timezone.test.js
+++ b/test/plugin/timezone.test.js
@@ -4,10 +4,12 @@ import dayjs from '../../src'
 import timezone from '../../src/plugin/timezone'
 import customParseFormat from '../../src/plugin/customParseFormat'
 import utc from '../../src/plugin/utc'
+import badMutable from '../../src/plugin/badMutable'
 
 dayjs.extend(utc)
 dayjs.extend(timezone)
 dayjs.extend(customParseFormat)
+dayjs.extend(badMutable)
 
 beforeEach(() => {
   MockDate.set(new Date())
@@ -313,9 +315,21 @@ describe('startOf and endOf', () => {
     expect(startOfDay.valueOf()).toEqual(originalDay.valueOf())
   })
 
+  it('corrects for timezone offset in startOf with format', () => {
+    const dateStr = '2010-01-01 00:00:00'
+    const originalDay = dayjs.tz(dateStr, NY)
+    expect(originalDay.startOf('day').format('YYYY-MM-DD HH:mm:ss')).toEqual(dateStr)
+  })
+
   it('corrects for timezone offset in endOf', () => {
     const originalDay = dayjs.tz('2009-12-31 23:59:59.999', NY)
     const endOfDay = originalDay.endOf('day')
     expect(endOfDay.valueOf()).toEqual(originalDay.valueOf())
+  })
+
+  it('corrects for timezone offset in endOf with format', () => {
+    const dateStr = '2009-12-31 23:59:59.999'
+    const originalDay = dayjs.tz(dateStr, NY)
+    expect(originalDay.endOf('day').format('YYYY-MM-DD HH:mm:ss.SSS')).toEqual(dateStr)
   })
 })


### PR DESCRIPTION
when using plugins of mutable 、timezone、UTC， methods startOf get an error result.

```
dayjs.extend(utc)
dayjs.extend(timezone)
dayjs.extend(customParseFormat)

dayjs.extend(badMutable)

dayjs.tz('2009-12-31 23:59:59.999', 'America/New_York').endOf('day').format('YYYY-MM-DD HH:mm:ss.SSS')
// without badMutable 2009-12-31 23:59:59.999
// with badMutable 2010-01-02 01:59:59.999
```