### PR TITLE
feat: Add lenient validation of the date parsing

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -60,8 +60,19 @@ Utils.l = parseLocale
 Utils.i = isDayjs
 Utils.w = wrapper
 
+const isLenient = (date, inputs) => {
+  if (
+    date.getFullYear() === Number(inputs.year) &&
+    date.getMonth() === Number(inputs.month) &&
+    date.getDate() === Number(inputs.day)
+  ) {
+    return false
+  }
+  return true
+}
+
 const parseDate = (cfg) => {
-  const { date, utc } = cfg
+  const { date, utc, disallowLenient } = cfg
   if (date === null) return new Date(NaN) // null is invalid
   if (Utils.u(date)) return new Date() // today
   if (date instanceof Date) return new Date(date)
@@ -74,8 +85,20 @@ const parseDate = (cfg) => {
         return new Date(Date.UTC(d[1], m, d[3]
           || 1, d[4] || 0, d[5] || 0, d[6] || 0, ms))
       }
-      return new Date(d[1], m, d[3]
+      const parsedDate = new Date(d[1], m, d[3]
         || 1, d[4] || 0, d[5] || 0, d[6] || 0, ms)
+      if (disallowLenient && isLenient(parsedDate, {
+        year: d[1],
+        month: m,
+        day: d[3] || 1,
+        hour: d[4] || 0,
+        minute: d[5] || 0,
+        second: d[6] || 0,
+        millisecond: ms
+      })) {
+        return new Date(NaN)
+      }
+      return parsedDate
     }
   }
 

--- a/test/constructor.test.js
+++ b/test/constructor.test.js
@@ -24,3 +24,26 @@ it('does not break isDayjs', () => {
   expect(dayjs.isDayjs(dayjs())).toBeTruthy()
   expect(dayjs.isDayjs(new Date())).toBeFalsy()
 })
+
+describe('disallowLenient configuration', () => {
+  it('isValid should return false for invalid days using default ISO format', () => {
+    const invalidDate = dayjs('2022-03-35T10:30:00', {
+      disallowLenient: true
+    })
+    expect(invalidDate.isValid()).toBeFalsy()
+  })
+
+  it('isValid should return false for invalid month using default ISO format', () => {
+    const invalidDate = dayjs('2022-13-20T10:30:00', {
+      disallowLenient: true
+    })
+    expect(invalidDate.isValid()).toBeFalsy()
+  })
+
+  it('isValid should return true for valid days using default ISO format', () => {
+    const validDate = dayjs('2022-03-25T10:30:00', {
+      disallowLenient: true
+    })
+    expect(validDate.isValid()).toBeTruthy()
+  })
+})


### PR DESCRIPTION
This pull request is aiming to add validation to the lenient dates ([Issue](https://github.com/iamkun/dayjs/issues/2871))

Current issue:
```js
dayjs('2025-13-36T14:19:39') // note that the month is 13 and day is 36
// output: Thu, 05 Feb 2026 12:19:39 GMT
// which calculates a new date using the remainders from days and months.
```

This PR adds another option called "lenientValidation", where if you will submit such case, you will get a new dayjs invalid instance.

```js
const badDate = dayjs('2025-13-36T14:19:39') // note that the month is 13 and day is 36
badDate.isValid();
// output: False
```

If you have better name for this option, feel free to suggest. I hope this PR is helpful.