### PR TITLE
Add plugin workDays

### DIFF
--- a/src/plugin/workDays/index.js
+++ b/src/plugin/workDays/index.js
@@ -1,0 +1,28 @@
+export default (option, dayjsClass, dayjs) => {
+    const format = date => date.format("YYYY-MM-DD")
+    dayjsClass.prototype.workDays = function (end = new Date(), weekends = [0, 6], vacations = [], overtimes = []) {
+        const startDate = dayjs(this).startOf("date"),
+            endDate = dayjs(end).startOf("date"),
+            weekendDays = weekends.map(num => +num),
+            vacationsDates = vacations.map(fdate => format(dayjs(fdate))),
+            overtimesDates = overtimes.map(fdate => format(dayjs(fdate))),
+            dayDiff = endDate.diff(startDate, 'day'),
+            direction = dayDiff >= 0 ? 1 : -1,
+            result = [],
+            isExclude = date => {
+                if (overtimesDates.includes(format(date))) {
+                    return false
+                } else {
+                    return weekendDays.includes(date.day()) || vacationsDates.includes(format(date))
+                }
+            }
+        let current = startDate
+        for (let count = 0; direction >= 0 ? count <= dayDiff : count >= dayDiff; count += direction) {
+            current = startDate.add(count, 'day')
+            if (!isExclude(current)) {
+                result.push(format(current))
+            }
+        }
+        return result
+    }
+}

--- a/test/plugin/workDays.test.js
+++ b/test/plugin/workDays.test.js
@@ -1,0 +1,35 @@
+
+import dayjs from '../../src'
+import MockDate from 'mockdate'
+import workDays from '../../src/plugin/workDays'
+
+dayjs.extend(workDays)
+beforeEach(() => {
+    MockDate.set(new Date())
+})
+afterEach(() => {
+    MockDate.reset()
+})
+describe("weekEnd",()=>{
+    it('Full weekEnd',()=>{
+        const dates=dayjs("2022/10/24").workDays("2022/10/30")
+        expect(dates)
+    })
+    it('Incomplete weekEnd',()=>{
+        const dates=dayjs("2022/10/24").workDays("2022/10/30",[0])
+        expect(dates)
+    })
+    it('reverse',()=>{
+        const dates=dayjs("2022/10/30").workDays("2022/10/24")
+        expect(dates)
+    })
+    it('vacations',()=>{
+        const dates=dayjs("2022/10/01").workDays("2022/10/12",[0,6],["2022/10/01","2022/10/02","2022/10/03","2022/10/04","2022/10/05","2022/10/06","2022/10/07"])
+        expect(dates)
+    })
+    it('overtime',()=>{
+        const dates=dayjs("2022/10/01").workDays("2022/10/12",[0,6],["2022/10/01","2022/10/02","2022/10/03","2022/10/04","2022/10/05","2022/10/06","2022/10/07"],["2022/10/08","2022/10/09"])
+        expect(dates)
+    })
+})
+

--- a/types/plugin/workDays.d.ts
+++ b/types/plugin/workDays.d.ts
@@ -1,0 +1,8 @@
+import { PluginFunc } from 'dayjs'
+declare const plugin: PluginFunc
+export = plugin
+declare module 'dayjs' {
+  interface Dayjs {
+    workDays(end:Date|Dayjs,weekends?:number[]|string[],vacations?:Dayjs[]|string[]|Date[],overtimes?:Dayjs[]|string[]|Date[]): string[]
+  }
+}


### PR DESCRIPTION
用于计算工作日的插件：

第一个参数是结束日期。将退还从开始日期到结束日期的所有工作日（不包括周六和周日）

第二个参数：休息日。默认值为[0,6]，即使是周六和周日（我希望您不要使用此参数）

第三个参数：假日日期。传入日期数组，以便日期不会出现在工作日结果中

第四个参数：加班日期。传入日期数组。这一天将被迫出现在工作日结果中（更不用说这个参数了）


A plug-in for calculating workdays:

The first parameter is the end date. All working days from the start date to the end date will be returned (excluding Saturday and Sunday)

Second parameter: rest day. The default value is [0,6] even if it is Saturday and Sunday (I hope you will not use this parameter)

The third parameter: holiday date. Pass in the date array, so that the date will not appear in the workday results

The fourth parameter: overtime date. The date array is passed in. This day will be forced to appear in the workday results (let alone this parameter)

```javascript
dayjs("2022/10/01").workDays("2022/10/10")
// [
//     '2022-10-03',
//     '2022-10-04',
//     '2022-10-05',
//     '2022-10-06',
//     '2022-10-07',
//     '2022-10-10'
// ]

dayjs("2022/10/01").workDays("2022/10/10",[0])
// [
//     '2022-10-01',
//     '2022-10-03',
//     '2022-10-04',
//     '2022-10-05',
//     '2022-10-06',
//     '2022-10-07',
//     '2022-10-08',
//     '2022-10-10'
// ]

dayjs("2022/10/01").workDays("2022/10/10",[0,6],["2022/10/01","2022/10/02","2022/10/03"])
// [
//     '2022-10-04',
//     '2022-10-05',
//     '2022-10-06',
//     '2022-10-07',
//     '2022-10-10'
// ]

dayjs("2022/10/01").workDays("2022/10/10",[0,6],["2022/10/01","2022/10/02","2022/10/03"],["2022/10/08","2022/10/09"])
// [
//     '2022-10-04',
//     '2022-10-05',
//     '2022-10-06',
//     '2022-10-07',
//     '2022-10-08',
//     '2022-10-09',
//     '2022-10-10'
//   ]

```
