### PR TITLE
fix: correct past property in KU (kurdish) locale

### DIFF
--- a/src/locale/ku.js
+++ b/src/locale/ku.js
@@ -72,7 +72,7 @@ const locale = {
   meridiem: hour => (hour < 12 ? 'پ.ن' : 'د.ن'),
   relativeTime: {
     future: 'لە %s',
-    past: '%s',
+    past: 'لەمەوپێش %s',
     s: 'چەند چرکەیەک',
     m: 'یەک خولەک',
     mm: '%d خولەک',


### PR DESCRIPTION
hello dayjs, in this pr add value to past property in english say ago say in kurdish say something like لەمەوپێش 

thank you.