### PR TITLE
fix: for `uz` locale make latin alphabet default, if you need cyrillic alphabet use `uz-cyrl`

### DIFF
--- a/src/locale/uz-cyrl.js
+++ b/src/locale/uz-cyrl.js
@@ -1,0 +1,40 @@
+// Uzbek [uz]
+import dayjs from 'dayjs'
+
+const locale = {
+  name: 'uz-cyrl',
+  weekdays: 'Якшанба_Душанба_Сешанба_Чоршанба_Пайшанба_Жума_Шанба'.split('_'),
+  months: 'январ_феврал_март_апрел_май_июн_июл_август_сентябр_октябр_ноябр_декабр'.split('_'),
+  weekStart: 1,
+  weekdaysShort: 'Якш_Душ_Сеш_Чор_Пай_Жум_Шан'.split('_'),
+  monthsShort: 'янв_фев_мар_апр_май_июн_июл_авг_сен_окт_ноя_дек'.split('_'),
+  weekdaysMin: 'Як_Ду_Се_Чо_Па_Жу_Ша'.split('_'),
+  ordinal: n => n,
+  formats: {
+    LT: 'HH:mm',
+    LTS: 'HH:mm:ss',
+    L: 'DD/MM/YYYY',
+    LL: 'D MMMM YYYY',
+    LLL: 'D MMMM YYYY HH:mm',
+    LLLL: 'D MMMM YYYY, dddd HH:mm'
+  },
+  relativeTime: {
+    future: 'Якин %s ичида',
+    past: 'Бир неча %s олдин',
+    s: 'фурсат',
+    m: 'бир дакика',
+    mm: '%d дакика',
+    h: 'бир соат',
+    hh: '%d соат',
+    d: 'бир кун',
+    dd: '%d кун',
+    M: 'бир ой',
+    MM: '%d ой',
+    y: 'бир йил',
+    yy: '%d йил'
+  }
+}
+
+dayjs.locale(locale, null, true)
+
+export default locale

