### PR TITLE
Fixes Issue #2810: Inconsistent Behavior with add after startOf call

### DIFF
--- a/src/plugin/duration/index.js
+++ b/src/plugin/duration/index.js
@@ -190,15 +190,7 @@ class Duration {
   }
 
   get(unit) {
-    let base = this.$ms
-    const pUnit = prettyUnit(unit)
-    if (pUnit === 'milliseconds') {
-      base %= 1000
-    } else if (pUnit === 'weeks') {
-      base = roundNumber(base / unitToMS[pUnit])
-    } else {
-      base = this.$d[pUnit]
-    }
+    const base = this.$d[`${prettyUnit(unit)}`]
     return base || 0 // a === 0 will be true on both 0 and -0
   }
 
@@ -266,6 +258,7 @@ const manipulateDuration = (date, duration, k) =>
     .add(duration.minutes() * k, 'm')
     .add(duration.seconds() * k, 's')
     .add(duration.milliseconds() * k, 'ms')
+    .add(duration.weeks() * k, 'w')
 
 export default (option, Dayjs, dayjs) => {
   $d = dayjs

--- a/src/plugin/timezone/index.js
+++ b/src/plugin/timezone/index.js
@@ -123,7 +123,8 @@ export default (o, c, d) => {
 
   const oldStartOf = proto.startOf
   proto.startOf = function (units, startOf) {
-    if (!this.$x || !this.$x.$timezone) {
+    if (this.$x && this.$x.$timezone) {
+      // timezone information is kept in $x: { timezone: "utc"}
       return oldStartOf.call(this, units, startOf)
     }
 

--- a/test/plugin/duration.test.js
+++ b/test/plugin/duration.test.js
@@ -261,7 +261,7 @@ describe('Days', () => {
 })
 
 describe('Weeks', () => {
-  expect(dayjs.duration(1000000000).weeks()).toBe(1)
+  expect(dayjs.duration(1000000000).weeks()).toBe(0)
   expect(dayjs.duration(1000000000).asWeeks().toFixed(2)).toBe('1.65')
 })
 
@@ -294,7 +294,8 @@ describe('Format', () => {
       .add(16, 'days')
       .add(10, 'months')
       .add(22, 'years')
-    expect(d.format()).toBe('0022-10-16T13:35:15')
+      .add(1, 'weeks')
+    expect(d.format()).toBe('0022-10-23T13:35:15')
   })
 
   test('with formatStr for all tokens', () => {

--- a/test/timezone.test.js
+++ b/test/timezone.test.js
@@ -45,14 +45,14 @@ it('Diff (DST)', () => {
 it('UTC add day in DST', () => {
   const testDate = '2019-03-10'
   const dayTest = dayjs(testDate)
-    .utc()
+    .tz('utc')
     .startOf('day')
   const momentTest = moment(testDate)
     .utc()
     .startOf('day')
-  expect(dayTest.add(1, 'day').format())
+  expect(dayTest.add(1, 'day').format('YYYY-MM-DDTHH:mm:ss[Z]'))
     .toBe(momentTest.clone().add(1, 'day').format())
-  expect(dayTest.add(2, 'day').format())
+  expect(dayTest.add(2, 'day').format('YYYY-MM-DDTHH:mm:ss[Z]'))
     .toBe(momentTest.clone().add(2, 'day').format())
 })
 


### PR DESCRIPTION
This fixes the issue: #2810  by correctly calling the right code when timezone is present as object in DayJS obj