### PR TITLE
[Plugin]: `formatIf`: like format(), but also works for invalid dates.

### DIFF
--- a/src/plugin/formatIf/index.js
+++ b/src/plugin/formatIf/index.js
@@ -1,0 +1,27 @@
+/**
+ * Enhanced dayjs().format() function: Only formats if the instance is valid,
+ * returning a default if not.
+ *
+ * Signature:
+ *
+ * `dayjs().formatIf(formatStr, invalidResponse)`
+ *
+ * - formatStr is the format string taken by `format()`
+ * - invalidResponse is returned in case dayjs().isValid() returns false
+ *
+ * Example:
+ *
+ * <code>
+ * import formatIf from 'dayjs/plugin/formatIf';
+ * dayjs.extend(formatIf);
+ *
+ * // .....
+ * dayjs('2022-03-29').formatIf('DD.MM.YYYY', '-'); // returns "-"
+ * dayjs('2022-03-28').formatIf('DD.MM.YYYY', '-'); // returns "28.03.2022"
+ * </code>
+ */
+export default (option, dayjsClass) => {
+  dayjsClass.prototype.formatIf = function (formatStr, invalidResponse = '') {
+    return this.isValid() ? this.format(formatStr) : invalidResponse
+  }
+}

--- a/test/plugin/formatIf.test.js
+++ b/test/plugin/formatIf.test.js
@@ -1,0 +1,45 @@
+import MockDate from 'mockdate'
+import dayjs from '../../src/index'
+import formatIf from '../../src/plugin/formatIf'
+
+dayjs.extend(formatIf)
+
+const goodDate = '2022-11-25'
+const badDate = 'non-parseable date'
+const format = 'DD.MM.YYYY'
+const goodOutput = '25.11.2022'
+const badOutput = 'invalid'
+const badOutputNr = 42
+
+beforeEach(() => {
+  MockDate.set(goodDate)
+})
+
+afterEach(() => {
+  MockDate.reset()
+})
+
+it('formatIf present on instance', () => {
+  expect(dayjs().formatIf).toBeInstanceOf(Function)
+})
+
+it('returns the formatted date when isValid()', () => {
+  expect(dayjs(new Date()).formatIf(format)).toEqual(goodOutput)
+})
+
+it('returns the formatted date when isValid(), ignoring the invalid response', () => {
+  expect(dayjs(new Date()).formatIf(format)).toEqual(goodOutput)
+})
+
+it('returns the default invalid response', () => {
+  const ret = dayjs(badDate).formatIf(format) === ''
+  expect(ret).toBeTruthy()
+})
+
+it('returns a specific invalid response', () => {
+  let ret = dayjs(badDate).formatIf(format, badOutput) === badOutput
+  expect(ret).toBeTruthy()
+
+  ret = dayjs(badDate).formatIf(format, badOutputNr) === badOutputNr
+  expect(ret).toBeTruthy()
+})

--- a/types/plugin/formatIf.d.ts
+++ b/types/plugin/formatIf.d.ts
@@ -1,0 +1,10 @@
+import { PluginFunc } from 'dayjs'
+
+declare const plugin: PluginFunc
+export = plugin
+
+declare module 'dayjs' {
+  interface Dayjs {
+    formatIf(formatStr: string, invalidResponse?: any): any
+  }
+}


### PR DESCRIPTION
I created a small plugin, `formatIf`, to enhance the original `format()`'s behaviour for invalid dates: `formatIf()` returns the formatted date (wrapper around `format()`) if the dayjs object is valid. If not, a default / configurable response is returned.

The intention is to have a more handy `dayjs().format()` function, which also works for invalid dates.
This is especially useful in contexts where you want to display a date in the frontend, and want a sensible
output if the date is null/invalid.

Example:

Instead of writing:

```js
let someDate = dayjs(someDateStr);
let output = someDate.isValid() ? someDate.format('DD.MM.YYYY') : '-';
```

you can now use the easier `formatIf()` function:

```js
let output = dayjs(someDateStr).formatIf('DD.MM.YYYY', '-');
```

Please consider adding this plugin to the official plugins list. If you have any questions / caveats, please contact me.