### PR TITLE
Negative year is considered a valid date

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -60,6 +60,14 @@ Utils.l = parseLocale
 Utils.i = isDayjs
 Utils.w = wrapper
 
+const hasNegativeDateComponent = (dateStr) => {
+  // Regular expression to match any part of the date that starts with a hyphen followed by digits
+  const negativeDatePattern = /(^-|\/-|--|\/-\d{2}|\d{2}\/-\d{2}\/|\d{4}\/-\d{2}|\/-\d{2}\/)/
+
+  // Test the date string against the pattern
+  return negativeDatePattern.test(dateStr)
+}
+
 const parseDate = (cfg) => {
   const { date, utc } = cfg
   if (date === null) return new Date(NaN) // null is invalid
@@ -77,6 +85,8 @@ const parseDate = (cfg) => {
       return new Date(d[1], m, d[3]
         || 1, d[4] || 0, d[5] || 0, d[6] || 0, ms)
     }
+
+    if (hasNegativeDateComponent(date)) return new Date(NaN)
   }
 
   return new Date(date) // everything else

--- a/test/display.test.js
+++ b/test/display.test.js
@@ -19,6 +19,9 @@ it('Format no formatStr', () => {
 it('Format invalid date', () => {
   expect(dayjs('').format()).toBe(new Date('').toString())
   expect(dayjs('otherString').format()).toBe(new Date('otherString').toString())
+  expect(dayjs('-1996/3/2').format()).toBe('Invalid Date')
+  expect(dayjs('1996/-3/2').format()).toBe('Invalid Date')
+  expect(dayjs('3/2/-1996').format()).toBe('Invalid Date')
 })
 
 it('Format Year YY YYYY', () => {


### PR DESCRIPTION
Issue: #2653

```js
dayjs('2/3/-1996'.split("/").reverse().join("/")).format("DD/MM/YYYY")
```
The output should be `invalid date`, but currently the return date is without negative value: `'02/03/1996'`

**Note:**
JS Date accept negative date values
Detailed explanation: https://stackoverflow.com/a/41345095

Another example:

<img width="475" alt="image" src="https://github.com/iamkun/dayjs/assets/23138717/f26f34b0-a038-4b61-8b77-82fa227379e5">
