### PR TITLE
refactor: move declaration for english 'ordinal' to 'en' locale file

### DIFF
--- a/src/locale/en.js
+++ b/src/locale/en.js
@@ -3,5 +3,10 @@
 export default {
   name: 'en',
   weekdays: 'Sunday_Monday_Tuesday_Wednesday_Thursday_Friday_Saturday'.split('_'),
-  months: 'January_February_March_April_May_June_July_August_September_October_November_December'.split('_')
+  months: 'January_February_March_April_May_June_July_August_September_October_November_December'.split('_'),
+  ordinal: (n) => {
+    const s = ['th', 'st', 'nd', 'rd']
+    const v = n % 100
+    return `[${n}${(s[(v - 20) % 10] || s[v] || s[0])}]`
+  }
 }

--- a/src/plugin/advancedFormat/index.js
+++ b/src/plugin/advancedFormat/index.js
@@ -1,6 +1,6 @@
 import { FORMAT_DEFAULT } from '../../constant'
 
-export default (o, c, d) => { // locale needed later
+export default (o, c) => { // locale needed later
   const proto = c.prototype
   const oldFormat = proto.format
   proto.format = function (formatStr) {

--- a/src/plugin/advancedFormat/index.js
+++ b/src/plugin/advancedFormat/index.js
@@ -3,12 +3,6 @@ import { FORMAT_DEFAULT } from '../../constant'
 export default (o, c, d) => { // locale needed later
   const proto = c.prototype
   const oldFormat = proto.format
-  d.en.ordinal = (number) => {
-    const s = ['th', 'st', 'nd', 'rd']
-    const v = number % 100
-    return `[${number}${(s[(v - 20) % 10] || s[v] || s[0])}]`
-  }
-  // extend en locale here
   proto.format = function (formatStr) {
     const locale = this.$locale()
 


### PR DESCRIPTION
All locale files have a definition for 'ordinal' except the 'en' one. For this locale the definition of 'ordinal' is part of the 'AdvancedFormat' plugin. This is inconsistent not quite logical.

This pr solves this topic and should solve issue #1891 