### PR TITLE
Fix: copy locale from original object to new dayjs object

### DIFF
--- a/src/plugin/timezone/index.js
+++ b/src/plugin/timezone/index.js
@@ -98,7 +98,7 @@ export default (o, c, d) => {
     const target = date.toLocaleString('en-US', { timeZone: timezone })
     const diff = Math.round((date - new Date(target)) / 1000 / 60)
     let ins = d(target).$set(MS, this.$ms)
-      .utcOffset((-Math.round(date.getTimezoneOffset() / 15) * 15) - diff, true)
+      .utcOffset((-Math.round(date.getTimezoneOffset() / 15) * 15) - diff, true).locale(this.$L)
     if (keepLocalTime) {
       const newOffset = ins.utcOffset()
       ins = ins.add(oldOffset - newOffset, MIN)

--- a/test/plugin/timezone.test.js
+++ b/test/plugin/timezone.test.js
@@ -4,6 +4,7 @@ import dayjs from '../../src'
 import timezone from '../../src/plugin/timezone'
 import customParseFormat from '../../src/plugin/customParseFormat'
 import utc from '../../src/plugin/utc'
+import zh from '../../src/locale/zh'
 
 dayjs.extend(utc)
 dayjs.extend(timezone)
@@ -296,7 +297,7 @@ describe('Get offsetName', () => {
   })
 })
 
-describe('CustomPraseFormat', () => {
+describe('CustomParseFormat', () => {
   const result = 1602786600
   it('normal', () => {
     expect(dayjs.tz('2020/10/15 12:30', DEN).unix()).toBe(result)
@@ -317,5 +318,13 @@ describe('startOf and endOf', () => {
     const originalDay = dayjs.tz('2009-12-31 23:59:59.999', NY)
     const endOfDay = originalDay.endOf('day')
     expect(endOfDay.valueOf()).toEqual(originalDay.valueOf())
+  })
+})
+
+describe('keep locale', () => {
+  it('should copy locale from the original dayjs object', () => {
+    const dayjsWithLocale = dayjs('2022-11-07', { locale: zh }).tz(TOKYO)
+    expect(dayjsWithLocale.locale()).toEqual('zh')
+    expect(dayjsWithLocale.format('MMM')).toEqual('11月')
   })
 })


### PR DESCRIPTION
const today = dayjs('2022-11-07', { locale: zh }).tz('Asia/Tokyo');

The locale of today  is 'en'  instead of 'zh'.

[Example of code sandbox](https://codesandbox.io/s/dayjs-timezone-problem-wuwvsb?file=/src/index.js)