### PR TITLE
fix: timezone parsing bug - Partially addresses #1827

### DIFF
--- a/src/plugin/timezone/index.js
+++ b/src/plugin/timezone/index.js
@@ -1,5 +1,7 @@
 import { MIN, MS } from '../../constant'
 
+const matchOffset = /Z|[+-]\d\d:?\d\d/gi
+
 const typeToPos = {
   year: 0,
   month: 1,
@@ -135,11 +137,11 @@ export default (o, c, d) => {
   d.tz = function (input, arg1, arg2) {
     const parseFormat = arg2 && arg1
     const timezone = arg2 || arg1 || defaultTimezone
-    const previousOffset = tzOffset(+d(), timezone)
-    if (typeof input !== 'string') {
+    if (typeof input !== 'string' || input.match(matchOffset)) {
       // timestamp number || js Date || Day.js
       return d(input).tz(timezone)
     }
+    const previousOffset = tzOffset(+d(), timezone)
     const localTs = d.utc(input, parseFormat).valueOf()
     const [targetTs, targetOffset] = fixOffset(localTs, previousOffset, timezone)
     const ins = d(targetTs).utcOffset(targetOffset)

--- a/test/plugin/timezone.test.js
+++ b/test/plugin/timezone.test.js
@@ -68,6 +68,18 @@ describe('Parse', () => {
     const newMs = dTz.millisecond()
     expect(oldMs).toEqual(newMs)
   })
+
+  it('should apply the offset of the target timezone taking into consideration the timezone of the original date', () => {
+    const dayjs1 = dayjs.tz('2022-03-11T14:29:26.319Z', 'America/Recife')
+    expect(dayjs1.format()).toBe('2022-03-11T11:29:26-03:00')
+    const dayjs2 = dayjs.tz('2012-02-01T13:50:21.01-03:00', 'America/Recife')
+    expect(dayjs2.format()).toBe('2012-02-01T13:50:21-03:00')
+    const dayjs3 = dayjs.tz('2022-02-03T13:50:21-00:00', 'America/Recife')
+    expect(dayjs3.format()).toBe('2022-02-03T10:50:21-03:00')
+    // TODO: support rfc2822 dates
+    // const dayjs4 = dayjs.tz('Fri, 11 Mar 2022 14:29:26 GMT', 'America/Recife')
+    // expect(dayjs4.format()).toBe('2022-03-11T11:29:26-03:00')
+  })
 })
 
 describe('Convert', () => {


### PR DESCRIPTION
Partially addresses [https://github.com/iamkun/dayjs/issues/1827](https://github.com/iamkun/dayjs/issues/1827)

This solution does not work with rfc2822 dates, but fixes the issues with iso dates. It's a good step forward.