### PR TITLE
Fix: fix timezone plugin cotr type declaration problem, allowed parameter is empty。

### DIFF
--- a/types/plugin/timezone.d.ts
+++ b/types/plugin/timezone.d.ts
@@ -10,8 +10,8 @@ declare module 'dayjs' {
   }
 
   interface DayjsTimezone {
-    (date: ConfigType, timezone?: string): Dayjs
-    (date: ConfigType, format: string, timezone?: string): Dayjs
+    (date?: ConfigType, timezone?: string): Dayjs
+    (date?: ConfigType, format?: string, timezone?: string): Dayjs
     guess(): string
     setDefault(timezone?: string): void
   }


### PR DESCRIPTION
### Problem description
---
Typescript type check failed, prompting `dayjs.tz()` method parameter cannot be empty!

>  S2554: Expected 1-3 arguments, but got 0.

``` ts
// dayjs.js
dayjs.extend(utc);
dayjs.extend(timezone);

dayjs.tz.setDefault(dayjs.tz.guess());

export default dayjs.tz;
```
```ts
import dayjs from './dayjs';
dayjs(); // S2554: Expected 1-3 arguments, but got 0.
```
### Expected Result

Because `dayjs.tz()` method calls dayjs internally, so its parameter type definition should be consistent.

```ts
declare function dayjs (date?: dayjs.ConfigType): dayjs.Dayjs

declare function dayjs (date?: dayjs.ConfigType, format?: dayjs.OptionType, strict?: boolean): dayjs.Dayjs

declare function dayjs (date?: dayjs.ConfigType, format?: dayjs.OptionType, locale?: string, strict?: boolean): dayjs.Dayjs
```