### PR TITLE
Fixes Issue #2810: Inconsistent Behavior with add after startOf call

### DIFF
--- a/src/plugin/timezone/index.js
+++ b/src/plugin/timezone/index.js
@@ -123,7 +123,8 @@ export default (o, c, d) => {
 
   const oldStartOf = proto.startOf
   proto.startOf = function (units, startOf) {
-    if (!this.$x || !this.$x.$timezone) {
+    if (this.$x && this.$x.$timezone) {
+      // timezone information is kept in $x: { timezone: "utc"}
       return oldStartOf.call(this, units, startOf)
     }
 

--- a/test/timezone.test.js
+++ b/test/timezone.test.js
@@ -45,14 +45,14 @@ it('Diff (DST)', () => {
 it('UTC add day in DST', () => {
   const testDate = '2019-03-10'
   const dayTest = dayjs(testDate)
-    .utc()
+    .tz('utc')
     .startOf('day')
   const momentTest = moment(testDate)
     .utc()
     .startOf('day')
-  expect(dayTest.add(1, 'day').format())
+  expect(dayTest.add(1, 'day').format('YYYY-MM-DDTHH:mm:ss[Z]'))
     .toBe(momentTest.clone().add(1, 'day').format())
-  expect(dayTest.add(2, 'day').format())
+  expect(dayTest.add(2, 'day').format('YYYY-MM-DDTHH:mm:ss[Z]'))
     .toBe(momentTest.clone().add(2, 'day').format())
 })
 


### PR DESCRIPTION
This fixes the issue: https://github.com/iamkun/dayjs/issues/2810 by correctly calling the right code when timezone is present as object in DayJS obj