### PR TITLE
fix: dayjs未暴露module入口，不支持在工具库中使用rollup打包

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.0.0-development",
   "description": "2KB immutable date time library alternative to Moment.js with the same modern API ",
   "main": "dayjs.min.js",
+  "module": "esm/index.js",
   "types": "index.d.ts",
   "scripts": {
     "test": "TZ=Pacific/Auckland npm run test-tz && TZ=Europe/London npm run test-tz && TZ=America/Whitehorse npm run test-tz && npm run test-tz && jest",


### PR DESCRIPTION
使用方式：
```
import type { OpUnitType, QUnitType, ManipulateType } from "dayjs"
import dayjs from "dayjs";
```

使用 rollup 打包，报错信息如下：
```
[10:49:29] 'buildBundle' errored after 12 s
[10:49:29] Error: 'default' is not exported by node_modules/dayjs/dayjs.min.js, imported by packages/utils/src/date-utils.ts
```

dayjs 是支持 esm 的，
![image](https://user-images.githubusercontent.com/30487257/180914167-8c7fc8b6-2af6-4184-8570-11a47da7afcc.png)

经分析，推测原因是因为 dayjs 的 package.json 中没有指定 module 字段，导致 rollup 默认从 main 入口访问到了 dayjs.min.js。
![image](https://user-images.githubusercontent.com/30487257/180914186-8993b7ba-b145-45a9-b97a-5a7c897fb8d4.png)

而 rollup 是基于 esm 打包的，所以会有一点问题。
我尝试加了一个 module 入口，可以支持 rollup 打包。
![image](https://user-images.githubusercontent.com/30487257/180914202-244bb882-59bf-42cd-93bc-9133f667c03a.png)

建议增加一个module入口，直接指向 esm/index.js。提升 esm 支持的友好度。
