### PR TITLE
Add types from index to quarterOfYear

### DIFF
--- a/types/plugin/quarterOfYear.d.ts
+++ b/types/plugin/quarterOfYear.d.ts
@@ -1,4 +1,10 @@
-import { PluginFunc, ConfigType, QUnitType, OpUnitType } from 'dayjs'
+import {
+  PluginFunc,
+  ConfigType,
+  ManipulateType,
+  QUnitType,
+  OpUnitType
+} from 'dayjs'
 
 declare const plugin: PluginFunc
 export = plugin
@@ -9,18 +15,18 @@ declare module 'dayjs' {
 
     quarter(quarter: number): Dayjs
 
-    add(value: number, unit: QUnitType): Dayjs
+    add(value: number, unit: QUnitType | ManipulateType): Dayjs
 
-    subtract(value: number, unit: QUnitType): Dayjs
+    subtract(value: number, unit: QUnitType | ManipulateType): Dayjs
 
     startOf(unit: QUnitType | OpUnitType): Dayjs
 
     endOf(unit: QUnitType | OpUnitType): Dayjs
 
-    isSame(date?: ConfigType, unit?: QUnitType): boolean
+    isSame(date?: ConfigType, unit?: QUnitType | OpUnitType): boolean
 
-    isBefore(date?: ConfigType, unit?: QUnitType): boolean
+    isBefore(date?: ConfigType, unit?: QUnitType | OpUnitType): boolean
 
-    isAfter(date?: ConfigType, unit?: QUnitType): boolean
+    isAfter(date?: ConfigType, unit?: QUnitType | OpUnitType): boolean
   }
 }


### PR DESCRIPTION
Resolves an issue where a variable being passed in as unit that may conform to *either* the base function's expected type (e.g., ManipulateType) *or* the augmented function's type (QUnitType) would be considered a type violation:

```ts
type MyUnit = 'days' | 'weeks' | 'months' | 'quarters' | 'years';

const doThing = (date: Dayjs, unit: MyUnit) => {
  if (date.isSame(dayjs(), unit)) {
    return date.add(7, unit);
  }
  return date.subtract(3, unit);
};
```

The types as they stand currently have two overloads: one that takes the base types and one that takes the extended types; neither take _both_, when really, the plugin makes it so that the function can take both kinds. This causes an error when I may pass in `'quarters'` _or_ `'weeks'` because `QUnitType` adds `'quarters'` to `UnitType` and `OpUnitType`/`ManipulateType` adds `'weeks'` but there is no type that has both.

This PR could also add this as a separate overload, if that were important. E.g.:

```ts
add(value: number, unit: QUnitType): Dayjs
add(value: number, unit: QUnitType | ManipulateType): Dayjs
```

But I don't think it is – I don't see any value in an overload _only_ accepting `QUnitType`.

Another open question, I suppose: here are the types today:

```ts
  export type OpUnitType = UnitType | "week" | "weeks" | 'w';
  export type QUnitType = UnitType | "quarter" | "quarters" | 'Q';
  export type ManipulateType = Exclude<OpUnitType, 'date' | 'dates'>;
```

Should the `QUnitType` being passed to `add`/`subtract` also be `Manipulate`d, excluding `'date' | 'dates'`? Are `'date' | 'dates'` valid values for `add`/`subtract` only when the plugin is added?

Maybe:

```ts
  export type OpUnitType = UnitType | "week" | "weeks" | 'w';
  export type QUnitType = UnitType | "quarter" | "quarters" | 'Q';
  export type ManipulateType = Exclude<OpUnitType, 'date' | 'dates'>;
  export type ManipulateQType = Exclude<QUnitType, 'date' | 'dates'>;
```

And maybe `QUnitType` should extend `OpUnitType` rather than `UnitType`? Which would make most of the changes in this PR obsolete, except that we'd replace `add#unit`/`subtract#unit` with `ManipulateQType`?