### PR TITLE
fix: allow to use ReadonlyDate in ConfigType

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -9,8 +9,10 @@ declare function dayjs (date?: dayjs.ConfigType, format?: dayjs.OptionType, stri
 declare function dayjs (date?: dayjs.ConfigType, format?: dayjs.OptionType, locale?: string, strict?: boolean): dayjs.Dayjs
 
 declare namespace dayjs {
+  type ReadonlyDate = Omit<Date, `set${string}`>;
+
   interface ConfigTypeMap {
-    default: string | number | Date | Dayjs | null | undefined
+    default: string | number | Date | ReadonlyDate | Dayjs | null | undefined
   }
 
   export type ConfigType = ConfigTypeMap[keyof ConfigTypeMap]


### PR DESCRIPTION
**Summary**

This pull request introduces support for the `ReadonlyDate` type as a valid input for the `dayjs()` function. The `ReadonlyDate` type excludes all setter methods from the native `Date` object, ensuring immutability.

The aim is to allow dates that are typed as `ReadonlyDate` in projects to be directly passed to the dayjs() function without compatibility issues.

**Benefits**

- Compatibility with Immutable Dates: Developers can now use `ReadonlyDate` objects (which exclude setter methods for immutability) as input to the `dayjs()` function, ensuring smooth integration with projects that require or enforce readonly types.

**Impact**

- No Breaking Changes: Existing code using `Date` and other types as input to `dayjs()` will continue to work as expected.
- Enhanced Flexibility: This change allows developers who use `ReadonlyDate` in their projects to seamlessly integrate `dayjs()` without needing to cast or modify their date types.