### PR TITLE
[bug] Fix `startOf` with active timezone/UTC

### DIFF
--- a/src/plugin/timezone/index.js
+++ b/src/plugin/timezone/index.js
@@ -114,17 +114,6 @@ export default (o, c, d) => {
     return result && result.value
   }
 
-  const oldStartOf = proto.startOf
-  proto.startOf = function (units, startOf) {
-    if (!this.$x || !this.$x.$timezone) {
-      return oldStartOf.call(this, units, startOf)
-    }
-
-    const withoutTz = d(this.format('YYYY-MM-DD HH:mm:ss:SSS'), { locale: this.$L })
-    const startOfWithoutTz = oldStartOf.call(withoutTz, units, startOf)
-    return startOfWithoutTz.tz(this.$x.$timezone, true)
-  }
-
   d.tz = function (input, arg1, arg2) {
     const parseFormat = arg2 && arg1
     const timezone = arg2 || arg1 || defaultTimezone

--- a/test/timezone.test.js
+++ b/test/timezone.test.js
@@ -80,3 +80,44 @@ it('UTC diff in DST', () => {
   expect(day1.diff(day2, 'd'))
     .toBe(-3)
 })
+
+it('startOf("month") returns correct value with active Timezone', () => {
+  // 2023-08-01T00:00:00Z
+  const initial = 1692050400000
+  const month1 = dayjs.utc(initial).startOf('month')
+  const month2 = dayjs(initial).tz('UTC').startOf('month')
+  const month3 = dayjs(initial).tz('Africa/Abidjan').startOf('month')
+  // 2023-08-01T00:00:00+02:00
+  const month4 = dayjs(initial).tz('Europe/Berlin').startOf('month')
+  // 2023-08-01T00:00:00-05:00
+  const month5 = dayjs(initial).tz('America/Cancun').startOf('month')
+
+  expect(month1.format()).toEqual('2023-08-01T00:00:00Z')
+  expect(month2.format()).toEqual('2023-08-01T00:00:00Z')
+  expect(month3.format()).toEqual('2023-08-01T00:00:00Z')
+  expect(month4.format()).toEqual('2023-08-01T00:00:00+02:00')
+  expect(month5.format()).toEqual('2023-08-01T00:00:00-05:00')
+})
+
+it('startOf("day") returns correct value with active Timezone', () => {
+  // initial date = 2023-08-15T12:00:00Z
+  const initial = 1692100800000
+  // should return the same day
+  const day1 = dayjs(initial).tz('UTC').startOf('day')
+  const day2 = dayjs(initial).tz('Africa/Abidjan').startOf('day')
+  const day3 = dayjs(initial).tz('Europe/Berlin').startOf('day')
+  const day4 = dayjs(initial).tz('America/Cancun').startOf('day')
+
+  expect(day1.format()).toEqual('2023-08-15T00:00:00Z')
+  expect(day2.format()).toEqual('2023-08-15T00:00:00Z')
+  expect(day3.format()).toEqual('2023-08-15T00:00:00+02:00')
+  expect(day4.format()).toEqual('2023-08-15T00:00:00-05:00')
+
+  // switching days when hours are close to the timezone-offset
+  const day5 = dayjs(initial).hour(23).tz('Europe/Berlin').startOf('day') // 2023-08-15T23:00:00Z
+  const day6 = dayjs(initial).hour(4).tz('America/Cancun').startOf('day') // 2023-08-15T04:00:00Z
+
+
+  expect(day5.format()).toEqual('2023-08-16T00:00:00+02:00')
+  expect(day6.format()).toEqual('2023-08-14T00:00:00-05:00')
+})


### PR DESCRIPTION
The overloaded `startOf` function did call the `tz` function again which resulted in a duplicate subtraction of the timezone offset.

Simply removing it did yield the correct values in all cases I did encounter.

I did also add some tests so that the coverage stays up! 👍🏼 

Fixes #2373 and #2303 