### PR TITLE
dayjs.diff improve performance

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -4,3 +4,4 @@ root = true
 charset = utf-8
 end_of_line = lf
 insert_final_newline = true
+indent_size = 2

--- a/src/index.js
+++ b/src/index.js
@@ -319,18 +319,20 @@ class Dayjs {
     const that = dayjs(input)
     const zoneDelta = (that.utcOffset() - this.utcOffset()) * C.MILLISECONDS_A_MINUTE
     const diff = this - that
-    let result = Utils.m(this, that)
+    const getMonth = () => Utils.m(this, that)
 
-    result = {
-      [C.Y]: result / 12,
-      [C.M]: result,
-      [C.Q]: result / 3,
-      [C.W]: (diff - zoneDelta) / C.MILLISECONDS_A_WEEK,
-      [C.D]: (diff - zoneDelta) / C.MILLISECONDS_A_DAY,
-      [C.H]: diff / C.MILLISECONDS_A_HOUR,
-      [C.MIN]: diff / C.MILLISECONDS_A_MINUTE,
-      [C.S]: diff / C.MILLISECONDS_A_SECOND
-    }[unit] || diff // milliseconds
+    let result = {
+      [C.Y]: () => getMonth() / 12,
+      [C.M]: () => getMonth(),
+      [C.Q]: () => getMonth() / 3,
+      [C.W]: () => (diff - zoneDelta) / C.MILLISECONDS_A_WEEK,
+      [C.D]: () => (diff - zoneDelta) / C.MILLISECONDS_A_DAY,
+      [C.H]: () => diff / C.MILLISECONDS_A_HOUR,
+      [C.MIN]: () => diff / C.MILLISECONDS_A_MINUTE,
+      [C.S]: () => diff / C.MILLISECONDS_A_SECOND
+    }[unit] || (() => diff) // milliseconds
+
+    result = result()
 
     return float ? result : Utils.a(result)
   }

--- a/src/index.js
+++ b/src/index.js
@@ -321,18 +321,36 @@ class Dayjs {
     const diff = this - that
     const getMonth = () => Utils.m(this, that)
 
-    let result = {
-      [C.Y]: () => getMonth() / 12,
-      [C.M]: () => getMonth(),
-      [C.Q]: () => getMonth() / 3,
-      [C.W]: () => (diff - zoneDelta) / C.MILLISECONDS_A_WEEK,
-      [C.D]: () => (diff - zoneDelta) / C.MILLISECONDS_A_DAY,
-      [C.H]: () => diff / C.MILLISECONDS_A_HOUR,
-      [C.MIN]: () => diff / C.MILLISECONDS_A_MINUTE,
-      [C.S]: () => diff / C.MILLISECONDS_A_SECOND
-    }[unit] || (() => diff) // milliseconds
-
-    result = result()
+    let result
+    switch (unit) {
+      case C.Y:
+        result = getMonth() / 12
+        break
+      case C.M:
+        result = getMonth()
+        break
+      case C.Q:
+        result = getMonth() / 3
+        break
+      case C.W:
+        result = (diff - zoneDelta) / C.MILLISECONDS_A_WEEK
+        break
+      case C.D:
+        result = (diff - zoneDelta) / C.MILLISECONDS_A_DAY
+        break
+      case C.H:
+        result = diff / C.MILLISECONDS_A_HOUR
+        break
+      case C.MIN:
+        result = diff / C.MILLISECONDS_A_MINUTE
+        break
+      case C.S:
+        result = diff / C.MILLISECONDS_A_SECOND
+        break
+      default:
+        result = diff // milliseconds
+        break
+    }
 
     return float ? result : Utils.a(result)
   }


### PR DESCRIPTION
在高频场景下 dayjs.diff 会成为性能瓶颈, 发现在进行 `dayjs.diff(time, 'day')` 计算时会有无效的一些计算，于是优化了在进行 diff day 场景下的性能

![image](https://user-images.githubusercontent.com/9263655/220305322-4730e31b-538d-4ddf-b989-2d48b27c0a0a.png)

test case

```js
const dayjs =  require('./dayjs.min.js');

let startTime = Date.now();
let endTime = Date.now() + 30 * 24 * 60 * 60 * 1000;

for(let i = 0; i < 100000; ++i) {
    dayjs(startTime).diff(endTime, 'day');
}
```

before

![image](https://user-images.githubusercontent.com/9263655/220305665-2721e6d4-cd71-4c53-990a-a4c30c148254.png)


after

![image](https://user-images.githubusercontent.com/9263655/220305712-4754a655-e14d-4f2a-8f09-b45dc911433f.png)



执行时间由 1.35s/100000次 提升到 0.2s/100000次



