### PR TITLE
fix wrong time when using .utcOffSet() multiple times

### DIFF
--- a/src/plugin/utc/index.js
+++ b/src/plugin/utc/index.js
@@ -96,7 +96,7 @@ export default (option, Dayjs, dayjs) => {
     if (input !== 0) {
       const localTimezoneOffset = this.$u
         ? this.toDate().getTimezoneOffset() : -1 * this.utcOffset()
-      ins = this.local().add(offset + localTimezoneOffset, MIN)
+      ins = this.add(offset + localTimezoneOffset, MIN)
       ins.$offset = offset
       ins.$x.$localOffset = localTimezoneOffset
     } else {


### PR DESCRIPTION
if you use dayjs().utcOffSet(-6).utcOffSet(-6) ... it will give you wrong time due the offset minutes were always added from utc time and not the current time