### PR TITLE
build: fix esm build in node runtime and types

### DIFF
--- a/build/esm-wrapper/index.d.ts
+++ b/build/esm-wrapper/index.d.ts
@@ -1,7 +1,15 @@
 /// <reference path="../../types/locale/index.d.ts" />
 
+import {PluginFunc, locale, unix, extend} from '../index'
 import dayjs = require('dayjs');
 
-export default dayjs;
+interface DayjsStatic extends dayjs {
+  locale: typeof locale
+  unix: typeof unix
+  extend: typeof extend
+}
 
-export {PluginFunc} from '../index'
+export default DayjsStatic
+
+export {PluginFunc, locale, unix, extend}
+

--- a/build/esm-wrapper/index.d.ts
+++ b/build/esm-wrapper/index.d.ts
@@ -3,3 +3,5 @@
 import dayjs = require('dayjs');
 
 export default dayjs;
+
+export {PluginFunc} from '../index'

--- a/build/esm-wrapper/index.d.ts
+++ b/build/esm-wrapper/index.d.ts
@@ -11,5 +11,5 @@ interface DayjsStatic extends dayjs {
 
 export default DayjsStatic
 
-export {PluginFunc, locale, unix, extend}
+export {PluginFunc}
 

--- a/build/esm-wrapper/index.d.ts
+++ b/build/esm-wrapper/index.d.ts
@@ -1,0 +1,5 @@
+/// <reference path="../../types/locale/index.d.ts" />
+
+import dayjs = require('dayjs');
+
+export default dayjs;

--- a/build/esm-wrapper/index.d.ts
+++ b/build/esm-wrapper/index.d.ts
@@ -1,4 +1,4 @@
-/// <reference path="../../types/locale/index.d.ts" />
+/// <reference path="../types/locale/index.d.ts" />
 
 import {PluginFunc, locale, unix, extend} from '../index'
 import dayjs = require('dayjs');

--- a/build/esm-wrapper/index.js
+++ b/build/esm-wrapper/index.js
@@ -1,0 +1,4 @@
+// eslint-disable-next-line import/no-unresolved
+import dayjs from './index.mjs'
+
+export default dayjs

--- a/build/esm-wrapper/index.js
+++ b/build/esm-wrapper/index.js
@@ -1,3 +1,11 @@
+/**
+ * You should not import this file,
+ *
+ * this file exists only to keep backward compatibility for bundlers.
+ *
+ * `import dayjs from "dayjs/esm/index.mjs"` instead.
+ */
+
 // eslint-disable-next-line import/no-unresolved
 import dayjs from './index.mjs'
 

--- a/build/esm.js
+++ b/build/esm.js
@@ -33,7 +33,7 @@ async function walk(dir, callback) {
     await Promise.all(readLocaleDir.map(l => async () => {
       const filePath = path.join(localeDir, l)
       const readFile = await fsp.readFile(filePath, 'utf8')
-      const result = readFile.replace('\'dayjs\'', '\'../index\'')
+      const result = readFile.replace("'dayjs'", "'../index'")
       await fsp.writeFile(filePath, result, 'utf8')
     })
       .map(f => f()))
@@ -41,7 +41,7 @@ async function walk(dir, callback) {
     await promisify(ncp)('./types/', './esm')
 
     const readLocaleFile = await fsp.readFile(localeTypePath, 'utf8')
-    const localResult = readLocaleFile.replace('\'dayjs', '\'dayjs/esm')
+    const localResult = readLocaleFile.replace("'dayjs", "'dayjs/esm")
     await fsp.writeFile(localeTypePath, localResult, 'utf8')
 
     const readPluginDir = await fsp.readdir(pluginDir)

--- a/build/esm.js
+++ b/build/esm.js
@@ -1,9 +1,10 @@
-const fsp = require('fs/promises')
+const fs = require('fs/promises')
 const path = require('path')
 const util = require('util')
-const { ncp } = require('ncp')
 
 const { promisify } = util
+
+const ncp = promisify(require('ncp'))
 
 const typeFileExt = '.d.ts'
 const localeDir = path.join(process.env.PWD, 'esm/locale')
@@ -12,12 +13,12 @@ const localeTypePath = path.join(process.env.PWD, 'esm/locale', `index${typeFile
 
 
 async function walk(dir, callback) {
-  const files = await fsp.readdir(dir)
+  const files = await fs.readdir(dir)
 
   /* eslint-disable no-restricted-syntax, no-await-in-loop */
   for (const file of files) {
     const filepath = path.join(dir, file)
-    const stats = await fsp.stat(filepath)
+    const stats = await fs.stat(filepath)
     if (stats.isDirectory()) {
       await walk(filepath, callback)
     } else if (stats.isFile()) {
@@ -29,45 +30,45 @@ async function walk(dir, callback) {
 
 (async () => {
   try {
-    const readLocaleDir = await fsp.readdir(localeDir)
+    const readLocaleDir = await fs.readdir(localeDir)
     await Promise.all(readLocaleDir.map(l => async () => {
       const filePath = path.join(localeDir, l)
-      const readFile = await fsp.readFile(filePath, 'utf8')
+      const readFile = await fs.readFile(filePath, 'utf8')
       const result = readFile.replace("'dayjs'", "'../index'")
-      await fsp.writeFile(filePath, result, 'utf8')
+      await fs.writeFile(filePath, result, 'utf8')
     })
       .map(f => f()))
 
-    await promisify(ncp)('./types/', './esm')
+    await ncp('./types/', './esm')
 
-    const readLocaleFile = await fsp.readFile(localeTypePath, 'utf8')
+    const readLocaleFile = await fs.readFile(localeTypePath, 'utf8')
     const localResult = readLocaleFile.replace("'dayjs", "'dayjs/esm")
-    await fsp.writeFile(localeTypePath, localResult, 'utf8')
+    await fs.writeFile(localeTypePath, localResult, 'utf8')
 
-    const readPluginDir = await fsp.readdir(pluginDir)
+    const readPluginDir = await fs.readdir(pluginDir)
 
     await Promise.all(readPluginDir.map(p => async () => {
       if (p.includes(typeFileExt)) {
         const pluginName = p.replace(typeFileExt, '')
         const filePath = path.join(pluginDir, p)
         const targetPath = path.join(pluginDir, pluginName, `index${typeFileExt}`)
-        const readFile = await fsp.readFile(filePath, 'utf8')
+        const readFile = await fs.readFile(filePath, 'utf8')
         const result = readFile.replace(/'dayjs'/g, '\'dayjs/esm\'')
-        await fsp.writeFile(targetPath, result, 'utf8')
-        await fsp.unlink(filePath)
+        await fs.writeFile(targetPath, result, 'utf8')
+        await fs.unlink(filePath)
       }
     })
       .map(f => f()))
 
     await walk('./esm/', async (p) => {
       if (p.endsWith('.js')) {
-        await fsp.rename(p, p.replace(/\.js$/g, '.mjs'))
+        await fs.rename(p, p.replace(/\.js$/g, '.mjs'))
       } else if (p.endsWith(typeFileExt)) {
-        const content = await fsp.readFile(p, 'utf8')
-        await fsp.writeFile(p, content.replaceAll('export = ', 'export default '))
+        const content = await fs.readFile(p, 'utf8')
+        await fs.writeFile(p, content.replaceAll('export = ', 'export default '))
       }
     })
-    await promisify(ncp)(path.join(__dirname, 'esm-wrapper/'), './esm')
+    await ncp(path.join(__dirname, 'esm-wrapper/'), './esm')
   } catch (e) {
     console.error(e) // eslint-disable-line no-console
   }

--- a/build/esm.js
+++ b/build/esm.js
@@ -62,6 +62,9 @@ async function walk(dir, callback) {
     await walk('./esm/', async (p) => {
       if (p.endsWith('.js')) {
         await fsp.rename(p, p.replace(/\.js$/g, '.mjs'))
+      } else if (p.endsWith(typeFileExt)) {
+        const content = await fsp.readFile(p, 'utf8')
+        await fsp.writeFile(p, content.replaceAll('export = ', 'export default '))
       }
     })
     await promisify(ncp)(path.join(__dirname, 'esm-wrapper/'), './esm')


### PR DESCRIPTION
This PR fix 2 thing:

1. allow ts user to import `dayjs/esm` without `allowSyntheticDefaultImports` flags.


2. fix dayjs/esm at node runtime.

now esm generate files with `.mjs` extension. Previously, it will raise a error when try to `import` in `.js` file without `"type": "module"` in node env.

```test
esm
|-- constant.mjs
|-- index.d.ts
|-- index.js
|-- index.mjs
|-- locale
|   |-- af.mjs
|   |-- am.mjs
|   |-- ar-dz.mjs
|   |-- ar-iq.mjs
...
```

`index.js` here is to not break bundler https://github.com/search?q=dayjs%2Fesm%2Findex.js&type=code

previously:

```text
$ node --experimental-specifier-resolution=node main.js
.../node_modules/dayjs/esm/index.js:1
import * as C from './constant';
^^^^^^

SyntaxError: Cannot use import statement outside a module
```


and now imports works fine in typescript/esm/nodejs

```ts
import advancedFormat from 'dayjs/esm/plugin/advancedFormat/index.mjs'
import dayjs from 'dayjs/esm/index.mjs'

dayjs.extend(advancedFormat)
```

ref: https://github.com/iamkun/dayjs/issues/2189