### PR TITLE
feat: add 2 digit Version (gg and GG) for WeekYear and ISOWeekYear

### DIFF
--- a/src/plugin/advancedFormat/index.js
+++ b/src/plugin/advancedFormat/index.js
@@ -12,14 +12,18 @@ export default (o, c) => { // locale needed later
 
     const utils = this.$utils()
     const str = formatStr || FORMAT_DEFAULT
-    const result = str.replace(/\[([^\]]+)]|Q|wo|ww|w|WW|W|zzz|z|gggg|GGGG|Do|X|x|k{1,2}|S/g, (match) => {
+    const result = str.replace(/\[([^\]]+)]|Q|wo|ww|w|WW|W|zzz|z|gggg|gg|GGGG|GG|Do|X|x|k{1,2}|S/g, (match) => {
       switch (match) {
         case 'Q':
           return Math.ceil((this.$M + 1) / 3)
         case 'Do':
           return locale.ordinal(this.$D)
+        case 'gg':
+          return String(this.weekYear()).slice(-2)
         case 'gggg':
           return this.weekYear()
+        case 'GG':
+          return String(this.isoWeekYear()).slice(-2)
         case 'GGGG':
           return this.isoWeekYear()
         case 'wo':

--- a/test/plugin/advancedFormat.test.js
+++ b/test/plugin/advancedFormat.test.js
@@ -100,6 +100,16 @@ it('Format Week of Year wo', () => {
     .toBe(moment(d).locale('zh-cn').format('wo'))
 })
 
+it('Format Week Year gg', () => {
+  const d = '2018-12-31'
+  expect(dayjs(d).format('gg')).toBe(moment(d).format('gg'))
+})
+
+it('Format Iso Week Year GG', () => {
+  const d = '2021-01-01'
+  expect(dayjs(d).format('GG')).toBe(moment(d).format('GG'))
+})
+
 it('Format Week Year gggg', () => {
   const d = '2018-12-31'
   expect(dayjs(d).format('gggg')).toBe(moment(d).format('gggg'))


### PR DESCRIPTION
The advanced format plugin allows two digit year output, but the Week Year and Iso Week Year Plugins only support 4 digit year numbers.

This PR adds the same functionality to Week Year and Iso Week Year Plugin as 'gg' and 'GG' formats.