### PR TITLE
fix: Invalid month number with customParseFormat leads to the next year date

### DIFF
--- a/src/plugin/customParseFormat/index.js
+++ b/src/plugin/customParseFormat/index.js
@@ -13,6 +13,14 @@ const matchWord = /\d*[^-_:/,()\s\d]+/ // Word
 
 let locale = {}
 
+const getMonth = (matchIndex) => {
+  if (matchIndex !== 12 && matchIndex % 12 === 0) {
+    return 12
+  }
+
+  return matchIndex % 12 || matchIndex
+}
+
 let parseTwoDigitYear = function (input) {
   input = +input
   return input + (input > 68 ? 1900 : 2000)
@@ -104,7 +112,7 @@ const expressions = {
     if (matchIndex < 1) {
       throw new Error()
     }
-    this.month = (matchIndex % 12) || matchIndex
+    this.month = getMonth(matchIndex)
   }],
   MMMM: [matchWord, function (input) {
     const months = getLocalePart('months')
@@ -112,7 +120,7 @@ const expressions = {
     if (matchIndex < 1) {
       throw new Error()
     }
-    this.month = (matchIndex % 12) || matchIndex
+    this.month = getMonth(matchIndex)
   }],
   Y: [matchSigned, addInput('year')],
   YY: [match2, function (input) {

--- a/test/plugin/customParseFormat.test.js
+++ b/test/plugin/customParseFormat.test.js
@@ -281,6 +281,16 @@ it('correctly parse ordinal', () => {
     .toBe(momentCN.locale())
 })
 
+describe('month doesn\'t lead to the next year', () => {
+  it('MMMM', () => {
+    const input = '03 декабря'
+    const format1 = 'D MMMM'
+    const format2 = 'D MMMMF'
+    expect(dayjs(input, format1, 'ru').valueOf()).toBe(moment(input, format1, 'ru').valueOf())
+    expect(dayjs(input, format2, 'ru').valueOf()).toBe(moment(input, format2, 'ru').valueOf())
+  })
+})
+
 describe('month function locale', () => {
   it('MMMM', () => {
     const input = '08 мая 2020'


### PR DESCRIPTION
closes https://github.com/iamkun/dayjs/issues/2249