### PR TITLE
fix: wrong ordinal for french locale

### DIFF
--- a/src/locale/fr.js
+++ b/src/locale/fr.js
@@ -34,7 +34,7 @@ const locale = {
     yy: '%d ans'
   },
   ordinal: (n) => {
-    const o = n === 1 ? 'er' : 'e'
+    const o = n === 1 ? 'er' : ''
     return `${n}${o}`
   }
 }


### PR DESCRIPTION
In french, when writing dates, there is no ordinal for numbers over 1.

- lundi 1er août 2022 :heavy_check_mark: 
- jeudi 11 août 2022 :heavy_check_mark: 
- jeudi 11e août 2022 :x: 

In other contexts, this could be correct, but not for dates.
See for instance on this French website of the government : https://www.service-public.fr/particuliers/actualites 