### PR TITLE
Fix: performance issue in tz plugin

### DIFF
--- a/src/plugin/timezone/index.js
+++ b/src/plugin/timezone/index.js
@@ -15,11 +15,11 @@ export default (o, c, d) => {
         hourCycle: 'h23',
         timeZone: timezone,
         year: 'numeric',
-        month: '2-digit',
-        day: '2-digit',
-        hour: '2-digit',
-        minute: '2-digit',
-        second: '2-digit',
+        month: 'numeric',
+        day: 'numeric',
+        hour: 'numeric',
+        minute: 'numeric',
+        second: 'numeric',
         timeZoneName
       })
       dtfCache[key] = dtf

--- a/src/plugin/timezone/index.js
+++ b/src/plugin/timezone/index.js
@@ -1,87 +1,125 @@
-import { INVALID_DATE_STRING, MILLISECONDS_A_MINUTE, MILLISECONDS_A_SECOND, MIN, MS } from '../../constant'
-
-const types = ['year', 'month', 'day', 'hour', 'minute', 'second', 'timeZoneName']
-
-// Cache time-zone lookups from Intl.DateTimeFormat,
-// as it is a *very* slow method.
-const dtfCache = { __proto: null }
-const getDateTimeFormat = (timezone, options = {}) => {
-  const { timeZoneName } = options
-  const key = `${timezone}|${timeZoneName}`
-  let dtf = dtfCache[key]
-  if (!dtf) {
-    dtf = new Intl.DateTimeFormat('en-US', {
-      hourCycle: 'h23',
-      timeZone: timezone,
-      year: 'numeric',
-      month: '2-digit',
-      day: '2-digit',
-      hour: '2-digit',
-      minute: '2-digit',
-      second: '2-digit',
-      timeZoneName
-    })
-    dtfCache[key] = dtf
-  }
-  return dtf
-}
+import { MILLISECONDS_A_MINUTE, MILLISECONDS_A_SECOND, MIN, MS } from '../../constant'
 
 export default (o, c, d) => {
   let defaultTimezone
+  const proto = c.prototype
 
-  const makeFormatParts = (timestamp, timezone, options) => {
+  // Cache time-zone lookups from Intl.DateTimeFormat,
+  // as it is a *very* slow method.
+  const dtfCache = { __proto: null }
+  const getDateTimeFormat = (timezone, timeZoneName) => {
+    const key = `${timezone}|${timeZoneName}`
+    let dtf = dtfCache[key]
+    if (!dtf) {
+      dtf = new Intl.DateTimeFormat('en-US', {
+        hourCycle: 'h23',
+        timeZone: timezone,
+        year: 'numeric',
+        month: '2-digit',
+        day: '2-digit',
+        hour: '2-digit',
+        minute: '2-digit',
+        second: '2-digit',
+        timeZoneName
+      })
+      dtfCache[key] = dtf
+    }
+    return dtf
+  }
+
+  const makeFormatParts = (timestamp, timezone, timeZoneName) => {
     const date = new Date(timestamp)
-    const dtf = getDateTimeFormat(timezone, options)
+    const dtf = getDateTimeFormat(timezone, timeZoneName)
     const formatResult = dtf.formatToParts(date)
-    const filled = []
-    formatResult.forEach(({ type, value }) => {
-      const i = types.indexOf(type)
-      if (i >= 0) {
-        filled[i] = value
-      }
-    })
-    return filled
+    return formatResult
   }
 
   const tzOffset = (timestamp, timezone) => {
-    const [Y, M, D, h, m, s] = makeFormatParts(timestamp, timezone)
-    const utcString = `${Y}-${M}-${D} ${h}:${m}:${s}`
-    const utcTs = +d.utc(utcString)
-    let asTS = +timestamp
+    const formatResult = makeFormatParts(timestamp, timezone)
+    let Y
+    let M
+    let D
+    let h
+    let m
+    let s
+    formatResult.forEach((r) => {
+      switch (r.type) {
+        case 'year':
+          Y = r.value
+          break
+        case 'month':
+          M = r.value - 1
+          break
+        case 'day':
+          D = r.value
+          break
+        case 'hour':
+          h = r.value
+          break
+        case 'minute':
+          m = r.value
+          break
+        case 'second':
+          s = r.value
+          break
+        default:
+          break
+      }
+    })
+    const utcTs = Date.UTC(Y, M, D, h, m, s)
+    const asTS = timestamp
     const over = asTS % MILLISECONDS_A_SECOND
-    asTS -= over
-    return (utcTs - asTS) / MILLISECONDS_A_MINUTE
+    return (utcTs - (asTS - over)) / MILLISECONDS_A_MINUTE
+  }
+
+  const tzToFirstOffsetCache = { __proto__: null }
+  const initialValue = +d()
+  const tzToFirstOffset = (timezone) => {
+    let offset = tzToFirstOffsetCache[timezone]
+    if (offset == null) {
+      offset = tzOffset(initialValue, timezone)
+      tzToFirstOffsetCache[timezone] = offset
+    }
+    return offset
   }
 
   // find the right offset a given local time. The o input is our guess, which determines which
   // offset we'll pick in ambiguous cases (e.g. there are two 3 AMs b/c Fallback DST)
   // https://github.com/moment/luxon/blob/master/src/datetime.js#L76
-  const fixOffset = (localTS, o0, tz) => {
+  const fixOffset = (localTS, tz) => {
+    let o0 = tzToFirstOffset(tz)
+    let utcGuess
+    let o2
     // Our UTC time is just a guess because our offset is just a guess
-    const utcGuess = offset => localTS - (offset * MILLISECONDS_A_MINUTE)
-    const next = offset => tzOffset(utcGuess(offset), tz)
+    utcGuess = localTS - (o0 * MILLISECONDS_A_MINUTE)
     // Test whether the zone matches the offset for this ts
-    let o2 = next(o0)
-    let o3 = next(o2)
-    // If o2 !== o3, we're in a hole time.
-    // The offset has changed, but the we don't adjust the time
-    if (o2 > o3) {
-      const tmp = o2
-      o2 = o3
-      o3 = tmp
+    o2 = tzOffset(utcGuess, tz)
+    // If so, offset didn't change and we're done
+    if (o0 !== o2) {
+      // If not, change the ts by the difference in the offset
+      o0 = o2
+      utcGuess = localTS - (o0 * MILLISECONDS_A_MINUTE)
+      o2 = tzOffset(utcGuess, tz)
+      // If that gives us the local time we want, we're done
+      // If it's different, we're in a hole time.
+      // The offset has changed, but the we don't adjust the time
+      if (o0 > o2) {
+        // swap o2 and o0
+        utcGuess = o0
+        o0 = o2
+        o2 = utcGuess
+        utcGuess = localTS - (o0 * MILLISECONDS_A_MINUTE)
+      }
     }
-    return d(utcGuess(o2)).utcOffset(o3)
+    return d(utcGuess).utcOffset(o2)
   }
 
-  const proto = c.prototype
-
   proto.tz = function (timezone = defaultTimezone, keepLocalTime) {
-    const oldOffset = this.utcOffset()
     const date = this.toDate()
     const target = this.isValid()
-      ? getDateTimeFormat(timezone).format(date)
-      : INVALID_DATE_STRING
-    const diff = Math.round((date - new Date(target)) / MILLISECONDS_A_MINUTE)
+      ? new Date(getDateTimeFormat(timezone).format(date))
+      : NaN
+    const diff = Math.round((date - target) / MILLISECONDS_A_MINUTE)
     const offset = -date.getTimezoneOffset() - diff
     const isUTC = !offset
     let ins
@@ -91,6 +129,7 @@ export default (o, c, d) => {
       ins = d(target, { locale: this.$L }).$set(MS, this.$ms)
         .utcOffset(offset, true)
       if (keepLocalTime) {
+        const oldOffset = this.utcOffset()
         const newOffset = ins.utcOffset()
         ins = ins.add(oldOffset - newOffset, MIN)
       }
@@ -102,7 +141,7 @@ export default (o, c, d) => {
   proto.offsetName = function (type) {
     // type: short(default) / long
     const zone = this.$x.$timezone || d.tz.guess()
-    const result = makeFormatParts(+this, zone, { timeZoneName: type || 'short' })[6]
+    const result = makeFormatParts(+this, zone, type || 'short').find(i => i.type === 'timeZoneName').value
     return result
   }
 
@@ -118,15 +157,14 @@ export default (o, c, d) => {
   }
 
   d.tz = function (input, arg1, arg2) {
-    const parseFormat = arg2 && arg1
     const timezone = arg2 || arg1 || defaultTimezone
-    const previousOffset = tzOffset(+d(), timezone)
     if (typeof input !== 'string') {
       // timestamp number || js Date || Day.js
       return d(input).tz(timezone)
     }
+    const parseFormat = arg2 && arg1
     const localTs = +d.utc(input, parseFormat)
-    const ins = fixOffset(localTs, previousOffset, timezone)
+    const ins = fixOffset(localTs, timezone)
     ins.$x.$timezone = timezone
     return ins
   }

--- a/src/plugin/timezone/index.js
+++ b/src/plugin/timezone/index.js
@@ -120,7 +120,9 @@ export default (o, c, d) => {
       ? new Date(getDateTimeFormat(timezone).format(date))
       : NaN
     const diff = Math.round((date - target) / MILLISECONDS_A_MINUTE)
-    const offset = -date.getTimezoneOffset() - diff
+    // Because a bug at FF24, we're rounding the timezone offset around 15 minutes
+    // https://github.com/moment/moment/pull/1871
+    const offset = (-Math.round(date.getTimezoneOffset() / 15) * 15) - diff
     const isUTC = !offset
     let ins
     if (isUTC) { // if utcOffset is 0, turn it to UTC mode

--- a/test/plugin/timezone.test.js
+++ b/test/plugin/timezone.test.js
@@ -72,21 +72,16 @@ describe('Parse', () => {
 
 describe('Convert', () => {
   it('convert to target time', () => {
-    const losAngeles = dayjs('2014-06-01T12:00:00Z').tz('America/Los_Angeles')
-    const MlosAngeles = moment('2014-06-01T12:00:00Z').tz('America/Los_Angeles')
-    expect(losAngeles.format()).toBe('2014-06-01T05:00:00-07:00')
-    expect(losAngeles.format()).toBe(MlosAngeles.format())
-    expect(losAngeles.valueOf()).toBe(1401624000000)
-    expect(losAngeles.valueOf()).toBe(MlosAngeles.valueOf())
-    expect(losAngeles.utcOffset()).toBe(-420)
-    expect(losAngeles.utcOffset()).toBe(MlosAngeles.utcOffset())
-  })
-
-  it('convert to target time', () => {
     [dayjs, moment].forEach((_) => {
       const losAngeles = _('2014-06-01T12:00:00Z').tz('America/Los_Angeles')
       expect(losAngeles.format()).toBe('2014-06-01T05:00:00-07:00')
       expect(losAngeles.valueOf()).toBe(1401624000000)
+      expect(losAngeles.utcOffset()).toBe(-420)
+
+      const prague = _('2023-10-02T00:00:00+02:00').tz('Europe/Prague')
+      expect(prague.format()).toBe('2023-10-02T00:00:00+02:00')
+      expect(prague.valueOf()).toBe(1696197600000)
+      expect(prague.utcOffset()).toBe(120)
     })
   })
 


### PR DESCRIPTION
In this PR, I have improved the performance of the timezone plugin.
I didn't adopt the previous PR #2019 because [it contained a breaking change](https://github.com/iamkun/dayjs/pull/2019#issuecomment-1211723494) and [it introduced a bug](https://github.com/iamkun/dayjs/pull/2019#issuecomment-1662043227).
I also shrunk the tz plugin after gzip from 1110bytes to 991bytes.

The changes are summarized below:

* `getDateTimeFormat`
  * Use `hourCycle: 'h23'` so we can use single DateTimeFormat options and remove [this workaround](https://github.com/iamkun/dayjs/blob/dev/src/plugin/timezone/index.js#L57-L60C32)
  * Set all parts to numeric
* `tzToFirstOffsetCache`
  * first guess of timezone offset in fixOffset (moved from [here](https://github.com/iamkun/dayjs/blob/dev/src/plugin/timezone/index.js#L138))
* change code to make it more compressible