### PR TITLE
Add "ru-ru" locale & tests. Ref: RFC 5646 Language Tags

### DIFF
--- a/src/locale/ru-ru.js
+++ b/src/locale/ru-ru.js
@@ -1,0 +1,95 @@
+// 'Russian (Russia)' [ru-RU]
+import dayjs from 'dayjs'
+
+const monthFormat = 'января_февраля_марта_апреля_мая_июня_июля_августа_сентября_октября_ноября_декабря'.split('_')
+const monthStandalone = 'январь_февраль_март_апрель_май_июнь_июль_август_сентябрь_октябрь_ноябрь_декабрь'.split('_')
+
+const monthShortFormat = 'янв._февр._мар._апр._мая_июня_июля_авг._сент._окт._нояб._дек.'.split('_')
+const monthShortStandalone = 'янв._февр._март_апр._май_июнь_июль_авг._сент._окт._нояб._дек.'.split('_')
+
+const MONTHS_IN_FORMAT = /D[oD]?(\[[^[\]]*\]|\s)+MMMM?/
+
+function plural(word, num) {
+  const forms = word.split('_')
+  return num % 10 === 1 && num % 100 !== 11 ? forms[0] : (num % 10 >= 2 && num % 10 <= 4 && (num % 100 < 10 || num % 100 >= 20) ? forms[1] : forms[2]) // eslint-disable-line
+}
+function relativeTimeWithPlural(number, withoutSuffix, key) {
+  const format = {
+    mm: withoutSuffix ? 'минута_минуты_минут' : 'минуту_минуты_минут',
+    hh: 'час_часа_часов',
+    dd: 'день_дня_дней',
+    MM: 'месяц_месяца_месяцев',
+    yy: 'год_года_лет'
+  }
+  if (key === 'm') {
+    return withoutSuffix ? 'минута' : 'минуту'
+  }
+
+  return `${number} ${plural(format[key], +number)}`
+}
+const months = (dayjsInstance, format) => {
+  if (MONTHS_IN_FORMAT.test(format)) {
+    return monthFormat[dayjsInstance.month()]
+  }
+  return monthStandalone[dayjsInstance.month()]
+}
+months.s = monthStandalone
+months.f = monthFormat
+
+const monthsShort = (dayjsInstance, format) => {
+  if (MONTHS_IN_FORMAT.test(format)) {
+    return monthShortFormat[dayjsInstance.month()]
+  }
+  return monthShortStandalone[dayjsInstance.month()]
+}
+monthsShort.s = monthShortStandalone
+monthsShort.f = monthShortFormat
+
+const locale = {
+  name: 'ru-ru',
+  weekdays: 'воскресенье_понедельник_вторник_среда_четверг_пятница_суббота'.split('_'),
+  weekdaysShort: 'вск_пнд_втр_срд_чтв_птн_сбт'.split('_'),
+  weekdaysMin: 'вс_пн_вт_ср_чт_пт_сб'.split('_'),
+  months,
+  monthsShort,
+  weekStart: 1,
+  yearStart: 4,
+  formats: {
+    LT: 'H:mm',
+    LTS: 'H:mm:ss',
+    L: 'DD.MM.YYYY',
+    LL: 'D MMMM YYYY г.',
+    LLL: 'D MMMM YYYY г., H:mm',
+    LLLL: 'dddd, D MMMM YYYY г., H:mm'
+  },
+  relativeTime: {
+    future: 'через %s',
+    past: '%s назад',
+    s: 'несколько секунд',
+    m: relativeTimeWithPlural,
+    mm: relativeTimeWithPlural,
+    h: 'час',
+    hh: relativeTimeWithPlural,
+    d: 'день',
+    dd: relativeTimeWithPlural,
+    M: 'месяц',
+    MM: relativeTimeWithPlural,
+    y: 'год',
+    yy: relativeTimeWithPlural
+  },
+  ordinal: n => n,
+  meridiem: (hour) => {
+    if (hour < 4) {
+      return 'ночи'
+    } else if (hour < 12) {
+      return 'утра'
+    } else if (hour < 17) {
+      return 'дня'
+    }
+    return 'вечера'
+  }
+}
+
+dayjs.locale(locale, null, true)
+
+export default locale

--- a/test/locale/ru.test.js
+++ b/test/locale/ru.test.js
@@ -3,8 +3,11 @@ import MockDate from 'mockdate'
 import dayjs from '../../src'
 import relativeTime from '../../src/plugin/relativeTime'
 import '../../src/locale/ru'
