### PR TITLE
fix: (duration/index.js) Duration regex

### DIFF
--- a/src/plugin/duration/index.js
+++ b/src/plugin/duration/index.js
@@ -10,7 +10,9 @@ import {
 const MILLISECONDS_A_YEAR = MILLISECONDS_A_DAY * 365
 const MILLISECONDS_A_MONTH = MILLISECONDS_A_YEAR / 12
 
-const durationRegex = /^(-|\+)?P(?:([-+]?[0-9,.]*)Y)?(?:([-+]?[0-9,.]*)M)?(?:([-+]?[0-9,.]*)W)?(?:([-+]?[0-9,.]*)D)?(?:T(?:([-+]?[0-9,.]*)H)?(?:([-+]?[0-9,.]*)M)?(?:([-+]?[0-9,.]*)S)?)?$/
+const durationRegexWeeks = /^([-+])?P([-+]?[\d,.]*W)$/
+const durationRegexYmd = /^([-+])?P([-+]?[\d,.]*Y)?([-+]?[\d,.]*M)?([-+]?[\d,.]*D)?T([-+]?[\d,.]*H)?([-+]?[\d,.]*M)?([-+]?[\d,.]*S)?$/
+const durationRegex = `(${WEEKS_FORMAT.source})|(${YMD_FORMAT.source})`
 
 const unitToMS = {
   years: MILLISECONDS_A_YEAR,

--- a/src/plugin/duration/index.js
+++ b/src/plugin/duration/index.js
@@ -12,7 +12,7 @@ const MILLISECONDS_A_MONTH = MILLISECONDS_A_YEAR / 12
 
 const durationRegexWeeks = /^([-+])?P([-+]?[\d,.]*W)$/
 const durationRegexYmd = /^([-+])?P([-+]?[\d,.]*Y)?([-+]?[\d,.]*M)?([-+]?[\d,.]*D)?T([-+]?[\d,.]*H)?([-+]?[\d,.]*M)?([-+]?[\d,.]*S)?$/
-const durationRegex = `(${WEEKS_FORMAT.source})|(${YMD_FORMAT.source})`
+const durationRegex = `(${durationRegexWeeks.source})|(${durationRegexYmd.source})`
 
 const unitToMS = {
   years: MILLISECONDS_A_YEAR,


### PR DESCRIPTION
This pull request includes changes to the `src/plugin/duration/index.js` file to improve the handling of duration parsing. The most important changes include splitting the duration regular expression into two separate regex patterns for weeks and YMD formats, and then combining them into a single `durationRegex`.

This change prevents users from combining `PnW` and `PnYnMnDTnHnMnS` [formats](https://en.wikipedia.org/wiki/ISO_8601#Durations).

Improvements to duration parsing:

* [`src/plugin/duration/index.js`](diffhunk://#diff-ab4244f985fbde8ce9d0f5a09abd5ed28c9ff797beb05c377005a70734983176L13-R15): Split the original `durationRegex` into `durationRegexWeeks` and `durationRegexYmd` for better readability and maintainability. Combined them into a single `durationRegex` that can handle both formats.