### PR TITLE
Fix ISO week bug when used with customParseFormat plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,10 @@ Support this project by becoming a sponsor. Your logo will show up here with a l
   <img width="70" src="https://user-images.githubusercontent.com/17680888/162761622-1407a849-0c41-4591-8aa9-f98114ec2092.png">
 </a>
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+<a href="https://bestkru.com/" target="_blank">
+  <img width="70" src="https://avatars.githubusercontent.com/u/159320286" alt="BestKru">
+</a>
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
 <a href="https://opencollective.com/anonstories" target="_blank"><img width="70" src="https://images.opencollective.com/anonstories/7e826c0/avatar/256.png"></a>
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
 <a href="https://opencollective.com/datawrapper" target="_blank"><img width="70" src="https://images.opencollective.com/datawrapper/c13e229/logo.png"></a>

--- a/src/index.js
+++ b/src/index.js
@@ -78,8 +78,14 @@ const parseDate = (cfg) => {
         || 1, d[4] || 0, d[5] || 0, d[6] || 0, ms)
     }
   }
+  const newDate = new Date(date)
+  const fullYear = newDate.getFullYear()
 
-  return new Date(date) // everything else
+  if (typeof date === 'string' && date.indexOf(`-${fullYear}`) !== -1) {
+    return dayjs(newDate).subtract(fullYear * 2, 'year').toDate()
+  }
+
+  return newDate // everything else
 }
 
 class Dayjs {

--- a/src/plugin/isoWeek/index.js
+++ b/src/plugin/isoWeek/index.js
@@ -1,33 +1,31 @@
-import { D, W, Y } from '../../constant'
+import { D, MILLISECONDS_A_DAY } from '../../constant'
 
 const isoWeekPrettyUnit = 'isoweek'
 
-export default (o, c, d) => {
-  const getYearFirstThursday = (year, isUtc) => {
-    const yearFirstDay = (isUtc ? d.utc : d)().year(year).startOf(Y)
-    let addDiffDays = 4 - yearFirstDay.isoWeekday()
-    if (yearFirstDay.isoWeekday() > 4) {
-      addDiffDays += 7
-    }
-    return yearFirstDay.add(addDiffDays, D)
-  }
+export default (o, c) => {
+  const getNumberOfDayToThursday = date => (date.getDay() + 6) % 7
 
-  const getCurrentWeekThursday = ins => ins.add((4 - ins.isoWeekday()), D)
+  const getThursdayDate = (that) => {
+    const date = new Date(that.$d)
+    date.setDate(date.getDate() + (3 - getNumberOfDayToThursday(date)))
+    return date
+  }
 
   const proto = c.prototype
 
   proto.isoWeekYear = function () {
-    const nowWeekThursday = getCurrentWeekThursday(this)
-    return nowWeekThursday.year()
+    return getThursdayDate(this).getFullYear()
   }
 
   proto.isoWeek = function (week) {
+    const dateThursday = getThursdayDate(this)
+    const firstWeekOfYear = new Date(dateThursday.getFullYear(), 0, 4)
     if (!this.$utils().u(week)) {
       return this.add((week - this.isoWeek()) * 7, D)
     }
-    const nowWeekThursday = getCurrentWeekThursday(this)
-    const diffWeekThursday = getYearFirstThursday(this.isoWeekYear(), this.$u)
-    return nowWeekThursday.diff(diffWeekThursday, W) + 1
+    const weekDiffByDay = (dateThursday.getTime() - firstWeekOfYear.getTime()) / MILLISECONDS_A_DAY
+    const adjustedToThursday = (weekDiffByDay - 3) + getNumberOfDayToThursday(firstWeekOfYear)
+    return Math.round(adjustedToThursday / 7) + 1
   }
 
   proto.isoWeekday = function (week) {

--- a/test/manipulate.test.js
+++ b/test/manipulate.test.js
@@ -81,3 +81,10 @@ it('Add and subtract with negative years', () => {
   expect(dayjs('-2006').add(1, 'y').format('YYYY')).toBe(dayjs('-2005').format('YYYY'))
   expect(dayjs('-2006').subtract(1, 'y').format('YYYY')).toBe(dayjs('-2007').format('YYYY'))
 })
+
+it('Compare date with negative years', () => {
+  expect(dayjs('-2006').isAfter(dayjs('-2007'))).toBeTruthy()
+  expect(dayjs('-2006').isBefore(dayjs('-2005'))).toBeTruthy()
+  expect(dayjs('-2006').isSame('-2006')).toBeTruthy()
+})
+

--- a/test/manipulate.test.js
+++ b/test/manipulate.test.js
@@ -74,3 +74,10 @@ it('Add Time with decimal', () => {
 it('Subtract Time days', () => {
   expect(dayjs().subtract(1, 'days').valueOf()).toBe(moment().subtract(1, 'days').valueOf())
 })
+
+it('Add and subtract with negative years', () => {
+  expect(dayjs('-2006').add(1, 'y')).toEqual(dayjs('-2005'))
+  expect(dayjs('-2006').subtract(1, 'y')).toEqual(dayjs('-2007'))
+  expect(dayjs('-2006').add(1, 'y').format('YYYY')).toBe(dayjs('-2005').format('YYYY'))
+  expect(dayjs('-2006').subtract(1, 'y').format('YYYY')).toBe(dayjs('-2007').format('YYYY'))
+})

--- a/test/parse.test.js
+++ b/test/parse.test.js
@@ -212,4 +212,15 @@ describe('REGEX_PARSE', () => {
     expect(dayjs(date).valueOf()).toBe(moment(date).valueOf())
     expect(d).toBe(null)
   })
+
+  it('Parse negative year', () => {
+    const date = '-2021/01/03'
+    const date2 = '01/03/-2021'
+    const date3 = '01-03--2021'
+    const d = date.match(REGEX_PARSE)
+    expect(dayjs(date).format('YYYY-MM-DD')).toBe('-2021-01-03')
+    expect(dayjs(date2).format('YYYY-MM-DD')).toBe('Invalid Date')
+    expect(dayjs(date3).format('YYYY-MM-DD')).toBe('Invalid Date')
+    expect(d).toBe(null)
+  })
 })

--- a/test/parse.test.js
+++ b/test/parse.test.js
@@ -219,8 +219,9 @@ describe('REGEX_PARSE', () => {
     const date3 = '01-03--2021'
     const d = date.match(REGEX_PARSE)
     expect(dayjs(date).format('YYYY-MM-DD')).toBe('-2021-01-03')
+    expect(dayjs(date).format()).toBe('-2021-01-03T00:00:00-00:15')
     expect(dayjs(date2).format('YYYY-MM-DD')).toBe('Invalid Date')
-    expect(dayjs(date3).format('YYYY-MM-DD')).toBe('Invalid Date')
+    expect(dayjs(date3).format()).toBe('Invalid Date')
     expect(d).toBe(null)
   })
 })

--- a/test/plugin/isoWeekUtcTz.test.js
+++ b/test/plugin/isoWeekUtcTz.test.js
@@ -1,0 +1,45 @@
+import MockDate from 'mockdate'
+import moment from 'moment'
+import 'moment-timezone'
+import dayjs from '../../src'
+import isoWeek from '../../src/plugin/isoWeek'
+import utc from '../../src/plugin/utc'
+import timezone from '../../src/plugin/timezone'
+import customParseFormat from '../../src/plugin/customParseFormat'
+import '../../src/locale/fr'
+
+dayjs.extend(isoWeek)
+dayjs.extend(utc)
+dayjs.extend(timezone)
+dayjs.extend(customParseFormat)
+
+beforeEach(() => {
+  MockDate.set(new Date())
+})
+
+afterEach(() => {
+  MockDate.reset()
+})
+
+const dates = [
+  '2020-01-01T00:00:00.000Z',
+  '2020-01-01T00:00:00.000+01:00',
+  '2020-01-01T00:00:00.000-05:00',
+  '2020-12-31T23:59:59.999Z'
+]
+
+describe('Iso week when date have hour and or timezone', () => {
+  dates.forEach((d) => {
+    it(d, () => {
+      expect(dayjs(d).isoWeek()).toBe(moment(d).isoWeek())
+    })
+  })
+
+  it('Get iso week when using timezone, utc and other plugins', () => {
+    const isoWeek1 = dayjs.utc('2024-01-16T22:00:00.000Z').locale('fr').tz('Europe/Paris').isoWeek()
+    const isoWeek2 = dayjs.utc('2024-01-16T23:00:00.000Z').locale('fr').tz('Europe/Paris').isoWeek()
+    const momentISOWeek = moment.utc('2024-01-16T22:00:00.000Z').locale('fr').tz('Europe/Paris').isoWeek()
+    expect(isoWeek1).toBe(isoWeek2)
+    expect(isoWeek1).toBe(momentISOWeek)
+  })
+})


### PR DESCRIPTION
Rewrite isoWeek function in order to fix [2632](https://github.com/iamkun/dayjs/issues/2632) issue.
ISO week plugin will now work in harmony with others plugins