### PR TITLE
fix: Format `YY` should never return one-digit years

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -285,7 +285,7 @@ class Dayjs {
     const matches = (match) => {
       switch (match) {
         case 'YY':
-          return String(this.$y).slice(-2)
+          return String(this.$y).slice(-2).padStart(2, '0')
         case 'YYYY':
           return Utils.s(this.$y, 4, '0')
         case 'M':

--- a/test/display.test.js
+++ b/test/display.test.js
@@ -22,7 +22,9 @@ it('Format invalid date', () => {
 })
 
 it('Format Year YY YYYY', () => {
+  const date = '0001-01-01T01:01:01.000Z'
   expect(dayjs().format('YY')).toBe(moment().format('YY'))
+  expect(dayjs(date).format('YY')).toBe(moment(date).format('YY'))
   expect(dayjs().format('YYYY')).toBe(moment().format('YYYY'))
 })
 


### PR DESCRIPTION
I noticed this issue while working on https://github.com/mui/mui-x:

```js
console.log(dayjs().set('year', 2009).format('YY')); // 09
console.log(dayjs().set('year', 9).format('YY')); // 9
```