### PR TITLE
fix: objectSupport plugin causes an error when null is passed to dayjs function (closes #2277)

### DIFF
--- a/src/plugin/objectSupport/index.js
+++ b/src/plugin/objectSupport/index.js
@@ -1,7 +1,7 @@
 export default (o, c, dayjs) => {
   const proto = c.prototype
   const isObject = obj => !(obj instanceof Date) && !(obj instanceof Array)
-        && !proto.$utils().u(obj) && (obj.constructor.name === 'Object')
+        && !proto.$utils().u(obj) && obj !== null && (obj.constructor.name === 'Object');
   const prettyUnit = (u) => {
     const unit = proto.$utils().p(u)
     return unit === 'date' ? 'day' : unit

--- a/src/plugin/objectSupport/index.js
+++ b/src/plugin/objectSupport/index.js
@@ -1,7 +1,7 @@
 export default (o, c, dayjs) => {
   const proto = c.prototype
   const isObject = obj => !(obj instanceof Date) && !(obj instanceof Array)
-        && !proto.$utils().u(obj) && obj !== null && (obj.constructor.name === 'Object');
+        && !proto.$utils().u(obj) && obj !== null && (obj.constructor.name === 'Object')
   const prettyUnit = (u) => {
     const unit = proto.$utils().p(u)
     return unit === 'date' ? 'day' : unit


### PR DESCRIPTION
This is a fix per #2277, discovered through usage with `twilio` npm package which has this same conflict.