### PR TITLE
Fix: objectSupport parsing objects with invalid units

### DIFF
--- a/src/constant.js
+++ b/src/constant.js
@@ -20,7 +20,6 @@ export const M = 'month'
 export const Q = 'quarter'
 export const Y = 'year'
 export const DATE = 'date'
-export const UNITS = [MS, S, MIN, H, D, W, M, Q, Y, DATE]
 
 export const FORMAT_DEFAULT = 'YYYY-MM-DDTHH:mm:ssZ'
 

--- a/src/constant.js
+++ b/src/constant.js
@@ -20,6 +20,7 @@ export const M = 'month'
 export const Q = 'quarter'
 export const Y = 'year'
 export const DATE = 'date'
+export const UNITS = [MS, S, MIN, H, D, W, M, Q, Y, DATE]
 
 export const FORMAT_DEFAULT = 'YYYY-MM-DDTHH:mm:ssZ'
 

--- a/src/plugin/objectSupport/index.js
+++ b/src/plugin/objectSupport/index.js
@@ -1,4 +1,6 @@
-import { UNITS } from '../../constant'
+import { D, Y, M, H, MIN, S, MS, DATE } from '../../constant'
+
+const UNITS = [D, Y, M, H, MIN, S, MS]
 
 export default (o, c, dayjs) => {
   const proto = c.prototype
@@ -6,7 +8,7 @@ export default (o, c, dayjs) => {
         && !proto.$utils().u(obj) && (obj.constructor.name === 'Object')
   const prettyUnit = (u) => {
     const unit = proto.$utils().p(u)
-    return unit === 'date' ? 'day' : unit
+    return unit === DATE ? D : unit
   }
   const parseDate = (cfg) => {
     const { date, utc } = cfg
@@ -25,17 +27,17 @@ export default (o, c, dayjs) => {
       return date
     }
     const now = utc ? dayjs.utc() : dayjs()
-    const d = $d.day || ((!$d.year && !($d.month >= 0)) ? now.date() : 1)
-    const y = $d.year || now.year()
-    const M = $d.month >= 0 ? $d.month : ((!$d.year && !$d.day) ? now.month() : 0) // eslint-disable-line no-nested-ternary,max-len
-    const h = $d.hour || 0
-    const m = $d.minute || 0
-    const s = $d.second || 0
-    const ms = $d.millisecond || 0
+    const d = $d[D] || ((!$d[Y] && !($d[M] >= 0)) ? now.date() : 1)
+    const y = $d[Y] || now.year()
+    const m = $d[M] >= 0 ? $d[M] : ((!$d[Y] && !$d[D]) ? now.month() : 0) // eslint-disable-line no-nested-ternary,max-len
+    const h = $d[H] || 0
+    const min = $d[MIN] || 0
+    const s = $d[S] || 0
+    const ms = $d[MS] || 0
     if (utc) {
-      return new Date(Date.UTC(y, M, d, h, m, s, ms))
+      return new Date(Date.UTC(y, m, d, h, min, s, ms))
     }
-    return new Date(y, M, d, h, m, s, ms)
+    return new Date(y, m, d, h, min, s, ms)
   }
 
   const oldParse = proto.parse

--- a/src/plugin/objectSupport/index.js
+++ b/src/plugin/objectSupport/index.js
@@ -1,3 +1,5 @@
+import { UNITS } from '../../constant'
+
 export default (o, c, dayjs) => {
   const proto = c.prototype
   const isObject = obj => !(obj instanceof Date) && !(obj instanceof Array)
@@ -8,28 +10,32 @@ export default (o, c, dayjs) => {
   }
   const parseDate = (cfg) => {
     const { date, utc } = cfg
-    const $d = {}
-    if (isObject(date)) {
-      if (!Object.keys(date).length) {
-        return new Date()
-      }
-      const now = utc ? dayjs.utc() : dayjs()
-      Object.keys(date).forEach((k) => {
-        $d[prettyUnit(k)] = date[k]
-      })
-      const d = $d.day || ((!$d.year && !($d.month >= 0)) ? now.date() : 1)
-      const y = $d.year || now.year()
-      const M = $d.month >= 0 ? $d.month : ((!$d.year && !$d.day) ? now.month() : 0)// eslint-disable-line no-nested-ternary,max-len
-      const h = $d.hour || 0
-      const m = $d.minute || 0
-      const s = $d.second || 0
-      const ms = $d.millisecond || 0
-      if (utc) {
-        return new Date(Date.UTC(y, M, d, h, m, s, ms))
-      }
-      return new Date(y, M, d, h, m, s, ms)
+    if (!isObject(date)) {
+      return date
     }
-    return date
+    const rawUnits = Object.keys(date)
+    if (!rawUnits.length) {
+      return new Date()
+    }
+    const $d = {}
+    rawUnits.forEach((rawUnit) => {
+      $d[prettyUnit(rawUnit)] = date[rawUnit]
+    })
+    if (Object.keys($d).some(unit => !UNITS.includes(unit))) {
+      return date
+    }
+    const now = utc ? dayjs.utc() : dayjs()
+    const d = $d.day || ((!$d.year && !($d.month >= 0)) ? now.date() : 1)
+    const y = $d.year || now.year()
+    const M = $d.month >= 0 ? $d.month : ((!$d.year && !$d.day) ? now.month() : 0) // eslint-disable-line no-nested-ternary,max-len
+    const h = $d.hour || 0
+    const m = $d.minute || 0
+    const s = $d.second || 0
+    const ms = $d.millisecond || 0
+    if (utc) {
+      return new Date(Date.UTC(y, M, d, h, m, s, ms))
+    }
+    return new Date(y, M, d, h, m, s, ms)
   }
 
   const oldParse = proto.parse

--- a/test/plugin/objectSupport.test.js
+++ b/test/plugin/objectSupport.test.js
@@ -126,6 +126,11 @@ describe('parse empty object', () => {
   })
 })
 
+it('rejects objects with invalid units', () => {
+  expect(dayjs({ invalidUnit: 42 }).isValid()).toBe(false)
+  expect(dayjs({ year: 2000, nonExistingUnit: 42 }).isValid()).toBe(false)
+})
+
 it('Constructor from Object', () => {
   for (let i = 0; i < tests.length; i += 1) {
     expect(dayjs(tests[i][0]).format(fmt)).toBe(tests[i][1])


### PR DESCRIPTION
Currently, if `dayjs` is extended with `objectSupport`, providing any kind of object that is not undefined, a Date or an Array ends up with a valid date. This behavior is unexpected and prone for false positives.
Before:
```js
dayjs({ value: { year: 2023 } }).isValid() // => true (current date)
```
After:
```js
dayjs({ value: { year: 2023 } }).isValid() // => false
```