### PR TITLE
Fix configuration for eslint (linting subdirectories; activating jest rules

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,5 +1,8 @@
 {
-  "extends": "airbnb-base",
+  "extends": [
+    "airbnb-base",
+    "plugin:jest/recommended"
+  ],
   "plugins": [
     "jest"
   ],

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "test": "TZ=Pacific/Auckland npm run test-tz && TZ=Europe/London npm run test-tz && TZ=America/Whitehorse npm run test-tz && npm run test-tz && jest",
     "test-tz": "date && jest test/timezone.test --coverage=false",
-    "lint": "./node_modules/.bin/eslint src/* test/* build/*",
+    "lint": "./node_modules/.bin/eslint src/**/* test/**/* build/**/*",
     "prettier": "prettier --write \"docs/**/*.md\"",
     "babel": "cross-env BABEL_ENV=build babel src --out-dir esm --copy-files && node build/esm",
     "build": "cross-env BABEL_ENV=build node build && npm run size",

--- a/src/locale/nl.js
+++ b/src/locale/nl.js
@@ -8,7 +8,7 @@ const locale = {
   weekdaysMin: 'zo_ma_di_wo_do_vr_za'.split('_'),
   months: 'januari_februari_maart_april_mei_juni_juli_augustus_september_oktober_november_december'.split('_'),
   monthsShort: 'jan_feb_mrt_apr_mei_jun_jul_aug_sep_okt_nov_dec'.split('_'),
-  ordinal: (n) => `${n}${n === 1 || n === 8 || n >= 20 ? 'ste' : 'de'}`,
+  ordinal: n => `${n}${n === 1 || n === 8 || n >= 20 ? 'ste' : 'de'}`,
   weekStart: 1,
   yearStart: 4,
   formats: {
@@ -33,8 +33,7 @@ const locale = {
     MM: '%d maanden',
     y: 'een jaar',
     yy: '%d jaar'
-  },
-  
+  }
 }
 
 dayjs.locale(locale, null, true)

--- a/test/comparison.test.js
+++ b/test/comparison.test.js
@@ -347,7 +347,7 @@ test('is after invalid', () => {
 
 // isBefore()
 
-test('is after without units', () => {
+test('is before without units', () => {
   const m = dayjs(new Date(2011, 3, 2, 3, 4, 5, 10))
   const mCopy = dayjs(m)
   expect(m.isBefore(dayjs(new Date(2012, 3, 2, 3, 5, 5, 10)))).toBe(true, 'year is later')

--- a/test/locale/keys.test.js
+++ b/test/locale/keys.test.js
@@ -95,7 +95,7 @@ Locale.forEach((locale) => {
         LT: expect.any(String),
         LTS: expect.any(String)
       }))
-      expect(Object.keys(remainingFormats).length).toEqual(0)
+      expect(Object.keys(remainingFormats)).toHaveLength(0)
       if (l) expect(l).toEqual(expect.any(String))
       if (ll) expect(ll).toEqual(expect.any(String))
       if (lll) expect(lll).toEqual(expect.any(String))

--- a/test/plugin/advancedFormat.test.js
+++ b/test/plugin/advancedFormat.test.js
@@ -88,13 +88,6 @@ it('Format Week of Year wo', () => {
     .toBe(moment(d).locale('zh-cn').format('wo'))
 })
 
-it('Format Week of Year wo', () => {
-  const d = '2018-12-01'
-  expect(dayjs(d).format('wo')).toBe(moment(d).format('wo'))
-  expect(dayjs(d).locale('zh-cn').format('wo'))
-    .toBe(moment(d).locale('zh-cn').format('wo'))
-})
-
 it('Format Week Year gggg', () => {
   const d = '2018-12-31'
   expect(dayjs(d).format('gggg')).toBe(moment(d).format('gggg'))

--- a/test/plugin/duration.test.js
+++ b/test/plugin/duration.test.js
@@ -139,16 +139,7 @@ describe('Clone', () => {
 })
 
 describe('Milliseconds', () => {
-  expect(dayjs.duration(500).milliseconds()).toBe(500)
-  expect(dayjs.duration(1500).milliseconds()).toBe(500)
-  expect(dayjs.duration(15000).milliseconds()).toBe(0)
-  expect(dayjs.duration(500).asMilliseconds()).toBe(500)
-  expect(dayjs.duration(1500).asMilliseconds()).toBe(1500)
-  expect(dayjs.duration(15000).asMilliseconds()).toBe(15000)
-})
-
-describe('Milliseconds', () => {
-  describe('Positive number', () => {
+  it('Positive number', () => {
     expect(dayjs.duration(500).milliseconds()).toBe(500)
     expect(dayjs.duration(1500).milliseconds()).toBe(500)
     expect(dayjs.duration(15000).milliseconds()).toBe(0)
@@ -157,7 +148,7 @@ describe('Milliseconds', () => {
     expect(dayjs.duration(15000).asMilliseconds()).toBe(15000)
   })
 
-  describe('Negative number', () => {
+  it('Negative number', () => {
     expect(dayjs.duration(-500).milliseconds()).toBe(-500)
     expect(dayjs.duration(-1500).milliseconds()).toBe(-500)
     expect(dayjs.duration(-15000).milliseconds()).toBe(0)

--- a/test/plugin/timezone.test.js
+++ b/test/plugin/timezone.test.js
@@ -72,21 +72,11 @@ describe('Parse', () => {
 
 describe('Convert', () => {
   it('convert to target time', () => {
-    const losAngeles = dayjs('2014-06-01T12:00:00Z').tz('America/Los_Angeles')
-    const MlosAngeles = moment('2014-06-01T12:00:00Z').tz('America/Los_Angeles')
-    expect(losAngeles.format()).toBe('2014-06-01T05:00:00-07:00')
-    expect(losAngeles.format()).toBe(MlosAngeles.format())
-    expect(losAngeles.valueOf()).toBe(1401624000000)
-    expect(losAngeles.valueOf()).toBe(MlosAngeles.valueOf())
-    expect(losAngeles.utcOffset()).toBe(-420)
-    expect(losAngeles.utcOffset()).toBe(MlosAngeles.utcOffset())
-  })
-
-  it('convert to target time', () => {
     [dayjs, moment].forEach((_) => {
       const losAngeles = _('2014-06-01T12:00:00Z').tz('America/Los_Angeles')
       expect(losAngeles.format()).toBe('2014-06-01T05:00:00-07:00')
       expect(losAngeles.valueOf()).toBe(1401624000000)
+      expect(losAngeles.utcOffset()).toBe(-420)
     })
   })
 
@@ -179,15 +169,6 @@ describe('DST, a time that never existed Spring Forward', () => {
 describe('DST, a time that never existed Fall Back', () => {
   // In the fall, at the end of DST
 
-  it('2012-11-04 00:59:59', () => {
-    const s = '2012-11-04 00:59:59';
-    [dayjs, moment].forEach((_) => {
-      const d = _.tz(s, NY)
-      expect(d.format()).toBe('2012-11-04T00:59:59-04:00')
-      expect(d.utcOffset()).toBe(-240)
-      expect(d.valueOf()).toBe(1352005199000)
-    })
-  })
   it('2012-11-04 00:59:59', () => {
     const s = '2012-11-04 00:59:59';
     [dayjs, moment].forEach((_) => {

--- a/test/plugin/utc.test.js
+++ b/test/plugin/utc.test.js
@@ -76,7 +76,7 @@ describe('Parse UTC ', () => {
     expect(dayjs.utc(d2).format()).toEqual(moment.utc(d2).format())
   })
 
-  it('Parse date string without timezone', () => {
+  it('Parse date and time string without timezone', () => {
     const d = '2017-04-22 19:50:16'
     expect(dayjs.utc(d).format()).toEqual('2017-04-22T19:50:16Z')
     expect(dayjs.utc(d).format()).toEqual(moment.utc(d).format())


### PR DESCRIPTION
The configuration for eslint had 2 minor topics:

- lintingwas only activated for directories 'src', 'test' and 'build' but not for the subdirectories of these directories
- jest rules for eslint were loaded (property "plugins" in .eslintrc.json) but not activated

Fixes these topics and removed the newly identified warnings.