### PR TITLE
fix: fix isDayjs check logic

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -6,7 +6,10 @@ let L = 'en' // global locale
 const Ls = {} // global loaded locale
 Ls[L] = en
 
-const isDayjs = d => d instanceof Dayjs // eslint-disable-line no-use-before-define
+const IS_DAYJS = '$isDayjsObject'
+
+// eslint-disable-next-line no-use-before-define
+const isDayjs = d => d instanceof Dayjs || !!((d || {})[IS_DAYJS])
 
 const parseLocale = (preset, object, isLocal) => {
   let l
@@ -72,7 +75,7 @@ const parseDate = (cfg) => {
           || 1, d[4] || 0, d[5] || 0, d[6] || 0, ms))
       }
       return new Date(d[1], m, d[3]
-          || 1, d[4] || 0, d[5] || 0, d[6] || 0, ms)
+        || 1, d[4] || 0, d[5] || 0, d[6] || 0, ms)
     }
   }
 
@@ -83,6 +86,7 @@ class Dayjs {
   constructor(cfg) {
     this.$L = parseLocale(cfg.locale, null, true)
     this.parse(cfg) // for plugin
+    this[IS_DAYJS] = true
   }
 
   parse(cfg) {

--- a/src/index.js
+++ b/src/index.js
@@ -9,7 +9,7 @@ Ls[L] = en
 const IS_DAYJS = '$isDayjsObject'
 
 // eslint-disable-next-line no-use-before-define
-const isDayjs = d => d instanceof Dayjs || (d && d[IS_DAYJS])
+const isDayjs = d => d instanceof Dayjs || !!(d && d[IS_DAYJS])
 
 const parseLocale = (preset, object, isLocal) => {
   let l

--- a/src/index.js
+++ b/src/index.js
@@ -9,7 +9,7 @@ Ls[L] = en
 const IS_DAYJS = '$isDayjsObject'
 
 // eslint-disable-next-line no-use-before-define
-const isDayjs = d => d instanceof Dayjs || !!((d || {})[IS_DAYJS])
+const isDayjs = d => d instanceof Dayjs || (d && d[IS_DAYJS])
 
 const parseLocale = (preset, object, isLocal) => {
   let l

--- a/test/constructor.test.js
+++ b/test/constructor.test.js
@@ -13,6 +13,13 @@ it('supports instanceof dayjs', () => {
   expect(dayjs() instanceof dayjs).toBeTruthy()
 })
 
+it('$isDayjsObject', () => {
+  const mockOtherVersionDayjsObj = {
+    $isDayjsObject: true
+  }
+  expect(dayjs.isDayjs(mockOtherVersionDayjsObj)).toBeTruthy()
+})
+
 it('does not break isDayjs', () => {
   expect(dayjs.isDayjs(dayjs())).toBeTruthy()
 })

--- a/test/constructor.test.js
+++ b/test/constructor.test.js
@@ -22,4 +22,5 @@ it('$isDayjsObject', () => {
 
 it('does not break isDayjs', () => {
   expect(dayjs.isDayjs(dayjs())).toBeTruthy()
+  expect(dayjs.isDayjs(new Date())).toBeFalsy()
 })


### PR DESCRIPTION
ref: https://github.com/moment/moment/blob/develop/src/lib/moment/constructor.js#L78

`isDayjs` should return `true` in different versions of dayjs.