### PR TITLE
fix(sec): upgrade moment-timezone to 0.5.35

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,7 @@
         "karma-sauce-launcher": "^1.1.0",
         "mockdate": "^2.0.2",
         "moment": "2.29.2",
-        "moment-timezone": "0.5.31",
+        "moment-timezone": "0.5.35",
         "ncp": "^2.0.0",
         "pre-commit": "^1.2.2",
         "prettier": "^1.16.1",
@@ -10773,9 +10773,9 @@
       }
     },
     "node_modules/moment-timezone": {
-      "version": "0.5.31",
-      "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.31.tgz",
-      "integrity": "sha512-+GgHNg8xRhMXfEbv81iDtrVeTcWt0kWmTEY1XQK14dICTXnWJnT0dxdlPspwqF3keKMVPXwayEsk1DI0AA/jdA==",
+      "version": "0.5.35",
+      "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.35.tgz",
+      "integrity": "sha512-cY/pBOEXepQvlgli06ttCTKcIf8cD1nmNwOKQQAdHBqYApQSpAqotBMX0RJZNgMp6i0PlZuf1mFtnlyEkwyvFw==",
       "dev": true,
       "dependencies": {
         "moment": ">= 2.9.0"
@@ -26355,9 +26355,9 @@
       "dev": true
     },
     "moment-timezone": {
-      "version": "0.5.31",
-      "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.31.tgz",
-      "integrity": "sha512-+GgHNg8xRhMXfEbv81iDtrVeTcWt0kWmTEY1XQK14dICTXnWJnT0dxdlPspwqF3keKMVPXwayEsk1DI0AA/jdA==",
+      "version": "0.5.35",
+      "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.35.tgz",
+      "integrity": "sha512-cY/pBOEXepQvlgli06ttCTKcIf8cD1nmNwOKQQAdHBqYApQSpAqotBMX0RJZNgMp6i0PlZuf1mFtnlyEkwyvFw==",
       "dev": true,
       "requires": {
         "moment": ">= 2.9.0"

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "karma-sauce-launcher": "^1.1.0",
     "mockdate": "^2.0.2",
     "moment": "2.29.2",
-    "moment-timezone": "0.5.31",
+    "moment-timezone": "0.5.35",
     "ncp": "^2.0.0",
     "pre-commit": "^1.2.2",
     "prettier": "^1.16.1",


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in moment-timezone 0.5.31
- [MPS-2022-56430](https://www.oscs1024.com/hd/MPS-2022-56430)


### What did I do？
Upgrade moment-timezone from 0.5.31 to 0.5.35 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### How can we automate the detection of these types of issues?
By using the [GitHub Actions](https://github.com/murphysecurity/actions) configurations provided by murphysec, we can conduct automatic code security checks in our CI pipeline.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS