### PR TITLE
wontfix/fixed uzbek language relative time translation

### DIFF
--- a/src/locale/uz-latn.js
+++ b/src/locale/uz-latn.js
@@ -20,7 +20,7 @@ const locale = {
   },
   relativeTime: {
     future: 'Yaqin %s ichida',
-    past: 'Bir necha %s oldin',
+    past: '%s oldin',
     s: 'soniya',
     m: 'bir daqiqa',
     mm: '%d daqiqa',

--- a/src/locale/uz.js
+++ b/src/locale/uz.js
@@ -20,7 +20,7 @@ const locale = {
   },
   relativeTime: {
     future: 'Якин %s ичида',
-    past: 'Бир неча %s олдин',
+    past: '%s олдин',
     s: 'фурсат',
     m: 'бир дакика',
     mm: '%d дакика',


### PR DESCRIPTION
When using the translation from i18n to Uzbek Latin and Uzbek Cyrillic, I encountered an incorrect translation into it.