### PR TITLE
fix: Add null to min and max return type

### DIFF
--- a/types/plugin/minMax.d.ts
+++ b/types/plugin/minMax.d.ts
@@ -4,8 +4,8 @@ declare const plugin: PluginFunc
 export = plugin
 
 declare module 'dayjs' {
-  export function max(dayjs: Dayjs[]): Dayjs
-  export function max(...dayjs: Dayjs[]): Dayjs
-  export function min(dayjs: Dayjs[]): Dayjs
-  export function min(...dayjs: Dayjs[]): Dayjs
+  export function max(dayjs: Dayjs[]): Dayjs | null
+  export function max(...dayjs: Dayjs[]): Dayjs | null
+  export function min(dayjs: Dayjs[]): Dayjs | null
+  export function min(...dayjs: Dayjs[]): Dayjs | null
 }


### PR DESCRIPTION
Currently `max` and `min` can return explicit `null` when there are no dates to compare ([see implementation](https://github.com/iamkun/dayjs/blob/dev/src/plugin/minMax/index.js#L9)).

This PR adds `null` to the return type of those functions. (I ended up with a crash on my project because I relied on the types)

