### PR TITLE
Fix issue #1980 - Validation fails for valid input with textual months followed by period (MMM. and MMMM.) 

### DIFF
--- a/src/plugin/customParseFormat/index.js
+++ b/src/plugin/customParseFormat/index.js
@@ -9,7 +9,7 @@ const match4 = /\d{4}/ // 0000 - 9999
 const match1to2 = /\d\d?/ // 0 - 99
 const matchSigned = /[+-]?\d+/ // -inf - inf
 const matchOffset = /[+-]\d\d:?(\d\d)?|Z/ // +00:00 -00:00 +0000 or -0000 +00 or Z
-const matchWord = /\d*[^-_:/,()\s\d]+/ // Word
+const matchWord = /\d*[^-_:/.,()\s\d]+/ // Word
 
 let locale = {}
 
@@ -99,7 +99,10 @@ const expressions = {
   MM: [match2, addInput('month')],
   MMM: [matchWord, function (input) {
     const months = getLocalePart('months')
-    const monthsShort = getLocalePart('monthsShort')
+    let monthsShort = getLocalePart('monthsShort')
+    if (monthsShort) {
+      monthsShort = [...monthsShort].map(item => item.replace(/\.$/, ''))
+    }
     const matchIndex = (monthsShort || months.map(_ => _.slice(0, 3))).indexOf(input) + 1
     if (matchIndex < 1) {
       throw new Error()

--- a/test/plugin/customParseFormat.test.js
+++ b/test/plugin/customParseFormat.test.js
@@ -425,6 +425,37 @@ describe('parse with special separator characters', () => {
   })
 })
 
+describe('parse with dot separator characters', () => {
+  it('parse dot separated date', () => {
+    const input = '25.Sep.2022'
+    const format = 'DD.MMM.YYYY'
+    const resultDayjs = dayjs(input, format)
+    const resultMoment = moment(input, format)
+    expect(resultMoment.isValid()).toBe(true)
+    expect(resultDayjs.isValid()).toBe(true)
+    expect(dayjs(input, format).valueOf()).toBe(moment(input, format).valueOf())
+  })
+  it('parse dot separated date in strict mode', () => {
+    const input = '25.Sep.2022'
+    const format = 'DD.MMM.YYYY'
+    const resultDayjs = dayjs(input, format, true)
+    const resultMoment = moment(input, format, true)
+    expect(resultMoment.isValid()).toBe(true)
+    expect(resultDayjs.isValid()).toBe(true)
+    expect(dayjs(input, format, true).valueOf()).toBe(moment(input, format, true).valueOf())
+  })
+  it('only the MMM separated with dot', () => {
+    const input = '25 Sep. 2022'
+    const format = 'DD MMM. YYYY'
+    const locale = 'en'
+    const resultDayjs = dayjs(input, format, locale)
+    const resultMoment = moment(input, format, locale)
+    expect(resultMoment.isValid()).toBe(true)
+    expect(resultDayjs.isValid()).toBe(true)
+    expect(dayjs(input, format, true).valueOf()).toBe(moment(input, format, true).valueOf())
+  })
+})
+
 it('parse X x', () => {
   const input = '1410715640.579'
   const format = 'X'


### PR DESCRIPTION
This pr solves the issue [#1980 ](https://github.com/iamkun/dayjs/issues/1980)
Also, dot is a common word separator used in dates with short or long month names ,for example, dayjs('22.Sep.2022','DD.MMM.YYYY').isValid() is returned false ; so it should be part of the characters, recognized as word separators.