### PR TITLE
fix: dayjs(null) throws error, not return dayjs object as invalid date

### DIFF
--- a/src/plugin/objectSupport/index.js
+++ b/src/plugin/objectSupport/index.js
@@ -1,6 +1,6 @@
 export default (o, c, dayjs) => {
   const proto = c.prototype
-  const isObject = obj => !(obj instanceof Date) && !(obj instanceof Array)
+  const isObject = obj => obj !== null && !(obj instanceof Date) && !(obj instanceof Array)
         && !proto.$utils().u(obj) && (obj.constructor.name === 'Object')
   const prettyUnit = (u) => {
     const unit = proto.$utils().p(u)

--- a/test/plugin/objectSupport.test.js
+++ b/test/plugin/objectSupport.test.js
@@ -140,6 +140,12 @@ it('Constructor from Object UTC', () => {
     expect(moment.utc(tests[i][0]).format(fmt)).toBe(result)
   }
 })
+
+it('Constructor from null should return Invalid Date', () => {
+  expect(dayjs(null).isValid()).toBe(false)
+  expect(moment(null).isValid()).toBe(false)
+})
+
 it('Set from Object', () => {
   for (let i = 0; i < tests.length; i += 1) {
     expect(dayjs(now).set(tests[i][0]).format(fmt)).toBe(moment(now).set(tests[i][0]).format(fmt))


### PR DESCRIPTION
fix: dayjs(null) throws error, not return dayjs object as invalid date #2095