### PR TITLE
Fix ISO week bug when used with other plugins

### DIFF
--- a/src/plugin/isoWeek/index.js
+++ b/src/plugin/isoWeek/index.js
@@ -1,33 +1,31 @@
-import { D, W, Y } from '../../constant'
+import { D, MILLISECONDS_A_DAY } from '../../constant'
 
 const isoWeekPrettyUnit = 'isoweek'
 
-export default (o, c, d) => {
-  const getYearFirstThursday = (year, isUtc) => {
-    const yearFirstDay = (isUtc ? d.utc : d)().year(year).startOf(Y)
-    let addDiffDays = 4 - yearFirstDay.isoWeekday()
-    if (yearFirstDay.isoWeekday() > 4) {
-      addDiffDays += 7
-    }
-    return yearFirstDay.add(addDiffDays, D)
-  }
+export default (o, c) => {
+  const getNumberOfDayToThursday = date => (date.getDay() + 6) % 7
 
-  const getCurrentWeekThursday = ins => ins.add((4 - ins.isoWeekday()), D)
+  const getThursdayDate = (that) => {
+    const date = new Date(that.$d)
+    date.setDate(date.getDate() + (3 - getNumberOfDayToThursday(date)))
+    return date
+  }
 
   const proto = c.prototype
 
   proto.isoWeekYear = function () {
-    const nowWeekThursday = getCurrentWeekThursday(this)
-    return nowWeekThursday.year()
+    return getThursdayDate(this).getFullYear()
   }
 
   proto.isoWeek = function (week) {
+    const dateThursday = getThursdayDate(this)
+    const firstWeekOfYear = new Date(dateThursday.getFullYear(), 0, 4)
     if (!this.$utils().u(week)) {
       return this.add((week - this.isoWeek()) * 7, D)
     }
-    const nowWeekThursday = getCurrentWeekThursday(this)
-    const diffWeekThursday = getYearFirstThursday(this.isoWeekYear(), this.$u)
-    return nowWeekThursday.diff(diffWeekThursday, W) + 1
+    const weekDiffByDay = (dateThursday.getTime() - firstWeekOfYear.getTime()) / MILLISECONDS_A_DAY
+    const adjustedToThursday = (weekDiffByDay - 3) + getNumberOfDayToThursday(firstWeekOfYear)
+    return Math.round(adjustedToThursday / 7) + 1
   }
 
   proto.isoWeekday = function (week) {

--- a/test/plugin/isoWeekUtcTz.test.js
+++ b/test/plugin/isoWeekUtcTz.test.js
@@ -1,0 +1,45 @@
+import MockDate from 'mockdate'
+import moment from 'moment'
+import 'moment-timezone'
+import dayjs from '../../src'
+import isoWeek from '../../src/plugin/isoWeek'
+import utc from '../../src/plugin/utc'
+import timezone from '../../src/plugin/timezone'
+import customParseFormat from '../../src/plugin/customParseFormat'
+import '../../src/locale/fr'
+
+dayjs.extend(isoWeek)
+dayjs.extend(utc)
+dayjs.extend(timezone)
+dayjs.extend(customParseFormat)
+
+beforeEach(() => {
+  MockDate.set(new Date())
+})
+
+afterEach(() => {
+  MockDate.reset()
+})
+
+const dates = [
+  '2020-01-01T00:00:00.000Z',
+  '2020-01-01T00:00:00.000+01:00',
+  '2020-01-01T00:00:00.000-05:00',
+  '2020-12-31T23:59:59.999Z'
+]
+
+describe('Iso week when date have hour and or timezone', () => {
+  dates.forEach((d) => {
+    it(d, () => {
+      expect(dayjs(d).isoWeek()).toBe(moment(d).isoWeek())
+    })
+  })
+
+  it('Get iso week when using timezone, utc and other plugins', () => {
+    const isoWeek1 = dayjs.utc('2024-01-16T22:00:00.000Z').locale('fr').tz('Europe/Paris').isoWeek()
+    const isoWeek2 = dayjs.utc('2024-01-16T23:00:00.000Z').locale('fr').tz('Europe/Paris').isoWeek()
+    const momentISOWeek = moment.utc('2024-01-16T22:00:00.000Z').locale('fr').tz('Europe/Paris').isoWeek()
+    expect(isoWeek1).toBe(isoWeek2)
+    expect(isoWeek1).toBe(momentISOWeek)
+  })
+})


### PR DESCRIPTION
Rewrite isoWeek function in order to fix [2632](https://github.com/iamkun/dayjs/issues/2632) issue.
ISO week plugin will now work in harmony with others plugins