### PR TITLE
fix: Fix timezone Date parsing for Hermes JS engine

### DIFF
--- a/src/plugin/timezone/index.js
+++ b/src/plugin/timezone/index.js
@@ -9,6 +9,8 @@ const typeToPos = {
   second: 5
 }
 
+const enParseFormat = 'M/D/YYYY, h:mm:ss A';
+
 // Cache time-zone lookups from Intl.DateTimeFormat,
 // as it is a *very* slow method.
 const dtfCache = {}
@@ -96,14 +98,14 @@ export default (o, c, d) => {
     const oldOffset = this.utcOffset()
     const date = this.toDate()
     const target = date.toLocaleString('en-US', { timeZone: timezone })
-    const diff = Math.round((date - new Date(target)) / 1000 / 60)
+    const diff = Math.round((date - d(target, enParseFormat).toDate()) / 1000 / 60)
     const offset = (-Math.round(date.getTimezoneOffset() / 15) * 15) - diff
     const isUTC = !Number(offset)
     let ins
     if (isUTC) { // if utcOffset is 0, turn it to UTC mode
       ins = this.utcOffset(0, keepLocalTime)
     } else {
-      ins = d(target, { locale: this.$L }).$set(MS, this.$ms)
+      ins = d(target, enParseFormat, this.$L).$set(MS, this.$ms)
         .utcOffset(offset, true)
       if (keepLocalTime) {
         const newOffset = ins.utcOffset()


### PR DESCRIPTION
When using the Hermes engine in the newer versions of React Native the timezone plugin doesn't work because there are a few places where the `Date` constructor is used to parse a `en` locale formatted date string and Hermes doesn't support that format of parsing (i.e. `new Date('8/20/1999, 5:00:15 AM')`). This issue results in the timezone plugin always returning GMT and UTC times when used in newer Expo and React Native apps. In order to work around this we can use dayjs itself to parse these dates instead of the native Date constructor. This PR allows dayjs to work in Expo and React Native with the timezone plugin.