### PR TITLE
Fix issue1923 - parsing of milliseconds like moment does

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -66,7 +66,7 @@ const parseDate = (cfg) => {
     const d = date.match(C.REGEX_PARSE)
     if (d) {
       const m = d[2] - 1 || 0
-      const ms = (d[7] || '0').substring(0, 3)
+      const ms = Utils.e((d[7] || '0').substring(0, 3), 3, '0')
       if (utc) {
         return new Date(Date.UTC(d[1], m, d[3]
           || 1, d[4] || 0, d[5] || 0, d[6] || 0, ms))

--- a/src/utils.js
+++ b/src/utils.js
@@ -6,6 +6,12 @@ const padStart = (string, length, pad) => {
   return `${Array((length + 1) - s.length).join(pad)}${string}`
 }
 
+const padEnd = (string, length, pad) => {
+  const s = String(string)
+  if (!s || s.length >= length) return string
+  return `${string}${Array((length + 1) - s.length).join(pad)}`
+}
+
 const padZoneStr = (instance) => {
   const negMinutes = -instance.utcOffset()
   const minutes = Math.abs(negMinutes)
@@ -47,6 +53,7 @@ const isUndefined = s => s === undefined
 
 export default {
   s: padStart,
+  e: padEnd,
   z: padZoneStr,
   m: monthDiff,
   a: absFloor,

--- a/test/parse.test.js
+++ b/test/parse.test.js
@@ -26,7 +26,11 @@ describe('Parse', () => {
     expect(dayjs(d).format()).toBe(moment(d).format()) // not recommend
     d = '2018-05-02 11:12:13'
     expect(dayjs(d).valueOf()).toBe(moment(d).valueOf())
-    d = '2018-05-02 11:12:13.998'
+    d = '2018-05-02 11:12:13.9'
+    expect(dayjs(d).valueOf()).toBe(moment(d).valueOf())
+    d = '2018-05-02 11:12:13.98'
+    expect(dayjs(d).valueOf()).toBe(moment(d).valueOf())
+    d = '2018-05-02 11:12:13.987'
     expect(dayjs(d).valueOf()).toBe(moment(d).valueOf())
     d = '2018-4-1'
     expect(dayjs(d).valueOf()).toBe(moment(d).valueOf()) // not recommend

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -2,6 +2,7 @@ import Utils from '../src/utils'
 
 const prettyUnit = Utils.p
 const padStart = Utils.s
+const padEnd = Utils.e
 const padZoneStr = Utils.z
 
 it('PrettyUnit', () => {
@@ -41,4 +42,9 @@ it('PadZoneStr', () => {
 it('PadStart', () => {
   expect(padStart(1, 2, '0')).toBe('01')
   expect(padStart(0, 2, '0')).toBe('00')
+})
+
+it('PadEnd', () => {
+  expect(padEnd(1, 2, '0')).toBe('10')
+  expect(padEnd(0, 2, '0')).toBe('00')
 })


### PR DESCRIPTION
With this fix, milliseconds in ISO date string are parsed like moment does (digits get padded to re right with '0' to 3 places).

Solves issue #1923.