### PR TITLE
feat: add diff360 plugin

### DIFF
--- a/src/plugin/diff360/index.js
+++ b/src/plugin/diff360/index.js
@@ -1,0 +1,43 @@
+export default (o, c) => {
+  c.prototype.diff360 = function (t, m) {
+    let startDay = parseInt(this.date(), 10)
+    const startMonth = parseInt(this.month(), 10) + 1
+    const startYear = parseInt(this.year(), 10)
+
+    let endDay = parseInt(t.date(), 10)
+    let endMonth = parseInt(t.month(), 10) + 1
+    let endYear = parseInt(t.year(), 10)
+
+    const isLeapYear =
+      (((startYear % 4) === 0) && ((startYear % 100) !== 0)) || ((startYear % 400) === 0)
+
+    if (startDay === 31) {
+      startDay -= 1
+    } else if (m && (startMonth === 2 && (startDay === 29 || (startDay === 28 && !isLeapYear)))) {
+      startDay = 30
+    }
+
+    if (endDay === 31) {
+      if (m && startDay !== 30) {
+        endDay = 1
+        if (endMonth === 12) {
+          endYear += 1
+          endMonth = 1
+        } else {
+          endMonth += 1
+        }
+      } else {
+        endDay = 30
+      }
+    }
+
+    let result = endDay
+    result += (endMonth * 30)
+    result += (endYear * 360)
+    result -= startDay
+    result -= (startMonth * 30)
+    result -= (startYear * 360)
+
+    return result
+  }
+}

--- a/test/plugin/diff360.test.js
+++ b/test/plugin/diff360.test.js
@@ -1,0 +1,81 @@
+import MockDate from 'mockdate'
+import dayjs from '../../src'
+import diff360 from '../../src/plugin/diff360'
+
+dayjs.extend(diff360)
+
+beforeEach(() => {
+  MockDate.set(new Date())
+})
+
+afterEach(() => {
+  MockDate.reset()
+})
+
+test('It returns 0 days between same date', () => {
+  expect(dayjs('2022-01-01').diff360(dayjs('2022-01-01'), true)).toBe(0)
+})
+
+test('It returns 1 day between two consecutive dates', () => {
+  expect(dayjs('2022-01-01').diff360(dayjs('2022-01-02'), true)).toBe(1)
+})
+
+test('It returns 30 days in every month', () => {
+  expect(dayjs('2022-01-01').diff360(dayjs('2022-02-01'), true)).toBe(30)
+  expect(dayjs('2022-02-01').diff360(dayjs('2022-03-01'), true)).toBe(30)
+  expect(dayjs('2022-03-01').diff360(dayjs('2022-04-01'), true)).toBe(30)
+  expect(dayjs('2022-04-01').diff360(dayjs('2022-05-01'), true)).toBe(30)
+  expect(dayjs('2022-05-01').diff360(dayjs('2022-06-01'), true)).toBe(30)
+  expect(dayjs('2022-07-01').diff360(dayjs('2022-08-01'), true)).toBe(30)
+  expect(dayjs('2022-08-01').diff360(dayjs('2022-09-01'), true)).toBe(30)
+  expect(dayjs('2022-09-01').diff360(dayjs('2022-10-01'), true)).toBe(30)
+  expect(dayjs('2022-10-01').diff360(dayjs('2022-11-01'), true)).toBe(30)
+  expect(dayjs('2022-11-01').diff360(dayjs('2022-12-01'), true)).toBe(30)
+  expect(dayjs('2022-12-01').diff360(dayjs('2023-01-01'), true)).toBe(30)
+})
+
+test('It returns 30 days for 31 days within same month', () => {
+  expect(dayjs('2022-01-01').diff360(dayjs('2022-01-31'), true)).toBe(30)
+})
+
+test('It returns 360 days for an entire year minus one day', () => {
+  expect(dayjs('2022-01-01').diff360(dayjs('2022-12-31'), true)).toBe(360)
+})
+
+test('It returns 60 days between two months on the end date with varying lengths', () => {
+  expect(dayjs('2022-01-31').diff360(dayjs('2022-03-31'), true)).toBe(60)
+})
+
+test('It returns 360 days for an entire year regardless of leap year', () => {
+  expect(dayjs('2022-01-01').diff360(dayjs('2023-01-01'), true)).toBe(360)
+  expect(dayjs('2023-01-01').diff360(dayjs('2024-01-01'), true)).toBe(360)
+  expect(dayjs('2024-01-01').diff360(dayjs('2025-01-01'), true)).toBe(360)
+  expect(dayjs('2025-01-01').diff360(dayjs('2026-01-01'), true)).toBe(360)
+})
+
+test('It returns 30 days in Feburary regardless of leap year', () => {
+  expect(dayjs('2022-02-01').diff360(dayjs('2022-03-01'), true)).toBe(30)
+  expect(dayjs('2023-02-01').diff360(dayjs('2023-03-01'), true)).toBe(30)
+  expect(dayjs('2024-02-01').diff360(dayjs('2024-03-01'), true)).toBe(30)
+  expect(dayjs('2025-02-01').diff360(dayjs('2025-03-01'), true)).toBe(30)
+})
+
+test('It returns 1 day between the 28th of Feburary and 1st of March (EU method)', () => {
+  expect(dayjs('2022-02-28').diff360(dayjs('2022-03-01'), true)).toBe(1)
+})
+
+test('It returns 3 days between the 28th of Feburary and 1st of March (US method)', () => {
+  expect(dayjs('2022-02-28').diff360(dayjs('2022-03-01'), false)).toBe(3)
+})
+
+test('It returns the correct number of days spanning multiple days within two months', () => {
+  expect(dayjs('2022-01-15').diff360(dayjs('2022-02-15'), true)).toBe(30)
+})
+
+test('It returns the correct number of days spanning multiple months', () => {
+  expect(dayjs('2022-12-01').diff360(dayjs('2023-03-01'), true)).toBe(90)
+})
+
+test('It returns the correct number of days spanning multiple years', () => {
+  expect(dayjs('2022-01-01').diff360(dayjs('2032-01-01'), true)).toBe(3600)
+})

--- a/types/plugin/diff360.d.ts
+++ b/types/plugin/diff360.d.ts
@@ -1,0 +1,10 @@
+import { PluginFunc, ConfigType } from 'dayjs'
+
+declare const plugin: PluginFunc
+export = plugin
+
+declare module 'dayjs' {
+  interface Dayjs {
+    diff360(date: ConfigType, methodUS: boolean): number
+  }
+}


### PR DESCRIPTION
This plugin returns the number of days between two dates based on a 360-day calendar (twelve 30-day months),

The 360-day calendar is a method of measuring durations used in financial markets, in computer models, in ancient literature, and in prophetic literary genres.

It uses the following algorithm to calculate the difference (Turn off dark mode to see):

![image](https://user-images.githubusercontent.com/8896149/171658390-ba587774-c9e3-4653-8063-11487258d067.png)
