### PR TITLE
Allow for dynamic quarter start

### DIFF
--- a/src/plugin/quarterOfYear/index.js
+++ b/src/plugin/quarterOfYear/index.js
@@ -6,7 +6,12 @@ export default (o, c) => {
     if (!this.$utils().u(quarter)) {
       return this.month((this.month() % 3) + ((quarter - 1) * 3))
     }
-    return Math.ceil((this.month() + 1) / 3)
+
+    const startMonth = this.$locale().quarterStart || 1
+    const month = this.month() + 1
+    const value = Math.ceil(((month - startMonth) + 1) / 3)
+
+    return value > 0 ? value : 4 + value
   }
 
   const oldAdd = proto.add
@@ -25,10 +30,13 @@ export default (o, c) => {
     const isStartOf = !utils.u(startOf) ? startOf : true
     const unit = utils.p(units)
     if (unit === Q) {
+      const startMonth = (this.$locale().quarterStart || 1) - 1
+
       const quarter = this.quarter() - 1
-      return isStartOf ? this.month(quarter * 3)
+
+      return isStartOf ? this.month(quarter * 3).add(startMonth, 'month')
         .startOf(M).startOf(D) :
-        this.month((quarter * 3) + 2).endOf(M).endOf(D)
+        this.month((quarter * 3) + 2).add(startMonth, 'month').endOf(M).endOf(D)
     }
     return oldStartOf.bind(this)(units, startOf)
   }

--- a/test/locale/keys.test.js
+++ b/test/locale/keys.test.js
@@ -31,6 +31,7 @@ Locale.forEach((locale) => {
       monthsShort,
       weekdaysMin,
       weekStart,
+      quarterStart,
       yearStart,
       meridiem
     } = locale.content
@@ -45,6 +46,7 @@ Locale.forEach((locale) => {
     if (weekdaysShort) expect(weekdaysShort).toEqual(expect.any(Array))
     if (weekdaysMin) expect(weekdaysMin).toEqual(expect.any(Array))
     if (weekStart) expect(weekStart).toEqual(expect.any(Number))
+    if (quarterStart) expect(quarterStart).toEqual(expect.any(Number))
     if (yearStart) expect(yearStart).toEqual(expect.any(Number))
 
     // months could be a function or array

--- a/test/plugin/quarterOfYear.test.js
+++ b/test/plugin/quarterOfYear.test.js
@@ -2,6 +2,7 @@ import MockDate from 'mockdate'
 import moment from 'moment'
 import dayjs from '../../src'
 import quarterOfYear from '../../src/plugin/quarterOfYear'
+import updateLocale from '../../src/plugin/updateLocale'
 
 dayjs.extend(quarterOfYear)
 
@@ -48,4 +49,57 @@ it('startOf endOf quarter', () => {
     .toBe(moment().startOf('quarter').format())
   expect(dayjs().endOf('quarter').format())
     .toBe(moment().endOf('quarter').format())
+})
+
+
+it('handle different start month ', () => {
+  const testDifferentMonth = (startMonth, quarters) => {
+    dayjs.updateLocale('en', {
+      quarterStart: startMonth
+    })
+
+    Object.keys(quarters).forEach((quarter) => {
+      const months = quarters[quarter]
+      const numericQuarter = parseInt(quarter, 10)
+
+      months.forEach((month) => {
+        const monthString = month > 9 ? month.toString() : `0${month}`
+        const date = `2013-${monthString}-01T00:00:00.000`
+
+        expect(dayjs(date).quarter()).toBe(numericQuarter)
+
+        const quarterStart = dayjs(date).startOf('quarter').month() + 1
+        const quarterEnd = dayjs(date).endOf('quarter').month() + 1
+
+        expect(quarterStart).toBe(months[0])
+        expect(quarterEnd).toBe(months[2])
+      })
+    })
+  }
+
+  dayjs.extend(updateLocale)
+
+  // quarter starts in january
+  testDifferentMonth(1, {
+    1: [1, 2, 3],
+    2: [4, 5, 6],
+    3: [7, 8, 9],
+    4: [10, 11, 12]
+  })
+
+  // quarter starts in feb
+  testDifferentMonth(2, {
+    1: [2, 3, 4],
+    2: [5, 6, 7],
+    3: [8, 9, 10],
+    4: [11, 12, 1]
+  })
+
+  // first quarter starts in july
+  testDifferentMonth(7, {
+    1: [7, 8, 9],
+    2: [10, 11, 12],
+    3: [1, 2, 3],
+    4: [4, 5, 6]
+  })
 })

--- a/types/locale/types.d.ts
+++ b/types/locale/types.d.ts
@@ -3,6 +3,7 @@ declare interface ILocale {
   weekdays?: string[]
   months?: string[]
   weekStart?: number
+  quarterStart?: number
   weekdaysShort?: string[]
   monthsShort?: string[]
   weekdaysMin?: string[]


### PR DESCRIPTION
many companies and institutions have different fiscal years than calendar years. This PR adds a `quarterStart` configuration option that lets the user configure what month their first quarters starts. 