### PR TITLE
fix: duration plugin getter get result  0 instead of undefined

### DIFF
--- a/src/plugin/duration/index.js
+++ b/src/plugin/duration/index.js
@@ -198,7 +198,7 @@ class Duration {
     } else {
       base = this.$d[pUnit]
     }
-    return base === 0 ? 0 : base // a === 0 will be true on both 0 and -0
+    return !base ? 0 : base // a === 0 will be true on both 0 and -0
   }
 
   add(input, unit, isSubtract) {

--- a/src/plugin/duration/index.js
+++ b/src/plugin/duration/index.js
@@ -198,7 +198,7 @@ class Duration {
     } else {
       base = this.$d[pUnit]
     }
-    return !base ? 0 : base // a === 0 will be true on both 0 and -0
+    return base || 0 // a === 0 will be true on both 0 and -0
   }
 
   add(input, unit, isSubtract) {

--- a/test/plugin/duration.test.js
+++ b/test/plugin/duration.test.js
@@ -186,6 +186,12 @@ describe('Add', () => {
   expect(a.add({ days: 5 }).days()).toBe(6)
 })
 
+describe('Add to a dayjs()', () => {
+  const a = dayjs()
+  const b = dayjs.duration({ hours: 7, minutes: 10 })
+  expect(a.add(b)).toEqual(a.add(7, 'hours').add(10, 'minutes'))
+})
+
 test('Add duration', () => {
   const a = dayjs('2020-10-01')
   const days = dayjs.duration(2, 'days')


### PR DESCRIPTION
fix #2364