### PR TITLE
Change ku to ckb locale

### DIFF
--- a/src/locale/ckb.js
+++ b/src/locale/ckb.js
@@ -1,0 +1,92 @@
+// Central Kurdish [ckb]
+import dayjs from 'dayjs'
+
+export const englishToArabicNumbersMap = {
+  1: '١',
+  2: '٢',
+  3: '٣',
+  4: '٤',
+  5: '٥',
+  6: '٦',
+  7: '٧',
+  8: '٨',
+  9: '٩',
+  0: '٠'
+}
+
+const arabicToEnglishNumbersMap = {
+  '١': '1',
+  '٢': '2',
+  '٣': '3',
+  '٤': '4',
+  '٥': '5',
+  '٦': '6',
+  '٧': '7',
+  '٨': '8',
+  '٩': '9',
+  '٠': '0'
+}
+
+const months = [
+  'کانوونی دووەم',
+  'شوبات',
+  'ئادار',
+  'نیسان',
+  'ئایار',
+  'حوزەیران',
+  'تەممووز',
+  'ئاب',
+  'ئەیلوول',
+  'تشرینی یەکەم',
+  'تشرینی دووەم',
+  'کانوونی یەکەم'
+]
+
+const locale = {
+  name: 'ckb',
+  months,
+  monthsShort: months,
+  weekdays: 'یەکشەممە_دووشەممە_سێشەممە_چوارشەممە_پێنجشەممە_هەینی_شەممە'.split('_'),
+  weekdaysShort: 'یەکشەم_دووشەم_سێشەم_چوارشەم_پێنجشەم_هەینی_شەممە'.split('_'),
+  weekStart: 6,
+  weekdaysMin: 'ی_د_س_چ_پ_هـ_ش'.split('_'),
+  preparse(string) {
+    return string
+      .replace(/[١٢٣٤٥٦٧٨٩٠]/g, match => arabicToEnglishNumbersMap[match])
+      .replace(/،/g, ',')
+  },
+  postformat(string) {
+    return string
+      .replace(/\d/g, match => englishToArabicNumbersMap[match])
+      .replace(/,/g, '،')
+  },
+  ordinal: n => n,
+  formats: {
+    LT: 'HH:mm',
+    LTS: 'HH:mm:ss',
+    L: 'DD/MM/YYYY',
+    LL: 'D MMMM YYYY',
+    LLL: 'D MMMM YYYY HH:mm',
+    LLLL: 'dddd, D MMMM YYYY HH:mm'
+  },
+  meridiem: hour => (hour < 12 ? 'پ.ن' : 'د.ن'),
+  relativeTime: {
+    future: 'لە %s',
+    past: 'لەمەوپێش %s',
+    s: 'چەند چرکەیەک',
+    m: 'یەک خولەک',
+    mm: '%d خولەک',
+    h: 'یەک کاتژمێر',
+    hh: '%d کاتژمێر',
+    d: 'یەک ڕۆژ',
+    dd: '%d ڕۆژ',
+    M: 'یەک مانگ',
+    MM: '%d مانگ',
+    y: 'یەک ساڵ',
+    yy: '%d ساڵ'
+  }
+}
+
+dayjs.locale(locale, null, true)
+
+export default locale


### PR DESCRIPTION
Hey there!

I'm opening this PR to add `ckb` locale to the list of supported locales. 

**Why?**
The Kurdish language has a variety of dialects, leading to inconsistencies in many packages. The `ku` locale, for instance, might represent Central Kurdish translation in one package, but in another package, it could be Northern or Southern Kurdish. These dialect differences are significant and could result in unintentional selection of the locale.

Therefore, this pull request proposes a consistent [CLDR](https://cldr.unicode.org/index) locale code by duplicating the existing `ku` locale, which represents Central Kurdish translation, into its own designated locale code.

**Note:** I chose to not delete `ku` locale since some people might still use this in their projects. But in the future, people could reserve this locale for another Kurdish dialect translation.

Thank you! 

**References:**
- [Picking the right language identifier by Unicode CLDR](https://cldr.unicode.org/index/cldr-spec/picking-the-right-language-code)
- [CKB in Ethnologue](https://www.ethnologue.com/language/ckb/)
- [CKB in ISO 639-3](https://iso639-3.sil.org/code/ckb)