### PR TITLE
Fix: Improve typing for min/max

### DIFF
--- a/types/plugin/minMax.d.ts
+++ b/types/plugin/minMax.d.ts
@@ -4,8 +4,19 @@ declare const plugin: PluginFunc
 export = plugin
 
 declare module 'dayjs' {
-  export function max(dayjs: Dayjs[]): Dayjs | null
-  export function max(...dayjs: Dayjs[]): Dayjs | null
-  export function min(dayjs: Dayjs[]): Dayjs | null
-  export function min(...dayjs: Dayjs[]): Dayjs | null
+  export function max(dayjs: [Dayjs, ...Dayjs[]]): Dayjs
+  export function max(noDates: never[]): null
+  export function max(maybeDates: Dayjs[]): Dayjs | null
+
+  export function max(...dayjs: [Dayjs, ...Dayjs[]]): Dayjs
+  export function max(...noDates: never[]): null
+  export function max(...maybeDates: Dayjs[]): Dayjs | null
+
+  export function min(dayjs: [Dayjs, ...Dayjs[]]): Dayjs
+  export function min(noDates: never[]): null
+  export function min(maybeDates: Dayjs[]): Dayjs | null
+
+  export function min(...dayjs: [Dayjs, ...Dayjs[]]): Dayjs
+  export function min(...noDates: never[]): null
+  export function min(...maybeDates: Dayjs[]): Dayjs | null
 }


### PR DESCRIPTION
I think it's good to be clear that `null` can be returned from `min`/`max`, but TypeScript is powerful enough to be even smarter about this. This PR updates the types so that at least _obvious_ scenarios where at least one date is passed don't then require `!` or other code smells.

As with all types as they get more complex, it's easy to miss things or forget scenarios. Please let me know if I've missed anything.

I wouldn't actually consider this a "fix" so much as an _improvement on existing types_ but I don't think it's a feature and since the prior revision was marked as a fix, I'm keeping in line with that change.