### PR TITLE
fix: handle swedish ordinal special cases

### DIFF
--- a/src/locale/sv.js
+++ b/src/locale/sv.js
@@ -12,7 +12,10 @@ const locale = {
   yearStart: 4,
   ordinal: (n) => {
     const b = n % 10
-    const o = (b === 1) || (b === 2) ? 'a' : 'e'
+    const c = n % 100
+    const isSpecialCase = c >= 11 && c <= 19
+
+    const o = (b === 1 || b === 2) && !isSpecialCase ? 'a' : 'e'
     return `[${n}${o}]`
   },
   formats: {

--- a/test/locale/sv.test.js
+++ b/test/locale/sv.test.js
@@ -19,3 +19,25 @@ it('Swedish locale Do 1a not format to 1am', () => {
   expect(dayjs('2019-01-02').locale('sv').format('dddd Do MMMM'))
     .toBe('onsdag 2a januari')
 })
+
+describe('Swedish locale ordinal', () => {
+  it('- regular cases', () => {
+    expect(dayjs('2019-01-01').locale('sv').format('Do')).toBe('1a')
+    expect(dayjs('2019-01-02').locale('sv').format('Do')).toBe('2a')
+    expect(dayjs('2019-01-03').locale('sv').format('Do')).toBe('3e')
+    expect(dayjs('2019-01-21').locale('sv').format('Do')).toBe('21a')
+    expect(dayjs('2019-01-22').locale('sv').format('Do')).toBe('22a')
+    expect(dayjs('2019-01-23').locale('sv').format('Do')).toBe('23e')
+  })
+  it('- special cases', () => {
+    expect(dayjs('2019-01-11').locale('sv').format('Do')).toBe('11e')
+    expect(dayjs('2019-01-12').locale('sv').format('Do')).toBe('12e')
+    expect(dayjs('2019-01-13').locale('sv').format('Do')).toBe('13e')
+    expect(dayjs('2019-01-14').locale('sv').format('Do')).toBe('14e')
+    expect(dayjs('2019-01-15').locale('sv').format('Do')).toBe('15e')
+    expect(dayjs('2019-01-16').locale('sv').format('Do')).toBe('16e')
+    expect(dayjs('2019-01-17').locale('sv').format('Do')).toBe('17e')
+    expect(dayjs('2019-01-18').locale('sv').format('Do')).toBe('18e')
+    expect(dayjs('2019-01-19').locale('sv').format('Do')).toBe('19e')
+  })
+})


### PR DESCRIPTION
I was faced with some oridinal special cases in Swedish language that were not handled properly

Swedish ordinals should look like this: 
`1a, 2a, 3e, 4e, 5e, 6e, 7e, 8e, 9e, 10e, 11e, 12e, 13e, 14e, 15e, 16e, 17e, 18e, 19e, 20e, 21a, 22a, 23e, 24e, 25e, 26e, 27e, 28e, 29e, 30e, 31a`

Where the range from 11e to 19e don't follow the regular ordinal in Swedish language
You can refer to [this resource](https://blogs.transparent.com/swedish/100-ordinal-numbers-in-swedish/)