### PR TITLE
fix issue1957: parse Dayjs object with plugin objectSupport

### DIFF
--- a/src/plugin/objectSupport/index.js
+++ b/src/plugin/objectSupport/index.js
@@ -1,6 +1,8 @@
 export default (o, c, dayjs) => {
   const proto = c.prototype
-  const isObject = obj => !(obj instanceof Date) && !(obj instanceof Array) && obj instanceof Object
+  // proto.constructor is Dayjs object
+  const isObject = obj => !(obj instanceof proto.constructor) && !(obj instanceof Date)
+    && !(obj instanceof Array) && obj instanceof Object
   const prettyUnit = (u) => {
     const unit = proto.$utils().p(u)
     return unit === 'date' ? 'day' : unit


### PR DESCRIPTION
Plugin objectSupport failed, when parsing a Dayjs object, as it only could handle Date object and the plain objectSupport object.