### PR TITLE
Fixed issue #2428

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -86,12 +86,12 @@ class Dayjs {
   constructor(cfg) {
     this.$L = parseLocale(cfg.locale, null, true)
     this.parse(cfg) // for plugin
+    this.$x = this.$x || cfg.x || {}
     this[IS_DAYJS] = true
   }
 
   parse(cfg) {
     this.$d = parseDate(cfg)
-    this.$x = cfg.x || {}
     this.init()
   }
 


### PR DESCRIPTION
Move the initialization of the $x attribute to after the parse method so it won't be affected by other plugins

fix #2428