### PR TITLE
fix the type of unit parameter of the methods that quarterOfYear plugin extends

### DIFF
--- a/types/plugin/quarterOfYear.d.ts
+++ b/types/plugin/quarterOfYear.d.ts
@@ -9,18 +9,18 @@ declare module 'dayjs' {
 
     quarter(quarter: number): Dayjs
 
-    add(value: number, unit: QUnitType): Dayjs
+    add(value: number, unit: QUnitType | OpUnitType): Dayjs
 
-    subtract(value: number, unit: QUnitType): Dayjs
+    subtract(value: number, unit: QUnitType | OpUnitType): Dayjs
 
     startOf(unit: QUnitType | OpUnitType): Dayjs
 
     endOf(unit: QUnitType | OpUnitType): Dayjs
 
-    isSame(date?: ConfigType, unit?: QUnitType): boolean
+    isSame(date?: ConfigType, unit?: QUnitType | OpUnitType): boolean
 
-    isBefore(date?: ConfigType, unit?: QUnitType): boolean
+    isBefore(date?: ConfigType, unit?: QUnitType | OpUnitType): boolean
 
-    isAfter(date?: ConfigType, unit?: QUnitType): boolean
+    isAfter(date?: ConfigType, unit?: QUnitType | OpUnitType): boolean
   }
 }


### PR DESCRIPTION

Example code:

```ts
import dayjs from 'dayjs'
import quarterOfYear from 'dayjs/plugin/quarterOfYear'

dayjs.extend(quarterOfYear)

const _bugsExample = (unit: 'week' | 'quarter') => {
  const dayjsInstance = dayjs()
  dayjsInstance.add(1, unit)
  dayjsInstance.subtract(1, unit)
  dayjsInstance.isSame(Date.now(), unit)
  dayjsInstance.isBefore(Date.now(), unit)
  dayjsInstance.isAfter(Date.now(), unit)
}

```

All reported the error:

```ts

/**

No overload matches this call.
  Overload 1 of 2, '(value: number, unit: QUnitType): Dayjs', gave the following error.
    Argument of type '"week" | "quarter"' is not assignable to parameter of type 'QUnitType'.
      Type '"week"' is not assignable to type 'QUnitType'.
  Overload 2 of 2, '(value: number, unit?: ManipulateType | undefined): Dayjs', gave the following error.
    Argument of type '"week" | "quarter"' is not assignable to parameter of type 'ManipulateType | undefined'.
      Type '"quarter"' is not assignable to type 'ManipulateType | undefined'.ts(2769)

*/

```
