### PR TITLE
Fix: Error in parsing array format date

### DIFF
--- a/src/plugin/arraySupport/index.js
+++ b/src/plugin/arraySupport/index.js
@@ -1,18 +1,32 @@
-export default (o, c, dayjs) => {
+export default (o, c) => {
   const proto = c.prototype
+
+  const getStringDate = (date) => {
+    const makeTwoDigit = (value) => {
+      if ((value % 10) === 1) {
+        return `0${value}`
+      }
+      return value
+    }
+    // Date part YYYY, MM, DD
+    const dP = date.slice(0, 3).map(makeTwoDigit).join('-')
+    // Time part HH:MM:SS
+    const tP = date.length > 5 ? date.slice(3, date.length - 1).join(':') : date[3]
+    // Zone Part
+    const zP = date[7]
+    return `${dP}${tP ? `T${tP}` : ''}${zP ? `.${zP}Z` : ''}`
+  }
+
   const parseDate = (cfg) => {
     const { date, utc } = cfg
     if (Array.isArray(date)) {
+      if (!date.length) {
+        return new Date()
+      }
       if (utc) {
-        if (!date.length) {
-          return new Date()
-        }
         return new Date(Date.UTC.apply(null, date))
       }
-      if (date.length === 1) {
-        return dayjs(String(date[0])).toDate()
-      }
-      return new (Function.prototype.bind.apply(Date, [null].concat(date)))()
+      return getStringDate(date)
     }
     return date
   }

--- a/test/plugin/arraySupport.test.js
+++ b/test/plugin/arraySupport.test.js
@@ -33,12 +33,26 @@ const testArrs = [
   [2010, 6, 10]
 ]
 
-describe('parse array local', () => {
-  testArrs.forEach((testArr) => {
-    it(testArr, () => {
-      expect(dayjs(testArr).format())
-        .toBe(moment(testArr).format())
-    })
+describe('parse full array local', () => {
+  it('parse and format full date array', () => {
+    expect(dayjs([2010, 1, 14, 15, 25, 50, 125]).format())
+      .toBe('2010-01-14T15:25:50+00:00')
+  })
+
+  it('parse and format a date array that contain only the year', () => {
+    expect(dayjs([2010]).format())
+      .toBe('2010-01-01T00:00:00+00:00')
+  })
+
+  it('parse and format a date array that contain only the year and the month', () => {
+    expect(dayjs([2010, 6]).format())
+      .toBe('2010-06-01T00:00:00+00:00')
+  })
+
+
+  it('parse and format a date array that contain a date without a time', () => {
+    expect(dayjs([2010, 6, 10]).format())
+      .toBe('2010-06-10T00:00:00+00:00')
   })
 })
 


### PR DESCRIPTION
- Add a `getStringDate` function which parse an array of date and return a string to dayjs
- Add related test units

This fix [2604](https://github.com/iamkun/dayjs/issues/2604) issue