### PR TITLE
fix: Mark `date` parameter as optional in timezone plugin

### DIFF
--- a/types/plugin/timezone.d.ts
+++ b/types/plugin/timezone.d.ts
@@ -10,7 +10,7 @@ declare module 'dayjs' {
   }
 
   interface DayjsTimezone {
-    (date: ConfigType, timezone?: string): Dayjs
+    (date?: ConfigType, timezone?: string): Dayjs
     (date: ConfigType, format: string, timezone?: string): Dayjs
     guess(): string
     setDefault(timezone?: string): void


### PR DESCRIPTION
LIke `dayjs()`, `dayjs.tz()` falls back to the default time internally if no parameter is passed. But the current Typescript types do not allow for this existing, expected, and correct functionality.