### PR TITLE
Unify chinese locales

### DIFF
--- a/src/locale/zh-hk.js
+++ b/src/locale/zh-hk.js
@@ -1,66 +1,12 @@
 // Chinese (Hong Kong) [zh-hk]
 import dayjs from 'dayjs'
+import tw from './zh-tw'
 
 const locale = {
-  name: 'zh-hk',
-  months: '一月_二月_三月_四月_五月_六月_七月_八月_九月_十月_十一月_十二月'.split('_'),
-  monthsShort: '1月_2月_3月_4月_5月_6月_7月_8月_9月_10月_11月_12月'.split('_'),
-  weekdays: '星期日_星期一_星期二_星期三_星期四_星期五_星期六'.split('_'),
-  weekdaysShort: '週日_週一_週二_週三_週四_週五_週六'.split('_'),
-  weekdaysMin: '日_一_二_三_四_五_六'.split('_'),
-  ordinal: (number, period) => {
-    switch (period) {
-      case 'W':
-        return `${number}週`
-      default:
-        return `${number}日`
-    }
-  },
-  formats: {
-    LT: 'HH:mm',
-    LTS: 'HH:mm:ss',
-    L: 'YYYY/MM/DD',
-    LL: 'YYYY年M月D日',
-    LLL: 'YYYY年M月D日 HH:mm',
-    LLLL: 'YYYY年M月D日dddd HH:mm',
-    l: 'YYYY/M/D',
-    ll: 'YYYY年M月D日',
-    lll: 'YYYY年M月D日 HH:mm',
-    llll: 'YYYY年M月D日dddd HH:mm'
-  },
-  relativeTime: {
-    future: '%s內',
-    past: '%s前',
-    s: '幾秒',
-    m: '一分鐘',
-    mm: '%d 分鐘',
-    h: '一小時',
-    hh: '%d 小時',
-    d: '一天',
-    dd: '%d 天',
-    M: '一個月',
-    MM: '%d 個月',
-    y: '一年',
-    yy: '%d 年'
-  },
-  meridiem: (hour, minute) => {
-    const hm = (hour * 100) + minute
-    if (hm < 600) {
-      return '凌晨'
-    } else if (hm < 900) {
-      return '早上'
-    } else if (hm < 1100) {
-      return '上午'
-    } else if (hm < 1300) {
-      return '中午'
-    } else if (hm < 1800) {
-      return '下午'
-    }
-    return '晚上'
-  }
+  ...tw,
+  name: 'zh-hk'
 }
 
 dayjs.locale(locale, null, true)
 
 export default locale
-

--- a/src/locale/zh.js
+++ b/src/locale/zh.js
@@ -1,65 +1,10 @@
 // Chinese [zh]
 import dayjs from 'dayjs'
+import cn from './zh-cn'
 
 const locale = {
-  name: 'zh',
-  weekdays: '星期日_星期一_星期二_星期三_星期四_星期五_星期六'.split('_'),
-  weekdaysShort: '周日_周一_周二_周三_周四_周五_周六'.split('_'),
-  weekdaysMin: '日_一_二_三_四_五_六'.split('_'),
-  months: '一月_二月_三月_四月_五月_六月_七月_八月_九月_十月_十一月_十二月'.split('_'),
-  monthsShort: '1月_2月_3月_4月_5月_6月_7月_8月_9月_10月_11月_12月'.split('_'),
-  ordinal: (number, period) => {
-    switch (period) {
-      case 'W':
-        return `${number}周`
-      default:
-        return `${number}日`
-    }
-  },
-  weekStart: 1,
-  yearStart: 4,
-  formats: {
-    LT: 'HH:mm',
-    LTS: 'HH:mm:ss',
-    L: 'YYYY/MM/DD',
-    LL: 'YYYY年M月D日',
-    LLL: 'YYYY年M月D日Ah点mm分',
-    LLLL: 'YYYY年M月D日ddddAh点mm分',
-    l: 'YYYY/M/D',
-    ll: 'YYYY年M月D日',
-    lll: 'YYYY年M月D日 HH:mm',
-    llll: 'YYYY年M月D日dddd HH:mm'
-  },
-  relativeTime: {
-    future: '%s后',
-    past: '%s前',
-    s: '几秒',
-    m: '1 分钟',
-    mm: '%d 分钟',
-    h: '1 小时',
-    hh: '%d 小时',
-    d: '1 天',
-    dd: '%d 天',
-    M: '1 个月',
-    MM: '%d 个月',
-    y: '1 年',
-    yy: '%d 年'
-  },
-  meridiem: (hour, minute) => {
-    const hm = (hour * 100) + minute
-    if (hm < 600) {
-      return '凌晨'
-    } else if (hm < 900) {
-      return '早上'
-    } else if (hm < 1100) {
-      return '上午'
-    } else if (hm < 1300) {
-      return '中午'
-    } else if (hm < 1800) {
-      return '下午'
-    }
-    return '晚上'
-  }
+  ...cn,
+  name: 'zh'
 }
 
 dayjs.locale(locale, null, true)


### PR DESCRIPTION
`zh` locale is identical to `zh-cn`, `zh-hk` should be identical to `zh-tw`. Unify locales by importing can make bundle size smaller and easier to maintain strings.