### PR TITLE
fix: .utcOffset(0, true) result and its clone are different

### DIFF
--- a/src/plugin/utc/index.js
+++ b/src/plugin/utc/index.js
@@ -87,21 +87,25 @@ export default (option, Dayjs, dayjs) => {
       }
     }
     const offset = Math.abs(input) <= 16 ? input * 60 : input
-    let ins = this
+
+    if (offset === 0) {
+      return this.utc(keepLocalTime)
+    }
+
+    let ins = this.clone()
+
     if (keepLocalTime) {
       ins.$offset = offset
-      ins.$u = input === 0
+      ins.$u = false
       return ins
     }
-    if (input !== 0) {
-      const localTimezoneOffset = this.$u
-        ? this.toDate().getTimezoneOffset() : -1 * this.utcOffset()
-      ins = this.local().add(offset + localTimezoneOffset, MIN)
-      ins.$offset = offset
-      ins.$x.$localOffset = localTimezoneOffset
-    } else {
-      ins = this.utc()
-    }
+
+    const localTimezoneOffset = this.$u
+      ? this.toDate().getTimezoneOffset() : -1 * this.utcOffset()
+    ins = this.local().add(offset + localTimezoneOffset, MIN)
+    ins.$offset = offset
+    ins.$x.$localOffset = localTimezoneOffset
+    
     return ins
   }
 

--- a/test/plugin/utc-utcOffset.test.js
+++ b/test/plugin/utc-utcOffset.test.js
@@ -149,3 +149,21 @@ test('utc startOf', () => {
   expect(d2d)
     .toBe(1500465600000)
 })
+
+test('cloning dates modified with utcOffset', () => {
+  const djs = dayjs('2023-10-29T00:00:00+03:00')
+
+  const tests = [
+    djs,
+    djs.utcOffset(-240),
+    djs.utcOffset(-240, true),
+    djs.utcOffset(120),
+    djs.utcOffset(120, true),
+    djs.utcOffset(0),
+    djs.utcOffset(0, true)
+  ]
+
+  tests.forEach((d) => {
+    expect(dayjs(d).format()).toEqual(d.format())
+  })
+})


### PR DESCRIPTION
Actually `.utcOffset(0, flag)` is the same as `.utc(flag)` but `.utcOffset` with `keepLocalTime = true` didn't modify the internal date accordingly. That caused a bug described in #2501

Fixed `.utcOffset` by returning `.utc(keepLocalTime)` if passed offset is zero.

Added some tests to cover possible mismatches.