### PR TITLE
fix: correctly parse years between 0 and 99. fixes #2550

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -70,12 +70,27 @@ const parseDate = (cfg) => {
     if (d) {
       const m = d[2] - 1 || 0
       const ms = (d[7] || '0').substring(0, 3)
+
+      let r
       if (utc) {
-        return new Date(Date.UTC(d[1], m, d[3]
+        r = new Date(Date.UTC(d[1], m, d[3]
           || 1, d[4] || 0, d[5] || 0, d[6] || 0, ms))
+
+        if (d[1] >= 0 && d[1] <= 99) {
+          r.setUTCFullYear(d[1])
+        }
+
+        return r
       }
-      return new Date(d[1], m, d[3]
+
+      r = new Date(d[1], m, d[3]
         || 1, d[4] || 0, d[5] || 0, d[6] || 0, ms)
+
+      if (d[1] >= 0 && d[1] <= 99) {
+        r.setFullYear(d[1])
+      }
+
+      return r
     }
   }
 

--- a/test/parse.test.js
+++ b/test/parse.test.js
@@ -212,4 +212,24 @@ describe('REGEX_PARSE', () => {
     expect(dayjs(date).valueOf()).toBe(moment(date).valueOf())
     expect(d).toBe(null)
   })
+
+  it('0022-01-01', () => {
+    const date = '0022-01-01'
+    expect(dayjs(date).get('year')).toBe(22)
+  })
+
+  it('0000-01-01', () => {
+    const date = '0000-01-01'
+    expect(dayjs(date).get('year')).toBe(0)
+  })
+
+  it('0099-01-01', () => {
+    const date = '0099-01-01'
+    expect(dayjs(date).get('year')).toBe(99)
+  })
+
+  it('0777-01-01', () => {
+    const date = '0777-01-01'
+    expect(dayjs(date).get('year')).toBe(777)
+  })
 })

--- a/test/plugin/utc.test.js
+++ b/test/plugin/utc.test.js
@@ -102,6 +102,12 @@ describe('Parse UTC ', () => {
     expect(ds.valueOf()).toEqual(ms.valueOf())
     expect(ds.millisecond()).toEqual(ms.millisecond())
   })
+
+  it('parses 0022-01-01', () => {
+    const date = '0022-01-01'
+
+    expect(dayjs(date, { utc: true }).get('year')).toBe(22)
+  })
 })
 
 it('Clone retains the UTC mode', () => {


### PR DESCRIPTION
In the related issue, `dayjs('0099-11-11').get('year')` gets `1999` instead of `99`.

However, in vanilla `Date`, it parses it correctly: `new Date('0099-01-01').getUTCFullYear() === 99`.

The reason lies in how we create the underlying `Date` object.

In `new Date()` of `parseDate`, when the first parameter is less than 99 and greater than 0, according to MDN:

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date#date_components_and_time_zones

> Note: Some methods, including the Date() constructor, Date.UTC(), and the deprecated [getYear()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/getYear)/[setYear()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/setYear) methods, interpret a two-digit year as a year in the 1900s. For example, new Date(99, 5, 24) is interpreted as June 24, 1999, not June 24, 99. See [Interpretation of two-digit years](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date#interpretation_of_two-digit_years) for more information.

When `d[1]` is between 0 and 99, the year is interpreted as `1900 + d[1]`, thus we get `1999` instead of `99`.

```js
new Date(d[1], m, d[3]
        || 1, d[4] || 0, d[5] || 0, d[6] || 0, ms)
```

To fix this, I don't think it is possible to create a `Date` object with the correct year directly, so I add one line to the year correctly. This is a little ugly, and better ideas welcome.