### PR TITLE
Fix: Invalid month number with customParseFormat leads to the next year date

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -280,7 +280,7 @@ class Dayjs {
 
     const matches = {
       YY: String(this.$y).slice(-2),
-      YYYY: this.$y,
+      YYYY: Utils.s(this.$y, 4, '0'),
       M: $M + 1,
       MM: Utils.s($M + 1, 2, '0'),
       MMM: getShort(locale.monthsShort, $M, months, 3),

--- a/src/plugin/customParseFormat/index.js
+++ b/src/plugin/customParseFormat/index.js
@@ -13,6 +13,14 @@ const matchWord = /\d*[^-_:/,()\s\d]+/ // Word
 
 let locale = {}
 
+const getMonth = (matchIndex) => {
+  if (matchIndex !== 12 && matchIndex % 12 === 0) {
+    return 12
+  }
+
+  return matchIndex % 12 || matchIndex
+}
+
 let parseTwoDigitYear = function (input) {
   input = +input
   return input + (input > 68 ? 1900 : 2000)
@@ -104,7 +112,8 @@ const expressions = {
     if (matchIndex < 1) {
       throw new Error()
     }
-    this.month = (matchIndex % 12) || matchIndex
+
+    this.month = getMonth(matchIndex)
   }],
   MMMM: [matchWord, function (input) {
     const months = getLocalePart('months')
@@ -112,7 +121,8 @@ const expressions = {
     if (matchIndex < 1) {
       throw new Error()
     }
-    this.month = (matchIndex % 12) || matchIndex
+
+    this.month = getMonth(matchIndex)
   }],
   Y: [matchSigned, addInput('year')],
   YY: [match2, function (input) {

--- a/test/display.test.js
+++ b/test/display.test.js
@@ -260,3 +260,15 @@ it('As JSON -> toJSON', () => {
 it('As ISO 8601 String -> toISOString e.g. 2013-02-04T22:44:30.652Z', () => {
   expect(dayjs().toISOString()).toBe(moment().toISOString())
 })
+
+it('Year 1 formatted with YYYY should pad with zeroes', () => {
+  const date = new Date(1, 0, 1)
+  date.setUTCFullYear(1) // Required because 0-99 are parsed as 19xx in JS: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/Date#year
+  expect(dayjs(date).format('YYYY')).toBe('0001')
+})
+
+it('Year 1 formatting matches moment format', () => {
+  const date = new Date(1, 0, 1)
+  date.setUTCFullYear(1)
+  expect(dayjs(date).format('YYYY')).toBe(moment(date).format('YYYY'))
+})

--- a/test/plugin/customParseFormat.test.js
+++ b/test/plugin/customParseFormat.test.js
@@ -281,6 +281,16 @@ it('correctly parse ordinal', () => {
     .toBe(momentCN.locale())
 })
 
+describe('month doesn\'t lead to the next year', () => {
+  it('MMMM', () => {
+    const input = '03 декабря'
+    const format1 = 'D MMMM'
+    const format2 = 'D MMMMF'
+    expect(dayjs(input, format1, 'ru').valueOf()).toBe(moment(input, format1, 'ru').valueOf())
+    expect(dayjs(input, format2, 'ru').valueOf()).toBe(moment(input, format2, 'ru').valueOf())
+  })
+})
+
 describe('month function locale', () => {
   it('MMMM', () => {
     const input = '08 мая 2020'


### PR DESCRIPTION
closes https://github.com/iamkun/dayjs/issues/2249