### PR TITLE
Fix isBefore/isAfter types to support optional arguments 

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -382,7 +382,7 @@ declare namespace dayjs {
      *
      * Docs: https://day.js.org/docs/en/query/is-before
      */
-    isBefore(date: ConfigType, unit?: OpUnitType): boolean
+    isBefore(date?: ConfigType, unit?: OpUnitType): boolean
     /**
      * This indicates whether the Day.js object is the same as the other supplied date-time.
      * ```
@@ -408,7 +408,7 @@ declare namespace dayjs {
      *
      * Docs: https://day.js.org/docs/en/query/is-after
      */
-    isAfter(date: ConfigType, unit?: OpUnitType): boolean
+    isAfter(date?: ConfigType, unit?: OpUnitType): boolean
 
     locale(): string
 


### PR DESCRIPTION
Comparison functions `isBefore` and `isAfter` default to using now (`dayjs()`) when no arguments are provided. The current type declarations don't allow for 0 arguments. This PR makes those arguments optional in `index.d.ts`.