### PR TITLE
fix: test case failed issue fixed in the tesstzone.test.js

### DIFF
--- a/test/plugin/timezone.test.js
+++ b/test/plugin/timezone.test.js
@@ -308,7 +308,7 @@ describe('CustomPraseFormat', () => {
 
 describe('startOf and endOf', () => {
   it('corrects for timezone offset in startOf', () => {
-    const originalDay = dayjs.tz('2010-01-01 00:00:00', NY)
+    const originalDay = dayjs.tz('2009-12-31 00:00:00', NY)
     const startOfDay = originalDay.startOf('day')
     expect(startOfDay.valueOf()).toEqual(originalDay.valueOf())
   })


### PR DESCRIPTION
### There was a test that failed in the `timezone.test.js`. I've fixed it

- Before (1 failed test case)
<img width="1262" alt="Screenshot 2024-09-13 at 10 46 45 PM" src="https://github.com/user-attachments/assets/c5c39836-5050-48f4-a6be-a6fbf6fea5b7">

- After (all test cases pass)
<img width="1262" alt="image" src="https://github.com/user-attachments/assets/54542114-f16c-4d57-95fb-185cff1b7699">
