### PR TITLE
fix: round durations to millisecond precision for ISO string

### DIFF
--- a/src/plugin/duration/index.js
+++ b/src/plugin/duration/index.js
@@ -139,7 +139,7 @@ class Duration {
 
     let seconds = this.$d.seconds || 0
     if (this.$d.milliseconds) {
-      seconds += this.$d.milliseconds / 1000
+      seconds += Math.round(this.$d.milliseconds) / 1000
     }
 
     const S = getNumberUnitFormat(seconds, 'S')

--- a/test/plugin/duration.test.js
+++ b/test/plugin/duration.test.js
@@ -70,6 +70,13 @@ describe('Creating', () => {
   it('convert to milliseconds', () => {
     expect(+dayjs.duration(100)).toBe(100)
   })
+  it('handles rounding to millisecond precision', () => {
+    expect(dayjs.duration(2 / 3).toISOString()).toBe('PT0.001S')
+  })
+  it('should handle round with millisecond precision when negative', () => {
+    expect(dayjs.duration(1000.5).toISOString()).toBe('PT1.001S')
+    expect(dayjs.duration(-1000.5).toISOString()).toBe('-PT1S')
+  })
 })
 
 describe('Parse ISO string', () => {


### PR DESCRIPTION
Fixes #2366 

Rounds the seconds value before formatting an ISO duration string