### PR TITLE
Fix: 12 PM Display Bug in Arabic Adapter 

### DIFF
--- a/src/locale/ar-dz.js
+++ b/src/locale/ar-dz.js
@@ -17,7 +17,7 @@ const locale = {
     LLL: 'D MMMM YYYY HH:mm',
     LLLL: 'dddd D MMMM YYYY HH:mm'
   },
-  meridiem: hour => (hour > 12 ? 'م' : 'ص'),
+  meridiem: hour => (hour >= 12 ? 'م' : 'ص'),
   relativeTime: {
     future: 'في %s',
     past: 'منذ %s',

--- a/src/locale/ar-iq.js
+++ b/src/locale/ar-iq.js
@@ -18,7 +18,7 @@ const locale = {
     LLL: 'D MMMM YYYY HH:mm',
     LLLL: 'dddd D MMMM YYYY HH:mm'
   },
-  meridiem: hour => (hour > 12 ? 'م' : 'ص'),
+  meridiem: hour => (hour >= 12 ? 'م' : 'ص'),
   relativeTime: {
     future: 'في %s',
     past: 'منذ %s',

--- a/src/locale/ar-kw.js
+++ b/src/locale/ar-kw.js
@@ -17,7 +17,7 @@ const locale = {
     LLL: 'D MMMM YYYY HH:mm',
     LLLL: 'dddd D MMMM YYYY HH:mm'
   },
-  meridiem: hour => (hour > 12 ? 'م' : 'ص'),
+  meridiem: hour => (hour >= 12 ? 'م' : 'ص'),
   relativeTime: {
     future: 'في %s',
     past: 'منذ %s',

--- a/src/locale/ar-ly.js
+++ b/src/locale/ar-ly.js
@@ -10,7 +10,7 @@ const locale = {
   monthsShort: 'يناير_فبراير_مارس_أبريل_مايو_يونيو_يوليو_أغسطس_سبتمبر_أكتوبر_نوفمبر_ديسمبر'.split('_'),
   weekdaysMin: 'ح_ن_ث_ر_خ_ج_س'.split('_'),
   ordinal: n => n,
-  meridiem: hour => (hour > 12 ? 'م' : 'ص'),
+  meridiem: hour => (hour >= 12 ? 'م' : 'ص'),
   formats: {
     LT: 'HH:mm',
     LTS: 'HH:mm:ss',

--- a/src/locale/ar-ma.js
+++ b/src/locale/ar-ma.js
@@ -18,7 +18,7 @@ const locale = {
     LLL: 'D MMMM YYYY HH:mm',
     LLLL: 'dddd D MMMM YYYY HH:mm'
   },
-  meridiem: hour => (hour > 12 ? 'م' : 'ص'),
+  meridiem: hour => (hour >= 12 ? 'م' : 'ص'),
   relativeTime: {
     future: 'في %s',
     past: 'منذ %s',

--- a/src/locale/ar-sa.js
+++ b/src/locale/ar-sa.js
@@ -17,7 +17,7 @@ const locale = {
     LLL: 'D MMMM YYYY HH:mm',
     LLLL: 'dddd D MMMM YYYY HH:mm'
   },
-  meridiem: hour => (hour > 12 ? 'م' : 'ص'),
+  meridiem: hour => (hour >= 12 ? 'م' : 'ص'),
   relativeTime: {
     future: 'في %s',
     past: 'منذ %s',

--- a/src/locale/ar-tn.js
+++ b/src/locale/ar-tn.js
@@ -18,7 +18,7 @@ const locale = {
     LLL: 'D MMMM YYYY HH:mm',
     LLLL: 'dddd D MMMM YYYY HH:mm'
   },
-  meridiem: hour => (hour > 12 ? 'م' : 'ص'),
+  meridiem: hour => (hour >= 12 ? 'م' : 'ص'),
   relativeTime: {
     future: 'في %s',
     past: 'منذ %s',

--- a/src/locale/ar.js
+++ b/src/locale/ar.js
@@ -37,7 +37,7 @@ const locale = {
   months,
   monthsShort: months,
   weekStart: 6,
-  meridiem: hour => (hour > 12 ? 'م' : 'ص'),
+  meridiem: hour => (hour >= 12 ? 'م' : 'ص'),
   relativeTime: {
     future: 'بعد %s',
     past: 'منذ %s',


### PR DESCRIPTION
While using the Arabic adapter in Day.js, there was an issue where selecting 12م (PM) gets displayed as 12ص (AM). I investigated the code and solved the issue