### PR TITLE
fix: duration plugin - MILLISECONDS_A_MONTH const calculation

### DIFF
--- a/src/plugin/duration/index.js
+++ b/src/plugin/duration/index.js
@@ -8,7 +8,7 @@ import {
 } from '../../constant'
 
 const MILLISECONDS_A_YEAR = MILLISECONDS_A_DAY * 365
-const MILLISECONDS_A_MONTH = MILLISECONDS_A_DAY * 30
+const MILLISECONDS_A_MONTH = MILLISECONDS_A_YEAR / 12
 
 const durationRegex = /^(-|\+)?P(?:([-+]?[0-9,.]*)Y)?(?:([-+]?[0-9,.]*)M)?(?:([-+]?[0-9,.]*)W)?(?:([-+]?[0-9,.]*)D)?(?:T(?:([-+]?[0-9,.]*)H)?(?:([-+]?[0-9,.]*)M)?(?:([-+]?[0-9,.]*)S)?)?$/
 

--- a/test/plugin/duration.test.js
+++ b/test/plugin/duration.test.js
@@ -85,8 +85,9 @@ describe('Parse ISO string', () => {
   it('ISO string with week', () => {
     const d = dayjs.duration('P2M3W4D')
     expect(d.toISOString()).toBe('P2M25D')
-    expect(d.asDays()).toBe(85) // moment 85, count 2M as 61 days
-    expect(d.asWeeks()).toBe(12.142857142857142) // moment 12.285714285714286
+    expect(d.asDays()).toBe(85.83333333333333) // moment 86, count 2M as 61 days
+    expect(d.asWeeks()).toBe(12.261904761904763) // moment 12.285714285714286
+    expect(d.asMonths()).toBe(2.8219178082191783) // moment 2.8213721020965523
   })
   it('Invalid ISO string', () => {
     expect(dayjs.duration('Invalid').toISOString()).toBe('P0D')


### PR DESCRIPTION
`MILLISECONDS_A_DAY * 30` will generate wrong value for a larger diffs, it's generating wrong durations for months

it should be either `MILLISECONDS_A_DAY * 30.416666666666668` (365 / 12) or `MILLISECONDS_A_YEAR / 12`

