### PR TITLE
Handle the invalid date the same way moment.js does, with and without the utc plugin

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -420,7 +420,7 @@ class Dayjs {
     // ie 8 return
     // new Dayjs(this.valueOf() + this.$d.getTimezoneOffset() * 60000)
     // .format('YYYY-MM-DDTHH:mm:ss.SSS[Z]')
-    return this.$d.toISOString()
+    return this.isValid() ? this.$d.toISOString() : null
   }
 
   toString() {

--- a/src/plugin/utc/index.js
+++ b/src/plugin/utc/index.js
@@ -123,7 +123,7 @@ export default (option, Dayjs, dayjs) => {
   }
 
   proto.toISOString = function () {
-    return this.toDate().toISOString()
+    return this.isValid() ? this.toDate().toISOString() : null
   }
 
   proto.toString = function () {

--- a/test/parse.test.js
+++ b/test/parse.test.js
@@ -100,6 +100,20 @@ describe('Parse', () => {
     expect(dayjs('otherString').isValid()).toBe(false)
     expect(dayjs(null).toString().toLowerCase()).toBe(moment(null).toString().toLowerCase())
   })
+
+  describe('Handles an invalid date in the same way that moment.js does', () => {
+    it('returns null for invalid date', () => {
+      expect(JSON.stringify({ date: dayjs('invalid') })).toEqual(JSON.stringify({ date: null }))
+    })
+
+    it('returns string "Invalid Date" when calling toString', () => {
+      expect(JSON.stringify({ date: dayjs('invalid').toString() })).toEqual(JSON.stringify({ date: 'Invalid Date' }))
+    })
+
+    it('returns null when calling toISOString', () => {
+      expect(JSON.stringify({ date: dayjs('invalid').toISOString() })).toEqual(JSON.stringify({ date: null }))
+    })
+  })
 })
 
 it('Unix Timestamp Number (milliseconds) 1523520536000', () => {

--- a/test/plugin/utc.test.js
+++ b/test/plugin/utc.test.js
@@ -348,3 +348,9 @@ it('utc keepLocalTime', () => {
 it('utc diff undefined edge case', () => {
   expect(dayjs().diff(undefined, 'seconds')).toBeDefined()
 })
+
+describe('Handles an invalid date in the same way that moment.js does', () => {
+  it('returns null when calling toISOString', () => {
+    expect(dayjs('invalid').toISOString()).toBeNull()
+  })
+})


### PR DESCRIPTION
The goal of this PR is to provide consistent behavior compared to moment js.

In momentjs the `dayjs('invalid').toISOString()` -> returns `null`

But in dayjs the `dayjs('invalid').toISOString()` -> throws an error 
The desired behavior is to also return `null`.

The PR changes apply to both cases, whether you use the `utc` plugin or not