### PR TITLE
Fix timezone offset equal to 0, during switch from summer to winter time

### DIFF
--- a/src/plugin/timezone/index.js
+++ b/src/plugin/timezone/index.js
@@ -95,10 +95,10 @@ export default (o, c, d) => {
   proto.tz = function (timezone = defaultTimezone, keepLocalTime) {
     const oldOffset = this.utcOffset()
     const date = this.toDate()
-    const target = date.toLocaleString('en-US', { timeZone: timezone })
+    const target = date.toLocaleString('en-US', { timeZone: timezone, timeZoneName: 'longOffset' })
     const diff = Math.round((date - new Date(target)) / 1000 / 60)
-    let ins = d(target).$set(MS, this.$ms)
-      .utcOffset((-Math.round(date.getTimezoneOffset() / 15) * 15) - diff, true)
+    const offset = (-Math.round(date.getTimezoneOffset() / 15) * 15) - diff
+    let ins = d(target).$set(MS, this.$ms).utcOffset(offset, true)
     if (keepLocalTime) {
       const newOffset = ins.utcOffset()
       ins = ins.add(oldOffset - newOffset, MIN)

--- a/test/plugin/timezone.test.js
+++ b/test/plugin/timezone.test.js
@@ -213,6 +213,18 @@ describe('DST, a time that never existed Fall Back', () => {
   })
 })
 
+it('2023-10-29T01:00:00.000Z Europe/Amsterdam', () => {
+  const tz = 'Europe/Amsterdam'
+
+  expect(dayjs('2023-10-29T00:00:00.000Z').tz(tz).utcOffset()).toBe(120)
+  expect(dayjs('2023-10-29T02:00:00.000Z').tz(tz).utcOffset()).toBe(60)
+
+  expect(moment('2023-10-29T00:59:59.000Z').tz('Europe/Amsterdam').utcOffset()).toBe(120)
+  expect(moment('2023-10-29T01:00:00.000Z').tz('Europe/Amsterdam').utcOffset()).toBe(60)
+
+  expect(dayjs('2023-10-29T01:00:00.000Z').tz(tz).utcOffset()).toBe(60)
+})
+
 it('DST valueOf', () => {
   const day1 = '2021-11-17T09:45:00.000Z'
   const d1 = dayjs.utc(day1).tz(PARIS)


### PR DESCRIPTION
We found that during a switch from summer to winter time, when the clock moves backward one hour, during the extra hour the timestamps were formatted incorrectly. `dayjs.format` would return a string with the `Z` character not replaced with a timezone, for example: `2023-10-29T03:00:00Z` rather than `2023-10-29T03:00:00+01:00`

We traced this back to an issue in the `tz` method, it appears that the time offset information is lost, when using the `toLocaleString` method, this will return a date like `10/29/2023, 2:00:00 AM`. This timestamp is ambiguous when switching to winter time, as this time occurs twice. This caused the `utcOffset` to be calculated as `0` (somehow)

The fix is to add the `timeZoneName: 'longOffset'` to the `toLocaleString` options, as this persists the time offset, and the utcOffset is calculated correctly again.