### PR TITLE
fix: fix startOf + add chain bug in timezone plugin

### DIFF
--- a/src/plugin/timezone/index.js
+++ b/src/plugin/timezone/index.js
@@ -127,9 +127,10 @@ export default (o, c, d) => {
       return oldStartOf.call(this, units, startOf)
     }
 
-    const withoutTz = d(this.format('YYYY-MM-DD HH:mm:ss:SSS'), { locale: this.$L })
+    const timezone = this.$x.$timezone
+    const withoutTz = this.clone().$set('$x', {})
     const startOfWithoutTz = oldStartOf.call(withoutTz, units, startOf)
-    return startOfWithoutTz.tz(this.$x.$timezone, true)
+    return startOfWithoutTz.tz(timezone, true)
   }
 
   d.tz = function (input, arg1, arg2) {

--- a/test/plugin/timezone.test.js
+++ b/test/plugin/timezone.test.js
@@ -352,3 +352,18 @@ describe('UTC timezone', () => {
     expect(dayjs2.format()).toBe(moment2.format())
   })
 })
+
+describe('add after startOf', () => {
+  it('corrects startOf month in UTC', () => {
+    const originalDay = dayjs.tz('2025-01-31', 'etc/UTC')
+    const startOfDay = originalDay.startOf('month')
+    expect(startOfDay.format('YYYY-MM-DD')).toEqual('2025-01-01')
+  })
+
+  it('corrects startOf and add in UTC', () => {
+    const originalDay = dayjs.tz('2025-01-31', 'etc/UTC')
+    const startOfDay = originalDay.startOf('month')
+    const addedDay = startOfDay.add(3, 'month')
+    expect(addedDay.format('YYYY-MM-DD')).toEqual('2025-04-01')
+  })
+})


### PR DESCRIPTION
#### Problem

- https://github.com/iamkun/dayjs/issues/2882
- I found this issue where `startOf()` followed by `add()` in timezone plugin returns incorrect dates. 

#### Solution

- *modified:* `startOf` method in `plugin/timezone` to properly preserve timestamps
- *added:* test cases for this edge case

