### PR TITLE
fix: remove space from h relativeTime

### DIFF
--- a/src/locale/it.js
+++ b/src/locale/it.js
@@ -23,7 +23,7 @@ const locale = {
     s: 'qualche secondo',
     m: 'un minuto',
     mm: '%d minuti',
-    h: 'un\' ora',
+    h: 'un\'ora',
     hh: '%d ore',
     d: 'un giorno',
     dd: '%d giorni',


### PR DESCRIPTION
I've found a typo in the it Locale for the h format in the relativeTime object.

Instead using "un' ora fa", it should be "un'ora fa" without the extra space. 
