### PR TITLE
Leap Year: isValid bug #2607

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -113,7 +113,12 @@ class Dayjs {
   }
 
   isValid() {
-    return !(this.$d.toString() === C.INVALID_DATE_STRING)
+    switch (this.$D !== this.$d.getDate()) {
+      case true:
+        return !(this.$d.toString() === C.INVALID_DATE_STRING)
+      default:
+        return false
+    }
   }
 
   isSame(that, units) {


### PR DESCRIPTION
Javascript (and most other programming languages) recognize that February only has 28 days (or 29 in a leap year). So, when you enter a date like "2024-02-31" using  `new Date("2024-02-31")`, it attempts to create a valid date.

Here's what happens behind the scenes:

- Javascript creates a Date object with the provided year, month (0-indexed, so February is 1), and day.
It recognizes February doesn't have 31 days.
- To create a valid date, Javascript automatically adjusts the date to the closest valid date. In this case, it becomes March 1st (the 1st day of the next month).
- This behavior is to ensure the Date object represents a real date within the calendar system.

This PR adds an additional check to `isValid` method ensuring the date matches before checking for validity

**Before**
```
  isValid() {
    return !(this.$d.toString() === C.INVALID_DATE_STRING)
  }
```

**After**
```
  isValid() {
    switch (this.$D !== this.$d.getDate()) {
      case true:
        return !(this.$d.toString() === C.INVALID_DATE_STRING)
      default:
        return false
    }
  }
```