### PR TITLE
feat: add normalize to duration to redistribute the unit values

### DIFF
--- a/src/plugin/duration/index.js
+++ b/src/plugin/duration/index.js
@@ -229,6 +229,10 @@ class Duration {
     return wrapper(this.$ms, this)
   }
 
+  normalize() {
+    return wrapper(this.$ms, this)
+  }
+
   humanize(withSuffix) {
     return $d()
       .add(this.$ms, 'ms')

--- a/test/plugin/duration.test.js
+++ b/test/plugin/duration.test.js
@@ -309,3 +309,34 @@ describe('Format', () => {
       .toBe('2/02.0002TEST9:09:6:06:8:08:5:05:1:01:010')
   })
 })
+
+describe('Normalize units', () => {
+  [
+    ['PT60S', 'PT1M'],
+    ['PT120M', 'PT2H'],
+    ['PT24H', 'P1D'],
+    ['P30DT10H', 'P1M'],
+    ['P31D', 'P1MT14H'],
+    ['P12M', 'P1Y'],
+
+    ['PT0.5M', 'PT30S'],
+    ['PT0.5H', 'PT30M'],
+    ['P0.5D', 'PT12H'],
+    ['P0.5M', 'P15DT5H'],
+    ['P0.5Y', 'P6M'],
+
+    ['P1Y13M25DT25H61M65S', 'P2Y1M26DT2H2M5S']
+  ].forEach(([input, output]) => {
+    test(`Normalize ${input} to ${output}`, () => {
+      const normalized = dayjs.duration(input).normalize()
+
+      expect(normalized.toISOString()).toBe(output)
+    })
+
+    test(`Clone ${input} to ${output}`, () => {
+      const cloned = dayjs.duration(input).clone()
+
+      expect(cloned.toISOString()).toBe(output)
+    })
+  })
+})

--- a/types/plugin/duration.d.ts
+++ b/types/plugin/duration.d.ts
@@ -30,6 +30,8 @@ declare namespace plugin {
 
     clone(): Duration
 
+    normalize(): Duration
+
     humanize(withSuffix?: boolean): string
 
     milliseconds(): number


### PR DESCRIPTION
clone apparently does the same, but this is an alias i would find to normalize the single time unit values of a duration.

luxon has the function https://moment.github.io/luxon/api-docs/index.html#durationnormalize.