### PR TITLE
Update and rename vi.js to vi_VN.js

### DIFF
--- a/src/locale/vi_VN.js
+++ b/src/locale/vi_VN.js
@@ -2,12 +2,12 @@
 import dayjs from 'dayjs'
 
 const locale = {
-  name: 'vi',
-  weekdays: 'chủ nhật_thứ hai_thứ ba_thứ tư_thứ năm_thứ sáu_thứ bảy'.split('_'),
+  name: 'vi_VN',
+  weekdays: 'Chủ Nhật_thứ Hai_thứ Ba_thứ Tư_thứ Năm_thứ Sáu_thứ Bảy'.split('_'),
   months: 'tháng 1_tháng 2_tháng 3_tháng 4_tháng 5_tháng 6_tháng 7_tháng 8_tháng 9_tháng 10_tháng 11_tháng 12'.split('_'),
   weekStart: 1,
   weekdaysShort: 'CN_T2_T3_T4_T5_T6_T7'.split('_'),
-  monthsShort: 'Th01_Th02_Th03_Th04_Th05_Th06_Th07_Th08_Th09_Th10_Th11_Th12'.split('_'),
+  monthsShort: 'thg 1_thg 2_thg 3_thg 4_thg 5_thg 6_thg 7_thg 8_thg 9_thg 10_thg 11_thg 12'.split('_'),
   weekdaysMin: 'CN_T2_T3_T4_T5_T6_T7'.split('_'),
   ordinal: n => n,
   formats: {


### PR DESCRIPTION
- Rename file due to change of locale code `vi` to `vi_VN`
- Update: name of weekdays have to be uppercased according to Vietnamese Law.
- Update: `monthShort` format writing style of `Th01` → `thg 1` (To not be mismatch between "Thứ" and "Tháng")