+import '../../src/locale/ru-ru'
 
 dayjs.extend(relativeTime)
+
+const locales = ['ru', 'ru-ru']
 
 beforeEach(() => {
   MockDate.set(new Date())
@@ -14,43 +17,48 @@ afterEach(() => {
   MockDate.reset()
 })
 
-it('Format Month with locale function', () => {
-  for (let i = 0; i <= 7; i += 1) {
-    const dayjsRU = dayjs().locale('ru').add(i, 'day')
-    const momentRU = moment().locale('ru').add(i, 'day')
-    const testFormat1 = 'DD MMMM YYYY MMM'
-    const testFormat2 = 'MMMM'
-    const testFormat3 = 'MMM'
-    expect(dayjsRU.format(testFormat1)).toEqual(momentRU.format(testFormat1))
-    expect(dayjsRU.format(testFormat2)).toEqual(momentRU.format(testFormat2))
-    expect(dayjsRU.format(testFormat3)).toEqual(momentRU.format(testFormat3))
-  }
-})
+describe('Russian date formats', () => {
+  locales.forEach((locale) => {
+    it('Format Month with locale function', () => {
+      for (let i = 0; i <= 7; i += 1) {
+        const dayjsRU = dayjs().locale(locale).add(i, 'day')
+        const momentRU = moment().locale(locale).add(i, 'day')
+        const testFormat1 = 'DD MMMM YYYY MMM'
+        const testFormat2 = 'MMMM'
+        const testFormat3 = 'MMM'
+        expect(dayjsRU.format(testFormat1)).toEqual(momentRU.format(testFormat1))
+        expect(dayjsRU.format(testFormat2)).toEqual(momentRU.format(testFormat2))
+        expect(dayjsRU.format(testFormat3)).toEqual(momentRU.format(testFormat3))
+      }
+    })
 
-it('RelativeTime: Time from X', () => {
-  const T = [
-    [44.4, 'second'], // a few seconds
-    [89.5, 'second'], // a minute
-    [43, 'minute'], // 44 minutes
-    [21, 'hour'], // 21 hours
-    [25, 'day'], // 25 days
-    [10, 'month'], // 2 month
-    [18, 'month'] // 2 years
-  ]
+    it('RelativeTime: Time from X', () => {
+      const T = [
+        [44.4, 'second'], // a few seconds
+        [89.5, 'second'], // a minute
+        [43, 'minute'], // 43 minutes
+        [21, 'hour'], // 21 hours
+        [25, 'day'], // 25 days
+        [10, 'month'], // 2 month
+        [18, 'month'] // 2 years
+      ]
 
-  T.forEach((t) => {
-    dayjs.locale('ru')
-    moment.locale('ru')
-    expect(dayjs().from(dayjs().add(t[0], t[1])))
-      .toBe(moment().from(moment().add(t[0], t[1])))
-    expect(dayjs().from(dayjs().add(t[0], t[1]), true))
-      .toBe(moment().from(moment().add(t[0], t[1]), true))
+      T.forEach((t) => {
+        dayjs.locale(locale)
+        moment.locale(locale)
+        expect(dayjs().from(dayjs().add(t[0], t[1])))
+          .toBe(moment().from(moment().add(t[0], t[1])))
+        expect(dayjs().from(dayjs().add(t[0], t[1]), true))
+          .toBe(moment().from(moment().add(t[0], t[1]), true))
+      })
+    })
+
+    it('Meridiem', () => {
+      expect(dayjs('2020-01-01 03:00:00').locale(locale).format('A')).toEqual('ночи')
+      expect(dayjs('2020-01-01 11:00:00').locale(locale).format('A')).toEqual('утра')
+      expect(dayjs('2020-01-01 16:00:00').locale(locale).format('A')).toEqual('дня')
+      expect(dayjs('2020-01-01 20:00:00').locale(locale).format('A')).toEqual('вечера')
+    })
   })
 })
 
-it('Meridiem', () => {
-  expect(dayjs('2020-01-01 03:00:00').locale('ru').format('A')).toEqual('ночи')
-  expect(dayjs('2020-01-01 11:00:00').locale('ru').format('A')).toEqual('утра')
-  expect(dayjs('2020-01-01 16:00:00').locale('ru').format('A')).toEqual('дня')
-  expect(dayjs('2020-01-01 20:00:00').locale('ru').format('A')).toEqual('вечера')
-})


### PR DESCRIPTION
I was trying to settle up dynamic imports of locale based of BCP 47 language tag and failed finding the module. In my case for "ru-ru" ("ru-RU - tag") which is same as "ru".