### PR TITLE
Update 'da' locale to match correct first week of year

### DIFF
--- a/src/locale/da.js
+++ b/src/locale/da.js
@@ -9,6 +9,7 @@ const locale = {
   months: 'januar_februar_marts_april_maj_juni_juli_august_september_oktober_november_december'.split('_'),
   monthsShort: 'jan._feb._mar._apr._maj_juni_juli_aug._sept._okt._nov._dec.'.split('_'),
   weekStart: 1,
+  yearStart: 4,
   ordinal: n => `${n}.`,
   formats: {
     LT: 'HH:mm',


### PR DESCRIPTION
The first week of the year in Denmark is always the week containing January 4th