### PR TITLE
feat: Add plugin/customParseFormat LowerCase months

### DIFF
--- a/src/plugin/customParseFormat/index.js
+++ b/src/plugin/customParseFormat/index.js
@@ -248,7 +248,6 @@ export default (o, C, d) => {
       // input number 1410715640579 and format string '1410715640579' equal
       // eslint-disable-next-line eqeqeq
       if (isStrict && date != this.format(format)) {
-        // console.log('Date("")', isStrict, date, this.format(format))
         this.$d = new Date('')
       }
       // reset global locale to make parallel unit test
@@ -258,7 +257,6 @@ export default (o, C, d) => {
       for (let i = 1; i <= len; i += 1) {
         args[1] = format[i - 1]
         const result = d.apply(this, args)
-        console.log(result, result.isValid())
         if (result.isValid()) {
           this.$d = result.$d
           this.$L = result.$L

--- a/test/plugin/customParseFormat.test.js
+++ b/test/plugin/customParseFormat.test.js
@@ -303,12 +303,15 @@ describe('Strict mode', () => {
     expect(dayjs(input, format).isValid()).toBe(true)
     expect(dayjs(input, format, true).isValid()).toBe(false)
     expect(dayjs('2020-Jan-01', 'YYYY-MMM-DD', true).isValid()).toBe(true)
+    expect(dayjs('2020-jan-01', 'YYYY-MMM-DD', true).isValid()).toBe(true)
     expect(dayjs('30/1/2020 10:59 PM', 'D/M/YYYY h:mm A', true).isValid()).toBe(true)
   })
   it('with locale', () => {
     const input = '2018 三月 99'
     const format = 'YYYY MMMM DD'
     expect(dayjs(input, format, 'zh-cn').isValid()).toBe(true)
+    expect(dayjs('2020-февр.-01', 'YYYY-MMM-DD', 'ru').isValid()).toBe(true)
+    expect(dayjs('2020-jan-01', 'YYYY-MMM-DD', 'en').isValid()).toBe(true)
     expect(dayjs(input, format, 'zh-cn', true).isValid()).toBe(false)
   })
 })

--- a/test/plugin/customParseFormat.test.js
+++ b/test/plugin/customParseFormat.test.js
@@ -304,6 +304,7 @@ describe('Strict mode', () => {
     expect(dayjs(input, format, true).isValid()).toBe(false)
     expect(dayjs('2020-Jan-01', 'YYYY-MMM-DD', true).isValid()).toBe(true)
     expect(dayjs('2020-jan-01', 'YYYY-MMM-DD', true).isValid()).toBe(true)
+    expect(dayjs('2020-jan-01', 'YYYY-MMM-DD').isValid()).toBe(true)
     expect(dayjs('30/1/2020 10:59 PM', 'D/M/YYYY h:mm A', true).isValid()).toBe(true)
   })
   it('with locale', () => {
@@ -311,6 +312,7 @@ describe('Strict mode', () => {
     const format = 'YYYY MMMM DD'
     expect(dayjs(input, format, 'zh-cn').isValid()).toBe(true)
     expect(dayjs('2020-февр.-01', 'YYYY-MMM-DD', 'ru').isValid()).toBe(true)
+    expect(dayjs('2020-jan-01', 'YYYY-MMM-DD', ['en']).isValid()).toBe(true)
     expect(dayjs('2020-jan-01', 'YYYY-MMM-DD', 'en').isValid()).toBe(true)
     expect(dayjs(input, format, 'zh-cn', true).isValid()).toBe(false)
   })


### PR DESCRIPTION
Adding possibilities to enter months with LowerCase (ex: 'January' || 'january')

Request : #2177 
Include src, types, test
~98% test coverage 😥

![image](https://user-images.githubusercontent.com/58274538/211694969-f4111461-c91c-49c0-ad8b-f117be511f3b.png)