### PR TITLE
Fix/minMax

### DIFF
--- a/src/plugin/minMax/index.js
+++ b/src/plugin/minMax/index.js
@@ -1,12 +1,20 @@
 export default (o, c, d) => {
   const sortBy = (method, dates) => {
-    if (!dates || !dates.length || !dates[0] || (dates.length === 1 && !dates[0].length)) {
+    if (
+      !dates ||
+      !dates.length ||
+      (dates.length === 1 && !dates[0]) ||
+      (dates.length === 1 && Array.isArray(dates[0]) && !dates[0].length)
+    ) {
       return null
     }
     if (dates.length === 1 && dates[0].length > 0) {
       [dates] = dates
     }
-    let result
+    while (dates.indexOf(null) !== -1) {
+      dates.forEach((date, index) => (!date ? dates.splice(index, 1) : null))
+    }
+    let result;
     [result] = dates
     for (let i = 1; i < dates.length; i += 1) {
       if (!dates[i].isValid() || dates[i][method](result)) {

--- a/src/plugin/minMax/index.js
+++ b/src/plugin/minMax/index.js
@@ -11,9 +11,7 @@ export default (o, c, d) => {
     if (dates.length === 1 && dates[0].length > 0) {
       [dates] = dates
     }
-    while (dates.indexOf(null) !== -1) {
-      dates.forEach((date, index) => (!date ? dates.splice(index, 1) : null))
-    }
+    dates = dates.filter(date => date)
     let result;
     [result] = dates
     for (let i = 1; i < dates.length; i += 1) {

--- a/test/plugin/minMax.test.js
+++ b/test/plugin/minMax.test.js
@@ -55,3 +55,17 @@ it('If Invalid Date return Invalid Date', () => {
   expect(dayjs.min([arg1, arg2, arg3, arg4]).format())
     .toBe(arg4.format())
 })
+
+it('Ignore if exists an "null" argument', () => {
+  expect(dayjs.max(null, null, arg1, arg2, null, arg3).format())
+    .toBe(arg1.format())
+  expect(dayjs.min([null, null, arg1, arg2, null, arg3]).format())
+    .toBe(arg3.format())
+})
+
+it('Return the only date if just provided one argument', () => {
+  expect(dayjs.max(arg1).format())
+    .toBe(arg1.format())
+  expect(dayjs.min([arg1]).format())
+    .toBe(arg1.format())
+})


### PR DESCRIPTION
### Motivation:
If I automatically get a list of dates from somewhere, that list might contain 'nulls', or even just return a single valid argument. At the moment, if not treated, the user will receive a TypeError or 'null' as a return, even with valid arguments.

### Makes two adjustments:
- If an array has a 'null' arg, doesnt return a TypeError, now just ignore the 'null' args and consider the others:

Example:
```
Before this alteration:
dayjs.max(dayjs("1995-03-16"), null, dayjs("2023-03-16")).format()
---> TypeError: Cannot read properties of null (reading 'isValid')

After:
dayjs.max(dayjs("1995-03-16"), null, dayjs("2023-03-16")).format()
---> 2023-03-16T00:00:00-03:00
```

- The second adjustment is when provided just one arg, instead of returning null, it returns the only given value.

Example:
```
Before this alteration:
dayjs.max(dayjs("1995-03-16"))
---> null

After:
dayjs.max(dayjs("1995-03-16"), null, dayjs("2023-03-16")).format()
---> 1995-03-16T00:00:00-03:00
```

I also added some tests to validate this propose.