--- a/src/locale/uz.js
+++ b/src/locale/uz.js
@@ -1,14 +1,14 @@
-// Uzbek [uz]
+// Uzbek Latin [uz]
 import dayjs from 'dayjs'
 
 const locale = {
   name: 'uz',
-  weekdays: 'Якшанба_Душанба_Сешанба_Чоршанба_Пайшанба_Жума_Шанба'.split('_'),
-  months: 'январ_феврал_март_апрел_май_июн_июл_август_сентябр_октябр_ноябр_декабр'.split('_'),
+  weekdays: 'Yakshanba_Dushanba_Seshanba_Chorshanba_Payshanba_Juma_Shanba'.split('_'),
+  months: 'Yanvar_Fevral_Mart_Aprel_May_Iyun_Iyul_Avgust_Sentabr_Oktabr_Noyabr_Dekabr'.split('_'),
   weekStart: 1,
-  weekdaysShort: 'Якш_Душ_Сеш_Чор_Пай_Жум_Шан'.split('_'),
-  monthsShort: 'янв_фев_мар_апр_май_июн_июл_авг_сен_окт_ноя_дек'.split('_'),
-  weekdaysMin: 'Як_Ду_Се_Чо_Па_Жу_Ша'.split('_'),
+  weekdaysShort: 'Yak_Dush_Sesh_Chor_Pay_Jum_Shan'.split('_'),
+  monthsShort: 'Yan_Fev_Mar_Apr_May_Iyun_Iyul_Avg_Sen_Okt_Noy_Dek'.split('_'),
+  weekdaysMin: 'Ya_Du_Se_Cho_Pa_Ju_Sha'.split('_'),
   ordinal: n => n,
   formats: {
     LT: 'HH:mm',
@@ -19,23 +19,32 @@ const locale = {
     LLLL: 'D MMMM YYYY, dddd HH:mm'
   },
   relativeTime: {
-    future: 'Якин %s ичида',
-    past: 'Бир неча %s олдин',
-    s: 'фурсат',
-    m: 'бир дакика',
-    mm: '%d дакика',
-    h: 'бир соат',
-    hh: '%d соат',
-    d: 'бир кун',
-    dd: '%d кун',
-    M: 'бир ой',
-    MM: '%d ой',
-    y: 'бир йил',
-    yy: '%d йил'
+    future: 'Yaqin %s ichida',
+    past: 'Bir necha %s oldin',
+    s: 'soniya',
+    m: 'bir daqiqa',
+    mm: '%d daqiqa',
+    h: 'bir soat',
+    hh: '%d soat',
+    d: 'bir kun',
+    dd: '%d kun',
+    M: 'bir oy',
+    MM: '%d oy',
+    y: 'bir yil',
+    yy: '%d yil'
+  },
+  meridiem: (hour) => {
+    if (hour < 4) {
+      return 'ertalab' // ночи
+    } else if (hour < 12) {
+      return 'ertalab' // утра
+    } else if (hour < 17) {
+      return 'soat' // дня
+    }
+    return 'kechki' // вечера
   }
 }
 
 dayjs.locale(locale, null, true)
 
 export default locale
-

--- a/test/locale/uz.test.js
+++ b/test/locale/uz.test.js
@@ -1,0 +1,68 @@
+import moment from 'moment'
+import MockDate from 'mockdate'
+import dayjs from '../../src'
+import relativeTime from '../../src/plugin/relativeTime'
+import '../../src/locale/uz'
+
+dayjs.extend(relativeTime)
+
+beforeEach(() => {
+  MockDate.set(new Date())
+})
+
+afterEach(() => {
+  MockDate.reset()
+})
+
+it('Format Month with locale function', () => {
+  for (let i = 0; i <= 7; i += 1) {
+    const dayjsRU = dayjs()
+      .locale('uz')
+      .add(i, 'day')
+    const momentRU = moment()
+      .locale('uz-latn')
+      .add(i, 'day')
+    const testFormat1 = 'DD MMMM YYYY MMM'
+    const testFormat2 = 'MMMM'
+    const testFormat3 = 'MMM'
+    expect(dayjsRU.format(testFormat1)).toEqual(momentRU.format(testFormat1))
+    expect(dayjsRU.format(testFormat2)).toEqual(momentRU.format(testFormat2))
+    expect(dayjsRU.format(testFormat3)).toEqual(momentRU.format(testFormat3))
+  }
+})
+
+it('RelativeTime: Time from X', () => {
+  const T = [
+    [44.4, 'second'], // a few seconds
+    [89.5, 'second'], // a minute
+    [43, 'minute'], // 44 minutes
+    [21, 'hour'], // 21 hours
+    [25, 'day'], // 25 days
+    [10, 'month'], // 2 month
+    [18, 'month'] // 2 years
+  ]
+
+  T.forEach((t) => {
+    dayjs.locale('uz')
+    moment.locale('uz-latn')
+    expect(dayjs().from(dayjs().add(t[0], t[1])))
+      .toBe(moment().from(moment().add(t[0], t[1])))
+    expect(dayjs().from(dayjs().add(t[0], t[1]), true))
+      .toBe(moment().from(moment().add(t[0], t[1]), true))
+  })
+})
+
+it('Meridiem', () => {
+  expect(dayjs('2020-01-01 03:00:00')
+    .locale('uz')
+    .format('A')).toEqual('ertalab')
+  expect(dayjs('2020-01-01 11:00:00')
+    .locale('uz')
+    .format('A')).toEqual('ertalab')
+  expect(dayjs('2020-01-01 16:00:00')
+    .locale('uz')
+    .format('A')).toEqual('soat')
+  expect(dayjs('2020-01-01 20:00:00')
+    .locale('uz')
+    .format('A')).toEqual('kechki')
+})


### PR DESCRIPTION
As discussed here https://github.com/ant-design/ant-design/pull/39556 the Latin alphabet in Uzbekistan is widely used by modern websites. 

In momentjs `uz` Cyrillic locale was added 7 years ago and nowadays is outdated:

1)  Schools and universities are using Uzbek books in the Latin alphabet.

2) If we take the browser locale or any popular Intl lib e.g. formatjs then they use Latin characters for `uz`:
https://unpkg.com/@formatjs/intl-displaynames@6.2.3/locale-data/uz.js

<img width="586" alt="Screenshot 2022-12-15 at 11 01 36" src="https://user-images.githubusercontent.com/1946920/207831538-83430788-ee2a-476b-8f20-a8304c3075bb.png">
They are using `uz-latn` & `uz-cyrl` for exact situations, and `uz` in Latin for default widespread use cases.

3) Modern websites and applications in Uzbekistan for the Uzbek locale are using the Latin alphabet.


@muminoff please confirm
<img width="1579" alt="Screen Shot 2022-12-20 at 09 22 46" src="https://user-images.githubusercontent.com/1946920/208618340-0daf462b-8d0d-4825-8df6-16595082afa5.png">


PS. This PR follows browser convention
- `uz` – latin alphabet
- `uz-latn` – latin alphabet
- `uz-cyrl` – cyrillic alphabet
