### PR TITLE
Added valueOf method to Duration instances

### DIFF
--- a/src/plugin/duration/index.js
+++ b/src/plugin/duration/index.js
@@ -235,6 +235,10 @@ class Duration {
       .fromNow(!withSuffix)
   }
 
+  valueOf() {
+    return this.asMilliseconds()
+  }
+
   milliseconds() { return this.get('milliseconds') }
   asMilliseconds() { return this.as('milliseconds') }
   seconds() { return this.get('seconds') }

--- a/test/plugin/duration.test.js
+++ b/test/plugin/duration.test.js
@@ -67,6 +67,9 @@ describe('Creating', () => {
       ms: -1
     }).toISOString()).toBe('-PT0.001S')
   })
+  it('convert to milliseconds', () => {
+    expect(+dayjs.duration(100)).toBe(100)
+  })
 })
 
 describe('Parse ISO string', () => {


### PR DESCRIPTION
The Duration class in MomentJS contains the `valueOf` method (https://github.com/moment/moment/blob/develop/src/lib/duration/as.js). This method returns the duration in milliseconds.