### PR TITLE
Fix parsing localized meridiem always returns am #2031

### DIFF
--- a/src/plugin/customParseFormat/index.js
+++ b/src/plugin/customParseFormat/index.js
@@ -52,7 +52,7 @@ const meridiemMatch = (input, isLowerCase) => {
     for (let i = 1; i <= 24; i += 1) {
       // todo: fix input === meridiem(i, 0, isLowerCase)
       if (input.indexOf(meridiem(i, 0, isLowerCase)) > -1) {
-        isAfternoon = i > 12
+        isAfternoon = i >= 12
         break
       }
     }

--- a/test/locale/ko.test.js
+++ b/test/locale/ko.test.js
@@ -1,0 +1,57 @@
+import MockDate from 'mockdate'
+import moment from 'moment'
+import dayjs from '../../src'
+import relativeTime from '../../src/plugin/relativeTime'
+import '../../src/locale/ko'
+import customParseFormat from '../../src/plugin/customParseFormat'
+
+dayjs.extend(relativeTime)
+dayjs.extend(customParseFormat)
+
+beforeEach(() => {
+  MockDate.set(new Date())
+})
+
+afterEach(() => {
+  MockDate.reset()
+})
+
+it('Korean locale relative time in past and future', () => {
+  const cases = [
+    [1, 'd', '하루 후'],
+    [-1, 'd', '하루 전'],
+    [2, 'd', '2일 후'],
+    [-2, 'd', '2일 전'],
+    [10, 'd', '10일 후'],
+    [-10, 'd', '10일 전'],
+    [6, 'm', '6분 후'],
+    [-6, 'm', '6분 전'],
+    [5, 'h', '5시간 후'],
+    [-5, 'h', '5시간 전'],
+    [3, 'M', '3달 후'],
+    [-3, 'M', '3달 전'],
+    [4, 'y', '4년 후'],
+    [-4, 'y', '4년 전']
+  ]
+  cases.forEach((c) => {
+    expect(dayjs().add(c[0], c[1]).locale('ko').fromNow())
+      .toBe(c[2])
+    expect(dayjs().add(c[0], c[1]).locale('ko').fromNow())
+      .toBe(moment().add(c[0], c[1]).locale('ko').fromNow())
+  })
+  expect(dayjs().add(-10, 'd').locale('ko').fromNow(true))
+    .toBe('10일')
+  expect(dayjs().add(-10, 'd').locale('ko').fromNow(true))
+    .toBe(moment().add(-10, 'd').locale('ko').fromNow(true))
+})
+
+it('Korean customParseFormat', () => {
+  expect(dayjs('2019-01-01').locale('ko').format('YYYY-MM-DD'))
+    .toBe(moment('2019-01-01').locale('ko').format('YYYY-MM-DD'))
+
+  expect(dayjs('오전 1:00', 'a h:mm').locale('ko').format('YYYY-MM-DD'))
+    .toBe(moment('오전 1:00', 'a h:mm').locale('ko').format('YYYY-MM-DD'))
+
+  expect(dayjs('오후 1:00', 'a h:mm', 'ko').format('a h:mm'))
+    .toBe(moment('오후 1:00', 'a h:mm', 'ko').format('a h:mm'))
+})


### PR DESCRIPTION
## Changes
- Fix customParseFormat.meridemMatch function to properly parse localized meridiem
- Add test cases in korean locale

## Describe the bug
Parsing localized time string including meridiem with format 'a hh:mm' ignores meridiem.

In Korean, "am" is "오전" and "pm" is "오후". There is no uppercase/lowercase in Korean.

However, dayjs `customParseFormat` doesn't recognize the meridiem and only returns hours in am.

## Describe fixes
I found that the `customParseFormat.meridemMatch` function iterates from 1 to 24 and check if there is a match. 

However, it sets the `isAfternoon` variable by comparing if the `i` is **greater than 12** which should be **greater than or equal to 12**.


## Expected behavior
```javascript
import dayjs from 'dayjs';
import 'dayjs/locale/ko.js';

import customParseFormat from 'dayjs/plugin/customParseFormat.js';
dayjs.extend(customParseFormat);

const amStr = '오전 10:00';
const pmStr = '오후 10:00';
const format = 'a h:mm';

const am = dayjs(amStr, format);
console.assert(am.hour() === 10, 'am.hour() === 10');
const pm = dayjs(pmStr, format);
console.assert(pm.hour() === 22, 'pm.hour() === 22');
```
```bash
$ node index.js
Assertion failed: pm.hour() === 22
```

The second assert should be passed, but it fails because it returns the hour as 10.

I have added a test case of it which was failing before applying the changes of this PR.
```javascript
it('Korean customParseFormat', () => {
  expect(dayjs('2019-01-01').locale('ko').format('YYYY-MM-DD'))
    .toBe(moment('2019-01-01').locale('ko').format('YYYY-MM-DD'))

  expect(dayjs('오전 1:00', 'a h:mm').locale('ko').format('YYYY-MM-DD'))
    .toBe(moment('오전 1:00', 'a h:mm').locale('ko').format('YYYY-MM-DD'))

  expect(dayjs('오후 1:00', 'a h:mm', 'ko').format('a h:mm'))
    .toBe(moment('오후 1:00', 'a h:mm', 'ko').format('a h:mm'))
})
```