### PR TITLE
test(duration): add duration test for half a year addition

### DIFF
--- a/test/plugin/duration.test.js
+++ b/test/plugin/duration.test.js
@@ -209,6 +209,10 @@ test('Add duration', () => {
   const b = dayjs('2023-02-01 00:00:00')
   const p = dayjs.duration('P1Y1M1DT1H1M1S')
   expect(b.add(p).format('YYYY-MM-DD HH:mm:ss')).toBe('2024-03-02 01:01:01')
+
+  const c = dayjs('2023-01-13T00:00:00.000Z')
+  const halfAYear = dayjs.duration(6, 'months')
+  expect(c.add(halfAYear).format('YYYY-MM-DD')).toBe('2023-07-13')
 })
 
 describe('Subtract', () => {


### PR DESCRIPTION
This pull request includes a small change to the `test/plugin/duration.test.js` file. The change adds a new test case to verify the addition of a duration of six months to a specific date.

* [`test/plugin/duration.test.js`](diffhunk://#diff-f09fcbdef977efd78db6f4d121524b2ccc509e764bd8e53aba52a4e5833bc4eeR212-R215): Added a test case to verify that adding a duration of six months to `2023-01-13T00:00:00.000Z` results in `2023-07-13`.