### PR TITLE
feat: diff plugin

### DIFF
--- a/src/plugin/diff/index.js
+++ b/src/plugin/diff/index.js
@@ -1,0 +1,40 @@
+import {
+  MILLISECONDS_A_DAY,
+  MILLISECONDS_A_HOUR,
+  MILLISECONDS_A_MINUTE,
+  MILLISECONDS_A_SECOND,
+  MILLISECONDS_A_WEEK
+} from '../../constant'
+
+export default (_, c, d) => {
+  c.prototype.diff = function (u, v) {
+    if (!u) throw new Error('Unit is not defined!')
+
+    const t = this.valueOf()
+    const vt = d(v).valueOf()
+    const df = Math.abs(t - vt)
+
+    switch (u) {
+      case 'millisecond':
+      case 'milliseconds':
+        return df
+      case 'second':
+      case 'seconds':
+        return Math.round(df / MILLISECONDS_A_SECOND)
+      case 'minute':
+      case 'minutes':
+        return Math.round(df / MILLISECONDS_A_MINUTE)
+      case 'hour':
+      case 'hours':
+        return Math.round(df / MILLISECONDS_A_HOUR)
+      case 'day':
+      case 'days':
+        return Math.round(df / MILLISECONDS_A_DAY)
+      case 'week':
+      case 'weeks':
+        return Math.round(df / MILLISECONDS_A_WEEK)
+      default:
+        throw new Error(`Unit "${u}" is not supported!`)
+    }
+  }
+}

--- a/test/plugin/diff.test.js
+++ b/test/plugin/diff.test.js
@@ -1,0 +1,109 @@
+import MockDate from 'mockdate'
+import dayjs from '../../src/index'
+import diff from '../../src/plugin/diff/index'
+
+dayjs.extend(diff)
+
+beforeEach(() => {
+  MockDate.set(new Date())
+})
+
+afterEach(() => {
+  MockDate.reset()
+})
+
+describe('no unit passed', () => {
+  test('throws an error', () => {
+    expect(() => dayjs().diff()).toThrow(expect.any(Error))
+  })
+})
+
+describe('unsupported unit', () => {
+  test('throws an error', () => {
+    expect(() => dayjs().diff('foo', new Date())).toThrow(expect.any(Error))
+  })
+})
+
+describe('milliseconds', () => {
+  test('returns difference for `millisecond` unit', () => {
+    const [a, b] = [new Date('2020-06-01 12:00:00'), new Date('2020-06-01 12:00:01')]
+
+    expect(dayjs(a).diff('millisecond', b)).toEqual(1000)
+  })
+
+  test('returns difference for `milliseconds` unit', () => {
+    const [a, b] = [new Date('2020-06-01 12:00:00'), new Date('2020-06-01 12:00:59')]
+
+    expect(dayjs(a).diff('millisecond', b)).toEqual(59000)
+  })
+})
+
+describe('seconds', () => {
+  test('returns difference for `second` unit', () => {
+    const [a, b] = [new Date('2020-06-01 12:00:00'), new Date('2020-06-01 12:00:01')]
+
+    expect(dayjs(a).diff('second', b)).toEqual(1)
+  })
+
+  test('returns difference for `seconds` unit', () => {
+    const [a, b] = [new Date('2020-06-01 12:00:00'), new Date('2020-06-01 12:01:59')]
+
+    expect(dayjs(a).diff('seconds', b)).toEqual(119)
+  })
+})
+
+describe('minutes', () => {
+  test('returns difference for `minute` unit', () => {
+    const [a, b] = [new Date('2020-06-01 12:00:00'), new Date('2020-06-01 12:01:00')]
+
+    expect(dayjs(a).diff('minute', b)).toEqual(1)
+  })
+
+  test('returns difference for `minutes` unit', () => {
+    const [a, b] = [new Date('2020-06-01 12:00:00'), new Date('2020-06-01 13:59:00')]
+
+    expect(dayjs(a).diff('minutes', b)).toEqual(119)
+  })
+})
+
+describe('hours', () => {
+  test('returns difference for `hour` unit', () => {
+    const [a, b] = [new Date('2020-06-01 12:00:00'), new Date('2020-06-01 13:00:00')]
+
+    expect(dayjs(a).diff('hour', b)).toEqual(1)
+  })
+
+  test('returns difference for `hours` unit', () => {
+    const [a, b] = [new Date('2020-06-01 12:00:00'), new Date('2020-06-02 23:00:00')]
+
+    expect(dayjs(a).diff('hours', b)).toEqual(35)
+  })
+})
+
+describe('days', () => {
+  test('returns difference for `day` unit', () => {
+    const [a, b] = [new Date('2020-06-01 12:00:00'), new Date('2020-06-02 12:00:00')]
+
+    expect(dayjs(a).diff('day', b)).toEqual(1)
+  })
+
+  test('returns difference for `days` unit', () => {
+    const [a, b] = [new Date('2020-06-01 12:00:00'), new Date('2020-07-01 12:00:00')]
+
+    expect(dayjs(a).diff('days', b)).toEqual(30)
+  })
+})
+
+describe('weeks', () => {
+  test('returns difference for `week` unit', () => {
+    const [a, b] = [new Date('2020-06-01 12:00:00'), new Date('2020-06-08 12:00:00')]
+
+    expect(dayjs(a).diff('week', b)).toEqual(1)
+  })
+
+  test('returns difference for `weeks` unit', () => {
+    const [a, b] = [new Date('2020-06-01 12:00:00'), new Date('2020-07-01 12:00:00')]
+
+    expect(dayjs(a).diff('weeks', b)).toEqual(4)
+  })
+})

--- a/types/plugin/diff.d.ts
+++ b/types/plugin/diff.d.ts
@@ -1,0 +1,10 @@
+import { PluginFunc, ConfigType, UnitTypeLong, UnitTypeLongPlural } from 'dayjs'
+
+declare const plugin: PluginFunc
+export = plugin
+
+declare module 'dayjs' {
+  interface Dayjs {
+    diff(u: UnitTypeLong | UnitTypeLongPlural, v: ConfigType): number
+  }
+}


### PR DESCRIPTION
Adds `diff` plugin to get difference between two dates in given units.

Usage example:

```js
dayjs('2022-06-11').diff('day', '2022-06-30') // 19
```

The functionality is very useful when you need to determine specific time gap and it isn't enough to have `23` limit for hours or `59` for minutes:

```js
dayjs('2022-06-11 01:00').diff('day', '2022-06-11 03:00') // 120
```

The plugin inspired by `date-fns` `differenceInMilliseconds`, `differenceInSeconds` etc. functions.

I haven't found where I should document the plugin. @iamkun could you please tell me, where is the documentation sources are located in?