### PR TITLE
fix: preserve locality when using timezone plugin methods

### DIFF
--- a/src/plugin/timezone/index.js
+++ b/src/plugin/timezone/index.js
@@ -97,7 +97,7 @@ export default (o, c, d) => {
     const date = this.toDate()
     const target = date.toLocaleString('en-US', { timeZone: timezone })
     const diff = Math.round((date - new Date(target)) / 1000 / 60)
-    let ins = d(target).$set(MS, this.$ms)
+    let ins = d(target, { locale: this.$L }).$set(MS, this.$ms)
       .utcOffset((-Math.round(date.getTimezoneOffset() / 15) * 15) - diff, true)
     if (keepLocalTime) {
       const newOffset = ins.utcOffset()
@@ -120,7 +120,7 @@ export default (o, c, d) => {
       return oldStartOf.call(this, units, startOf)
     }
 
-    const withoutTz = d(this.format('YYYY-MM-DD HH:mm:ss:SSS'))
+    const withoutTz = d(this.format('YYYY-MM-DD HH:mm:ss:SSS'), { locale: this.$L })
     const startOfWithoutTz = oldStartOf.call(withoutTz, units, startOf)
     return startOfWithoutTz.tz(this.$x.$timezone, true)
   }

--- a/test/plugin/timezone.test.js
+++ b/test/plugin/timezone.test.js
@@ -318,4 +318,15 @@ describe('startOf and endOf', () => {
     const endOfDay = originalDay.endOf('day')
     expect(endOfDay.valueOf()).toEqual(originalDay.valueOf())
   })
+
+  it('preserves locality when tz is called', () => {
+    const tzWithoutLocality = dayjs.tz('2023-02-17 00:00:00', NY)
+    const tzWithLocality = dayjs.tz('2023-02-17 00:00:00', NY).locale({
+      name: 'locale_test',
+      weekStart: 3
+    })
+
+    expect(tzWithoutLocality.startOf('week').format('YYYY-MM-DD')).toEqual('2023-02-12')
+    expect(tzWithLocality.startOf('week').format('YYYY-MM-DD')).toEqual('2023-02-15')
+  })
 })


### PR DESCRIPTION
Fixes #2398 

Not entirely sure if this needs to be added below, to the non-prototype methods. I'm not familiar with this codebase but happy to make changes as needed to this PR.