### PR TITLE
fix: offset calculation of timezone plugin

### DIFF
--- a/src/plugin/timezone/index.js
+++ b/src/plugin/timezone/index.js
@@ -96,7 +96,8 @@ export default (o, c, d) => {
     const oldOffset = this.utcOffset()
     const date = this.toDate()
     const target = date.toLocaleString('en-US', { timeZone: timezone })
-    const diff = Math.round((date - new Date(target)) / 1000 / 60)
+    const targetDate = d(target, 'M/D/YYYY H:mm:ss A')
+    const diff = Math.round(this.diff(targetDate, 'ms') / 1000 / 60)
     let ins = d(target).$set(MS, this.$ms)
       .utcOffset((-Math.round(date.getTimezoneOffset() / 15) * 15) - diff, true)
     if (keepLocalTime) {


### PR DESCRIPTION
Update calculation of timezone offset. This change was caused by this issue https://github.com/iamkun/dayjs/issues/2207. The thing is that [Hermes](https://reactnative.dev/docs/hermes) in React Native doesn't fully support Intl API (https://github.com/facebook/hermes/issues/23). Let me explain.

This code
```
const target = date.toLocaleString('en-US', { timeZone: timezone })
```
works correct, it returns the date in `en-US` format, but after that when returned string is passed to `Date` constructor it returns `Date { NaN }`
```
const target = date.toLocaleString('en-US', { timeZone: timezone })
new Date(target) // Date { NaN }
```

Date constructor cannot recognise this format, so calculation of difference is broken. And I think that we can use `dayjs` to do backward formatting.

**Note**: in my opinion we can improve somehow the calculation of timezone offset not to depend on some APIs support (get rid of `Date.toLocaleString`).