### PR TITLE
[en-AU] Use the same ordinal as moment

### DIFF
--- a/src/locale/en-au.js
+++ b/src/locale/en-au.js
@@ -9,7 +9,6 @@ const locale = {
   weekdaysShort: 'Sun_Mon_Tue_Wed_Thu_Fri_Sat'.split('_'),
   monthsShort: 'Jan_Feb_Mar_Apr_May_Jun_Jul_Aug_Sep_Oct_Nov_Dec'.split('_'),
   weekdaysMin: 'Su_Mo_Tu_We_Th_Fr_Sa'.split('_'),
-  ordinal: n => n,
   formats: {
     LT: 'h:mm A',
     LTS: 'h:mm:ss A',
@@ -32,6 +31,11 @@ const locale = {
     MM: '%d months',
     y: 'a year',
     yy: '%d years'
+  },
+  ordinal: (n) => {
+    const s = ['th', 'st', 'nd', 'rd']
+    const v = n % 100
+    return `[${n}${(s[(v - 20) % 10] || s[v] || s[0])}]`
   }
 }
 


### PR DESCRIPTION
The en-AU locale wasn't using ordinal at all. It should follow the same as the other English languages.