### PR TITLE
Add ConfigTypeMap entry for objectSupport (#1441)

### DIFF
--- a/types/plugin/objectSupport.d.ts
+++ b/types/plugin/objectSupport.d.ts
@@ -9,4 +9,40 @@ declare module 'dayjs' {
         add(argument: object): Dayjs
         subtract(argument: object): Dayjs
     }
+
+    interface ConfigTypeMap {
+        objectSupport: {
+            years?: number | string;
+            year?: number | string;
+            y?: number | string;
+
+            months?: number | string;
+            month?: number | string;
+            M?: number | string;
+
+            days?: number | string;
+            day?: number | string;
+            d?: number | string;
+
+            dates?: number | string;
+            date?: number | string;
+            D?: number | string;
+
+            hours?: number | string;
+            hour?: number | string;
+            h?: number | string;
+
+            minutes?: number | string;
+            minute?: number | string;
+            m?: number | string;
+
+            seconds?: number | string;
+            second?: number | string;
+            s?: number | string;
+
+            milliseconds?: number | string;
+            millisecond?: number | string;
+            ms?: number | string;
+        }
+    }
 }


### PR DESCRIPTION
Close #1441.

This PR add `ConfigTypeMap` entry for `plugin/objectSupport`.
By this change, The bellow code will be treaded valid.
```typescript
x = dayjs({
  year: 2010,
  month: 1,
  day: 12
});

dayjs.utc({
  year: 2010,
  month: 1,
  day: 12
});
```