### PR TITLE
Update id.js

### DIFF
--- a/src/locale/id.js
+++ b/src/locale/id.js
@@ -18,18 +18,18 @@ const locale = {
     LLLL: 'dddd, D MMMM YYYY [pukul] HH.mm'
   },
   relativeTime: {
-    future: 'dalam %s',
+    future: '%s dari sekarang',
     past: '%s yang lalu',
     s: 'beberapa detik',
-    m: 'semenit',
+    m: '1 menit',
     mm: '%d menit',
-    h: 'sejam',
+    h: '1 jam',
     hh: '%d jam',
-    d: 'sehari',
+    d: '1 hari',
     dd: '%d hari',
-    M: 'sebulan',
+    M: '1 bulan',
     MM: '%d bulan',
-    y: 'setahun',
+    y: '1 tahun',
     yy: '%d tahun'
   },
   ordinal: n => `${n}.`


### PR DESCRIPTION
Hi @iamkun 

The relativeTime configuration was updated to improve consistency and clarity in formatting. Phrases like `semenit`, `sejam`, `sehari`, `sebulan`, and `setahun` were standardized to `1 menit`, `1 jam`, `1 hari`, `1 bulan`, and `1 tahun` to follow a uniform numeric style. This change makes the output less confusing in *Bahasa Indonesia*, as using `1` instead of `se-` provides a clearer and more consistent representation of time units. Additionally, the future format was updated to `%s dari sekarang` for a more natural and clear phrasing. These updates ensure the relative time outputs are easier to understand, user-friendly, and consistent across all use cases.