### PR TITLE
feat: add day strings to 'customParseFormat'

### DIFF
--- a/src/plugin/customParseFormat/index.js
+++ b/src/plugin/customParseFormat/index.js
@@ -1,6 +1,6 @@
 import { u } from '../localizedFormat/utils'
 
-const formattingTokens = /(\[[^[]*\])|([-_:/.,()\s]+)|(A|a|Q|YYYY|YY?|ww?|MM?M?M?|Do|DD?|hh?|HH?|mm?|ss?|S{1,3}|z|ZZ?)/g
+const formattingTokens = /(\[[^[]*\])|([-_:/.,()\s]+)|(A|a|Q|YYYY|YY?|ww?|MM?M?M?|Do|DD?|dd?d?d?|hh?|HH?|mm?|ss?|S{1,3}|z|ZZ?)/g
 
 const match1 = /\d/ // 0 - 9
 const match2 = /\d\d/ // 00 - 99
@@ -96,6 +96,29 @@ const expressions = {
       if (ordinal(i).replace(/\[|\]/g, '') === input) {
         this.day = i
       }
+    }
+  }],
+  dd: [matchWord, function (input) {
+    const weekdays = getLocalePart('weekdays')
+    const weekdaysMin = getLocalePart('weekdaysMin')
+    const matchIndex = (weekdaysMin || weekdays.map(_ => _.slice(0, 2))).indexOf(input) + 1
+    if (matchIndex < 1) {
+      throw new Error()
+    }
+  }],
+  ddd: [matchWord, function (input) {
+    const weekdays = getLocalePart('weekdays')
+    const weekdaysShort = getLocalePart('weekdaysShort')
+    const matchIndex = (weekdaysShort || weekdays.map(_ => _.slice(0, 3))).indexOf(input) + 1
+    if (matchIndex < 1) {
+      throw new Error()
+    }
+  }],
+  dddd: [matchWord, function (input) {
+    const weekdays = getLocalePart('weekdays')
+    const matchIndex = weekdays.indexOf(input) + 1
+    if (matchIndex < 1) {
+      throw new Error()
     }
   }],
   w: [match1to2, addInput('week')],

--- a/test/plugin/customParseFormat.test.js
+++ b/test/plugin/customParseFormat.test.js
@@ -460,3 +460,35 @@ it('parse w, ww', () => {
   const format2 = 'YYYY-[w]ww'
   expect(dayjs(input2, format2).format(format1)).toBe(input2)
 })
+
+describe('parse day strings', () => {
+  it('parse day from string', () => {
+    const input1 = 'Friday, 10 Jan 2025'
+    const format1 = 'dddd, DD MMM YYYY'
+    expect(dayjs(input1, format1).format(format1)).toBe(input1)
+    expect(dayjs(input1, format1).valueOf()).toBe(moment(input1, format1).valueOf())
+    const input2 = '10 Jan 2025'
+    const format2 = 'DD MMM YYYY'
+    expect(dayjs(input2, format2).format('dddd')).toBe(moment(input1, format1).format('dddd'))
+  })
+
+  it('parse day from short string', () => {
+    const input1 = 'Fri, 10 Jan 2025'
+    const format1 = 'ddd, DD MMM YYYY'
+    expect(dayjs(input1, format1).format(format1)).toBe(input1)
+    expect(dayjs(input1, format1).valueOf()).toBe(moment(input1, format1).valueOf())
+    const input2 = '10 Jan 2025'
+    const format2 = 'DD MMM YYYY'
+    expect(dayjs(input2, format2).format('ddd')).toBe(moment(input1, format1).format('ddd'))
+  })
+
+  it('parse day from min string', () => {
+    const input1 = 'Fr, 10 Jan 2025'
+    const format1 = 'dd, DD MMM YYYY'
+    expect(dayjs(input1, format1).format(format1)).toBe(input1)
+    expect(dayjs(input1, format1).valueOf()).toBe(moment(input1, format1).valueOf())
+    const input2 = '10 Jan 2025'
+    const format2 = 'DD MMM YYYY'
+    expect(dayjs(input2, format2).format('dd')).toBe(moment(input1, format1).format('dd'))
+  })
+})


### PR DESCRIPTION
While migrating my project from moment to dayjs, I noticed that day strings ("Monday", "Tuesday", etc) were not being parsed by the customParseFormat plugin.

This PR adds that ability and associated test cases.