### PR TITLE
feat: add relative time to localedata plugin

### DIFF
--- a/src/plugin/localeData/index.js
+++ b/src/plugin/localeData/index.js
@@ -30,6 +30,7 @@ export default (o, c, dayjs) => { // locale needed later
         (instance ? instance.format('ddd') : getShort(this, 'weekdaysShort', 'weekdays', 3)),
       longDateFormat: format => getLongDateFormat(this.$locale(), format),
       meridiem: this.$locale().meridiem,
+      relativeTime: this.$locale().relativeTime,
       ordinal: this.$locale().ordinal
     }
   }
@@ -48,6 +49,7 @@ export default (o, c, dayjs) => { // locale needed later
       monthsShort: () => dayjs.monthsShort(),
       longDateFormat: format => getLongDateFormat(localeObject, format),
       meridiem: localeObject.meridiem,
+      relativeTime: localeObject.relativeTime,
       ordinal: localeObject.ordinal
     }
   }

--- a/test/plugin/localeData.test.js
+++ b/test/plugin/localeData.test.js
@@ -111,6 +111,13 @@ it('meridiem', () => {
   dayjs.locale('en')
 })
 
+it('relativeTime', () => {
+  dayjs.locale('zh-cn')
+  expect(typeof dayjs.localeData().relativeTime).toEqual('object')
+  expect(typeof dayjs().localeData().relativeTime).toEqual('object')
+  dayjs.locale('en')
+})
+
 it('ordinal', () => {
   dayjs.locale('zh-cn')
   expect(typeof dayjs.localeData().ordinal).toEqual('function')

--- a/types/plugin/localeData.d.ts
+++ b/types/plugin/localeData.d.ts
@@ -16,6 +16,21 @@ declare module 'dayjs' {
     monthsShort(instance?: Dayjs): MonthNames;
     longDateFormat(format: string): string;
     meridiem(hour?: number, minute?: number, isLower?: boolean): string;
+    relativeTime: Partial<{
+      future: string
+      past: string
+      s: string
+      m: string
+      mm: string
+      h: string
+      hh: string
+      d: string
+      dd: string
+      M: string
+      MM: string
+      y: string
+      yy: string
+    }>
     ordinal(n: number): string
   }
 
@@ -28,6 +43,21 @@ declare module 'dayjs' {
     monthsShort(): MonthNames;
     longDateFormat(format: string): string;
     meridiem(hour?: number, minute?: number, isLower?: boolean): string;
+    relativeTime: Partial<{
+      future: string
+      past: string
+      s: string
+      m: string
+      mm: string
+      h: string
+      hh: string
+      d: string
+      dd: string
+      M: string
+      MM: string
+      y: string
+      yy: string
+    }>
     ordinal(n: number): string
   }
 


### PR DESCRIPTION
I'd to be able to use relativeTime in localeData objects, this seems like a relatively easy path here to do so. 