### PR TITLE
feat: add parse zone plugin

### DIFF
--- a/src/plugin/parseZone/index.js
+++ b/src/plugin/parseZone/index.js
@@ -1,0 +1,69 @@
+const REGEX_TIMEZONE_OFFSET_FORMAT = /^(.*)([+-])(\d{2}):(\d{2})|(Z)$/
+
+const parseOffset = dateString => dateString.match(REGEX_TIMEZONE_OFFSET_FORMAT)
+
+const formatOffset = (parsedOffset) => {
+  const [, , sign, tzHour, tzMinute] = parsedOffset
+  const uOffset = (parseInt(tzHour, 10) * 60) + parseInt(tzMinute, 10)
+  return sign === '+' ? uOffset : -uOffset
+}
+
+/**
+ * @authors thanks to all the people who contributed to the below issue <3
+ * @see https://github.com/iamkun/dayjs/issues/651#issuecomment-763033265
+ * decorates dayjs in order to keep the utcOffset of the given date string
+ * natively dayjs auto-converts to local time & losing utcOffset info.
+ *
+ * This plugins depends on the UTC plugin. To support the custom format option,
+ * you will need the CustomParseFormat plugin too.
+ */
+const pluginFunc = (
+  option,
+  dayjsClass,
+  dayjsFactory
+) => {
+  dayjsFactory.parseZone = function (
+    date,
+    format,
+    locale,
+    strict
+  ) {
+    if (typeof format === 'string') {
+      format = { format }
+    }
+    if (typeof date !== 'string') {
+      return dayjsFactory(date, format, locale, strict)
+    }
+    const match = parseOffset(date)
+    if (match === null) {
+      return dayjsFactory(date, {
+        $offset: 0
+      })
+    }
+    if (match[0] === 'Z') {
+      return dayjsFactory(
+        date,
+        {
+          utc: true,
+          ...format
+        },
+        locale,
+        strict
+      )
+    }
+    const [, dateTime] = match
+    const offset = formatOffset(match)
+
+    return dayjsFactory(
+      dateTime,
+      {
+        $offset: offset,
+        ...format
+      },
+      locale,
+      strict
+    )
+  }
+}
+
+export default pluginFunc

--- a/test/plugin/parseZone.test.js
+++ b/test/plugin/parseZone.test.js
@@ -1,0 +1,63 @@
+import MockDate from 'mockdate'
+import moment from 'moment'
+import dayjs from '../../src'
+import utc from '../../src/plugin/utc'
+import customParseFormat from '../../src/plugin/customParseFormat'
+import parseZone from '../../src/plugin/parseZone'
+
+dayjs.extend(utc)
+dayjs.extend(customParseFormat)
+dayjs.extend(parseZone)
+
+// based on https://github.com/moment/moment/blob/e96809208c9d1b1bbe22d605e76985770024de42/src/test/moment/zones.js
+
+beforeEach(() => {
+  MockDate.set(new Date())
+})
+
+afterEach(() => {
+  MockDate.reset()
+})
+describe('parse zone', () => {
+  it('produces same result as moment parse zone', () => {
+    const m = moment.parseZone('2013-01-01T00:00:00-13:00')
+    const d = dayjs.parseZone('2013-01-01T00:00:00-13:00')
+    expect(d.format('YYYY-MM-DD HH:mm:ss')).toEqual(m.format('YYYY-MM-DD HH:mm:ss'))
+  })
+
+  it('holds the original offset instead of converting to local', () => {
+    const dParseZone = dayjs.parseZone('2013-01-01T00:00:00-13:00')
+    const dWithoutParseZone = dayjs('2013-01-01T00:00:00-13:00')
+
+    expect(dParseZone.format('Z')).toEqual('-13:00')
+    expect(dWithoutParseZone.format('Z')).toEqual('+00:00')
+  })
+
+  it('handles positive and negative timezone', () => {
+    const dNegative = dayjs.parseZone('2013-01-01T00:00:00-13:00')
+    const dPositive = dayjs.parseZone('2013-01-01T00:00:00+13:00')
+
+    expect(dPositive.format('YYYY-MM-DD HH:mm:ss Z')).toEqual('2013-01-01 00:00:00 +13:00')
+    expect(dNegative.format('YYYY-MM-DD HH:mm:ss Z')).toEqual('2013-01-01 00:00:00 -13:00')
+  })
+
+  it('works with custom format plugin', () => {
+    const d = dayjs.parseZone('2013 01 01 00:00:00 -13:00', 'YYYY MM DD HH:mm:ss')
+    expect(d.format('YYYY-MM-DD HH:mm:ss')).toEqual('2013-01-01 00:00:00')
+  })
+
+  it('uses default constructor when no date string is provided', () => {
+    const d = dayjs.parseZone(new Date(2013, 0, 1, 0, 0, 0))
+    expect(d.format('YYYY-MM-DD HH:mm:ss')).toEqual('2013-01-01 00:00:00')
+  })
+
+  it('keeps the time and change the zone to 0 when no timezone is provided', () => {
+    const d = dayjs.parseZone('2013-01-01T00:00:00')
+    expect(d.format('YYYY-MM-DD HH:mm:ss')).toEqual('2013-01-01 00:00:00')
+  })
+
+  it('handles UTC format', () => {
+    const d = dayjs.parseZone('2013-01-01T00:00:00Z')
+    expect(d.format('YYYY-MM-DD HH:mm:ss')).toEqual(dayjs.utc('2013-01-01T00:00:00').format('YYYY-MM-DD HH:mm:ss'))
+  })
+})

--- a/types/plugin/parseZone.d.ts
+++ b/types/plugin/parseZone.d.ts
@@ -1,0 +1,12 @@
+import { ConfigType, PluginFunc } from 'dayjs'
+/**
+ * @see https://github.com/iamkun/dayjs/issues/651#issuecomment-763033265
+ * decorates dayjs in order to keep the utcOffset of the given date string
+ * natively dayjs auto-converts to local time & losing utcOffset info.
+ */
+declare const pluginFunc: PluginFunc<unknown>
+export default pluginFunc
+
+declare module 'dayjs' {
+  export function parseZone(date?: ConfigType, format?: string, locale?: string, strict?: boolean): Dayjs
+}


### PR DESCRIPTION
Closes https://github.com/iamkun/dayjs/issues/651

I'm opening this PR based on the discussion in the linked issue above.
This is something that affects many people as timezone is a complicated topic.

Example scenarios are:
- use the date timezone in format, rather than converting to the local one
- do calculations in the provided format, rather than converting to the local one
- display date and times with the original location in travel websites, rather than the user location (it confuses customers)


Example usage:

```js
import dayjs from "dayjs";
import parseZone from "dayjs/plugins/parseZone";

dayjs.extend(parseZone);

const parsedDate = dayjs.parseZone("2016-12-21T07:01:21-08:00");

expect(parsedDate.format("MMMM D, YYYY, h:mm A")).toBe("December 21, 2016, 7:01 AM");
```