### PR TITLE
Fixed Kurdish relative time conversion issue

### DIFF
--- a/src/locale/ku.js
+++ b/src/locale/ku.js
@@ -71,8 +71,8 @@ const locale = {
   },
   meridiem: hour => (hour < 12 ? 'پ.ن' : 'د.ن'),
   relativeTime: {
-    future: 'لە %s',
-    past: 'لەمەوپێش %s',
+    future: '%s لە',
+    past: '%s لەمەوپێش',
     s: 'چەند چرکەیەک',
     m: 'یەک خولەک',
     mm: '%d خولەک',


### PR DESCRIPTION
When using the relative time plugin and transfer a time and use the `ku`(kurdish) locale the translated time to text should look like this

Expected Result
`٢ خولەک لەمەوپێش`

Result
`لەمەوپێش ٢ خولەک`

the issue was just a variable misplacement.