### PR TITLE
fix: .format('YYYY') returns less than 4 digits for years < 1000

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -280,7 +280,7 @@ class Dayjs {
 
     const matches = {
       YY: String(this.$y).slice(-2),
-      YYYY: this.$y,
+      YYYY: Utils.s(this.$y, 4, '0'),
       M: $M + 1,
       MM: Utils.s($M + 1, 2, '0'),
       MMM: getShort(locale.monthsShort, $M, months, 3),

--- a/test/display.test.js
+++ b/test/display.test.js
@@ -24,6 +24,9 @@ it('Format invalid date', () => {
 it('Format Year YY YYYY', () => {
   expect(dayjs().format('YY')).toBe(moment().format('YY'))
   expect(dayjs().format('YYYY')).toBe(moment().format('YYYY'))
+  const timeWithThreeDigitYear = '0200-05-02T01:00:00.000'
+  expect(dayjs(timeWithThreeDigitYear).format('YYYY')).toBe(moment(timeWithThreeDigitYear).format('YYYY'))
+  expect(dayjs(timeWithThreeDigitYear).format('YY')).toBe(moment(timeWithThreeDigitYear).format('YY'))
 })
 
 it('Format Month M MM MMM MMMM', () => {


### PR DESCRIPTION
close #1745 