### PR TITLE
fix: en-gb locale time format

### DIFF
--- a/src/locale/en-gb.js
+++ b/src/locale/en-gb.js
@@ -26,12 +26,12 @@ const locale = {
     yy: '%d years'
   },
   formats: {
-    LT: 'HH:mm',
-    LTS: 'HH:mm:ss',
+    LT: 'h:mm A',
+    LTS: 'h:mm:ss A',
     L: 'DD/MM/YYYY',
     LL: 'D MMMM YYYY',
-    LLL: 'D MMMM YYYY HH:mm',
-    LLLL: 'dddd, D MMMM YYYY HH:mm'
+    LLL: 'D MMMM YYYY h:mm A',
+    LLLL: 'dddd, D MMMM YYYY h:mm A'
   },
   ordinal: (n) => {
     const s = ['th', 'st', 'nd', 'rd']


### PR DESCRIPTION
I have created this pr to fix the current en-gb formats as dont match what is specified on the locale formate [docs](https://day.js.org/docs/en/display/format#localized-formats)
