### PR TITLE
Fix ar iq numbers

### DIFF
--- a/src/locale/ar-iq.js
+++ b/src/locale/ar-iq.js
@@ -1,6 +1,33 @@
 //  Arabic (Iraq) [ar-iq]
 import dayjs from 'dayjs'
 
+export const englishToArabicNumbersMap = {
+  1: '١',
+  2: '٢',
+  3: '٣',
+  4: '٤',
+  5: '٥',
+  6: '٦',
+  7: '٧',
+  8: '٨',
+  9: '٩',
+  0: '٠'
+}
+
+const arabicToEnglishNumbersMap = {
+  '١': '1',
+  '٢': '2',
+  '٣': '3',
+  '٤': '4',
+  '٥': '5',
+  '٦': '6',
+  '٧': '7',
+  '٨': '8',
+  '٩': '9',
+  '٠': '0'
+}
+
+
 const locale = {
   name: 'ar-iq',
   weekdays: 'الأحد_الإثنين_الثلاثاء_الأربعاء_الخميس_الجمعة_السبت'.split('_'),
@@ -9,6 +36,16 @@ const locale = {
   weekdaysShort: 'أحد_إثنين_ثلاثاء_أربعاء_خميس_جمعة_سبت'.split('_'),
   monthsShort: 'كانون الثاني_شباط_آذار_نيسان_أيار_حزيران_تموز_آب_أيلول_تشرين الأول_ تشرين الثاني_كانون الأول'.split('_'),
   weekdaysMin: 'ح_ن_ث_ر_خ_ج_س'.split('_'),
+  preparse(string) {
+    return string
+      .replace(/[١٢٣٤٥٦٧٨٩٠]/g, match => arabicToEnglishNumbersMap[match])
+      .replace(/،/g, ',')
+  },
+  postformat(string) {
+    return string
+      .replace(/\d/g, match => englishToArabicNumbersMap[match])
+      .replace(/,/g, '،')
+  },
   ordinal: n => n,
   formats: {
     LT: 'HH:mm',

--- a/test/locale/ar-iq.test.js
+++ b/test/locale/ar-iq.test.js
@@ -1,3 +1,4 @@
+import moment from 'moment'
 import MockDate from 'mockdate'
 import dayjs from '../../src'
 import relativeTime from '../../src/plugin/relativeTime'
@@ -20,4 +21,14 @@ it('Meridiem', () => {
   expect(dayjs('2020-01-01 11:00:00').locale('ar-iq').format('A')).toEqual('ص')
   expect(dayjs('2020-01-01 16:00:00').locale('ar-iq').format('A')).toEqual('م')
   expect(dayjs('2020-01-01 20:00:00').locale('ar-iq').format('A')).toEqual('م')
+})
+
+it('Preparse with locale function', () => {
+  for (let i = 0; i <= 7; i += 1) {
+    dayjs.locale(locale)
+    const momentArIq = moment()
+      .locale('ar-iq')
+      .add(i, 'day')
+    expect(dayjs(momentArIq.format()).format()).toEqual(momentArIq.format())
+  }
 })

--- a/test/locale/ar-iq.test.js
+++ b/test/locale/ar-iq.test.js
@@ -1,11 +1,11 @@
-import moment from 'moment'
 import MockDate from 'mockdate'
 import dayjs from '../../src'
 import relativeTime from '../../src/plugin/relativeTime'
-import '../../src/locale/ru'
 import locale from '../../src/locale/ar-iq'
+import preParsePostFormat from '../../src/plugin/preParsePostFormat'
 
 dayjs.extend(relativeTime)
+dayjs.extend(preParsePostFormat)
 
 beforeEach(() => {
   MockDate.set(new Date())
@@ -26,9 +26,6 @@ it('Meridiem', () => {
 it('Preparse with locale function', () => {
   for (let i = 0; i <= 7; i += 1) {
     dayjs.locale(locale)
-    const momentArIq = moment()
-      .locale('ar-iq')
-      .add(i, 'day')
-    expect(dayjs(momentArIq.format()).format()).toEqual(momentArIq.format())
+    expect(dayjs(1500000000000).format('DD/MM/YYYY, hh:mm')).toEqual('١٤/٠٧/٢٠١٧، ٠٥:٤٠')
   }
 })


### PR DESCRIPTION
Adds correct formatting when [`preparse-postformat`](https://day.js.org/docs/en/plugin/preparse-postformat) Plugin have been used to extend the instance in `ar-iq` locale.