### PR TITLE
Add support for ASP.NET style time spans

### DIFF
--- a/src/plugin/duration/index.js
+++ b/src/plugin/duration/index.js
@@ -11,6 +11,8 @@ const MILLISECONDS_A_YEAR = MILLISECONDS_A_DAY * 365
 const MILLISECONDS_A_MONTH = MILLISECONDS_A_YEAR / 12
 
 const durationRegex = /^(-|\+)?P(?:([-+]?[0-9,.]*)Y)?(?:([-+]?[0-9,.]*)M)?(?:([-+]?[0-9,.]*)W)?(?:([-+]?[0-9,.]*)D)?(?:T(?:([-+]?[0-9,.]*)H)?(?:([-+]?[0-9,.]*)M)?(?:([-+]?[0-9,.]*)S)?)?$/
+const durationAspNetStyleRegex = /(\d+)?\.?\s?(\d{2}):(\d{2}):?(\d{2})?\.?(\d{1,3})?$/
+
 
 const unitToMS = {
   years: MILLISECONDS_A_YEAR,
@@ -82,6 +84,7 @@ class Duration {
     }
     if (typeof input === 'string') {
       const d = input.match(durationRegex)
+      const durationAspNetStyle = input.match(durationAspNetStyleRegex)
       if (d) {
         const properties = d.slice(2)
         const numberD = properties.map(value => (value != null ? Number(value) : 0));
@@ -93,6 +96,20 @@ class Duration {
           this.$d.hours,
           this.$d.minutes,
           this.$d.seconds
+        ] = numberD
+        this.calMilliseconds()
+        return this
+      }
+
+      if (durationAspNetStyle) {
+        const properties = durationAspNetStyle.slice(1)
+        const numberD = properties.map(value => (value != null ? Number(value) : 0));
+        [
+          this.$d.days,
+          this.$d.hours,
+          this.$d.minutes,
+          this.$d.seconds,
+          this.$d.milliseconds
         ] = numberD
         this.calMilliseconds()
         return this

--- a/test/plugin/duration.test.js
+++ b/test/plugin/duration.test.js
@@ -309,3 +309,64 @@ describe('Format', () => {
       .toBe('2/02.0002TEST9:09:6:06:8:08:5:05:1:01:010')
   })
 })
+
+describe('Parse ASP.NET style time spans', () => {
+  it('Full ASP.NET style string', () => {
+    const d = dayjs.duration('2.01:01:01.100')
+    expect(d.toISOString()).toBe('P2DT1H1M1.1S')
+
+    expect(d.days()).toBe(2)
+    expect(d.hours()).toBe(1)
+    expect(d.minutes()).toBe(1)
+    expect(d.seconds()).toBe(1)
+    expect(d.milliseconds()).toBe(100)
+  })
+
+  it('Full ASP.NET style string with space separator for days', () => {
+    const d = dayjs.duration('2 01:01:01.100')
+    expect(d.toISOString()).toBe('P2DT1H1M1.1S')
+
+    expect(d.days()).toBe(2)
+    expect(d.hours()).toBe(1)
+    expect(d.minutes()).toBe(1)
+    expect(d.seconds()).toBe(1)
+    expect(d.milliseconds()).toBe(100)
+  })
+
+  it('Hours, minutes', () => {
+    const d = dayjs.duration('01:01')
+    expect(d.toISOString()).toBe('PT1H1M')
+
+    expect(d.days()).toBe(0)
+    expect(d.hours()).toBe(1)
+    expect(d.minutes()).toBe(1)
+    expect(d.seconds()).toBe(0)
+    expect(d.milliseconds()).toBe(0)
+  })
+
+  it('Hours, minutes, seconds', () => {
+    const d = dayjs.duration('01:01:02')
+    expect(d.toISOString()).toBe('PT1H1M2S')
+
+    expect(d.days()).toBe(0)
+    expect(d.hours()).toBe(1)
+    expect(d.minutes()).toBe(1)
+    expect(d.seconds()).toBe(2)
+    expect(d.milliseconds()).toBe(0)
+  })
+
+  it('Hours, minutes, seconds, milliseconds', () => {
+    const d = dayjs.duration('01:01:02.999')
+    expect(d.toISOString()).toBe('PT1H1M2.999S')
+
+    expect(d.days()).toBe(0)
+    expect(d.hours()).toBe(1)
+    expect(d.minutes()).toBe(1)
+    expect(d.seconds()).toBe(2)
+    expect(d.milliseconds()).toBe(999)
+  })
+
+  it('Invalid ISO string', () => {
+    expect(dayjs.duration('Invalid').toISOString()).toBe('P0D')
+  })
+})


### PR DESCRIPTION
The goal of this PR is to extend the **Duration** plugin so that it will support parsing strings in ASP.NET style time spans.

It can now parse the string in the following formats:
- dayjs.duration('2.01:01:01.100')
- dayjs.duration('2 01:01:01.100')
- dayjs.duration('01:01:01.100')
- dayjs.duration('01:01:01') 
- dayjs.duration('01:01')

_The format is an hour, minute, second string separated by colons like 23:59:59. The number of days can be prefixed with a dot or space separator like 7.23:59:59 or 7 23:59:59. Partial seconds are supported as well 23:59:59.999._

As of version 2.1.0, `momentjs` supports this format https://momentjs.com/docs/#/durations/:~:text=As%20of%202.1.0%2C%20moment%20supports%20parsing%20ASP.NET%20style%20time%20spans.%20The%20following%20formats%20are%20supported.