### PR TITLE
Add Thai README

### DIFF
--- a/docs/th/README-th.md
+++ b/docs/th/README-th.md
@@ -1,19 +1,19 @@
 <div align="center">
-	<a href="https://go.warp.dev/dayjs" target="_blank">
-		<img alt="Warp sponsorship" width="400" src="https://github.com/warpdotdev/brand-assets/blob/main/Github/Sponsor/Warp-Github-LG-02.png">
-		<br>
-		<h>Warp is built for coding with multiple AI agents</b>
-	</a>
+<a href="https://go.warp.dev/dayjs" target="_blank">
+<img alt="Warp sponsorship" width="400" src="https://github.com/warpdotdev/brand-assets/blob/main/Github/Sponsor/Warp-Github-LG-02.png">
+<br>
+<h>Warp ถูกสร้างขึ้นเพื่อการเขียนโค้ดร่วมกับ AI agent หลายตัว</h>
+</a>
 </div>
 
----   
+---
 
-English | [简体中文](./docs/zh-cn/README.zh-CN.md) | [日本語](./docs/ja/README-ja.md) | [Português Brasileiro](./docs/pt-br/README-pt-br.md) | [한국어](./docs/ko/README-ko.md) | [Español (España)](./docs/es-es/README-es-es.md) | [Русский](./docs/ru/README-ru.md) | [Türkçe](./docs/tr/README-tr.md) | [සිංහල](./docs/si/README-si.md) | [עברית](./docs/he/README-he.md) | [ไทย](./docs/th/README-th.md)
+[English](../../README.md) | [简体中文](../zh-cn/README.zh-CN.md) | [日本語](../ja/README-ja.md) | [Português Brasileiro](../pt-br/README-pt-br.md) | [한국어](../ko/README-ko.md) | [Español (España)](../es-es/README-es-es.md) | [Русский](../ru/README-ru.md) | [Türkçe](../tr/README-tr.md) | [සිංහල](../si/README-si.md) | [עברית](../he/README-he.md) | ไทย
 
 <p align="center"><a href="https://day.js.org/" target="_blank" rel="noopener noreferrer"><img width="550"
                                                                              src="https://user-images.githubusercontent.com/17680888/39081119-3057bbe2-456e-11e8-862c-646133ad4b43.png"
                                                                              alt="Day.js" /></a></p>
-<p align="center">Fast <b>2kB</b> alternative to Moment.js with the same modern API</p>
+<p align="center">ทางเลือกที่รวดเร็ว <b>2kB</b> สำหรับ Moment.js พร้อม API สมัยใหม่แบบเดียวกัน</p>
 <p align="center">
     <a href="https://bundlephobia.com/package/dayjs"><img
             src="https://img.shields.io/bundlephobia/minzip/dayjs?style=flat-square&color=%2345cc11"
@@ -32,88 +32,88 @@ English | [简体中文](./docs/zh-cn/README.zh-CN.md) | [日本語](./docs/ja/R
     </a>
 </p>
 
-> Day.js is a minimalist JavaScript library that parses, validates, manipulates, and displays dates and times for modern browsers with a largely Moment.js-compatible API. If you use Moment.js, you already know how to use Day.js.
+> Day.js เป็นไลบรารี JavaScript ขนาดเล็กที่ใช้สำหรับแปลง ตรวจสอบ ปรับแต่ง และแสดงวันที่และเวลาในเบราว์เซอร์สมัยใหม่ โดยมี API ที่คล้ายกับ Moment.js หากคุณเคยใช้ Moment.js คุณก็สามารถใช้ Day.js ได้ทันที
 
 ```js
 dayjs().startOf('month').add(1, 'day').set('year', 2018).format('YYYY-MM-DD HH:mm:ss');
 ```
 
-* 🕒 Familiar Moment.js API & patterns
-* 💪 Immutable
-* 🔥 Chainable
-* 🌐 I18n support
-* 📦 2kb mini library
-* 👫 All browsers supported
+* 🕒 API และรูปแบบการใช้งานคล้าย Moment.js
+* 💪 ไม่เปลี่ยนแปลงค่าเดิม (Immutable)
+* 🔥 เชื่อมต่อคำสั่งได้ (Chainable)
+* 🌐 รองรับหลายภาษา (I18n)
+* 📦 ไลบรารีขนาดเล็ก 2kb
+* 👫 รองรับทุกเบราว์เซอร์
 
 ---
 
-## Getting Started
+## เริ่มต้นใช้งาน
 
-### Documentation
+### เอกสารประกอบ
 
-You can find more details, API, and other docs on [day.js.org](https://day.js.org/) website.
+สามารถดูรายละเอียดเพิ่มเติม, API และเอกสารอื่น ๆ ได้ที่เว็บไซต์ [day.js.org](https://day.js.org/)
 
-### Installation
+### การติดตั้ง
 
 ```console
 npm install dayjs --save
 ```
 
-📚[Installation Guide](https://day.js.org/docs/en/installation/installation)
+📚[คู่มือการติดตั้ง](https://day.js.org/docs/en/installation/installation)
 
 ### API
 
-It's easy to use Day.js APIs to parse, validate, manipulate, and display dates and times.
+ใช้งาน API ของ Day.js ได้ง่ายในการแปลง ตรวจสอบ ปรับแต่ง และแสดงวันที่และเวลา
 
 ```javascript
-dayjs('2018-08-08') // parse
+dayjs('2018-08-08') // แปลง
 
-dayjs().format('{YYYY} MM-DDTHH:mm:ss SSS [Z] A') // display
+dayjs().format('{YYYY} MM-DDTHH:mm:ss SSS [Z] A') // แสดงผล
 
 dayjs().set('month', 3).month() // get & set
 
-dayjs().add(1, 'year') // manipulate
+dayjs().add(1, 'year') // ปรับแต่ง
 
-dayjs().isBefore(dayjs()) // query
+dayjs().isBefore(dayjs()) // ตรวจสอบ
 ```
 
 📚[API Reference](https://day.js.org/docs/en/parse/parse)
 
 ### I18n
 
-Day.js has great support for internationalization.
+Day.js รองรับการแปลหลายภาษาอย่างดี
 
-But none of them will be included in your build unless you use it.
+แต่จะไม่ถูกเพิ่มเข้าไปใน build ของคุณ เว้นแต่คุณจะเรียกใช้งาน
 
 ```javascript
-import 'dayjs/locale/es' // load on demand
+import 'dayjs/locale/es' // โหลดเมื่อจำเป็น
 
-dayjs.locale('es') // use Spanish locale globally
+dayjs.locale('es') // ใช้ภาษา Spanish ทั่วทั้งโปรเจกต์
 
-dayjs('2018-05-05').locale('zh-cn').format() // use Chinese Simplified locale in a specific instance
+dayjs('2018-05-05').locale('zh-cn').format() // ใช้ภาษาจีนใน instance เฉพาะ
 ```
 
 📚[Internationalization](https://day.js.org/docs/en/i18n/i18n)
 
 ### Plugin
 
-A plugin is an independent module that can be added to Day.js to extend functionality or add new features.
+Plugin คือโมดูลอิสระที่สามารถเพิ่มเข้าไปใน Day.js เพื่อขยายความสามารถหรือเพิ่มฟีเจอร์ใหม่
 
 ```javascript
-import advancedFormat from 'dayjs/plugin/advancedFormat' // load on demand
+import advancedFormat from 'dayjs/plugin/advancedFormat' // โหลดเมื่อจำเป็น
 
-dayjs.extend(advancedFormat) // use plugin
+dayjs.extend(advancedFormat) // ใช้งาน plugin
 
-dayjs().format('Q Do k kk X x') // more available formats
+dayjs().format('Q Do k kk X x') // รูปแบบเพิ่มเติม
 ```
 
-📚[Plugin List](https://day.js.org/docs/en/plugin/plugin)
+📚[รายการ Plugin](https://day.js.org/docs/en/plugin/plugin)
 
-## Sponsors
+## ผู้สนับสนุน
 
-Support this project by becoming a sponsor. Your logo will show up here with a link to your website.
+สนับสนุนโปรเจกต์นี้โดยการเป็นผู้สนับสนุน โลโก้ของคุณจะปรากฏที่นี่พร้อมลิงก์ไปยังเว็บไซต์ของคุณ
 
-[[Become a sponsor via Github](https://github.com/sponsors/iamkun/)] [[Become a sponsor via OpenCollective](https://opencollective.com/dayjs#sponsor)]
+[[เป็นผู้สนับสนุนผ่าน Github](https://github.com/sponsors/iamkun/)] [[เป็นผู้สนับสนุนผ่าน OpenCollective](https://opencollective.com/dayjs#sponsor)]
 
 <a href="https://toyokumo.co.jp" target="_blank">
   <img width="70" src="https://user-images.githubusercontent.com/17680888/197092231-2367b5eb-1e43-467e-a311-23f7cd97b086.png">
@@ -155,14 +155,13 @@ Support this project by becoming a sponsor. Your logo will show up here with a l
   <img width="70" src="https://avatars.githubusercontent.com/u/153308555?s=200&v=4">
 </a>
 
+## ผู้ร่วมพัฒนา
 
-## Contributors
+โปรเจกต์นี้เกิดขึ้นได้ด้วยผู้ร่วมพัฒนาทุกคน
 
-This project exists thanks to all the people who contribute.
+ขอเชิญให้กด 💖 star 💖 เพื่อสนับสนุนเรา ขอบคุณมาก
 
-Please give us a 💖 star 💖 to support us. Thank you.
-
-And thank you to all our backers! 🙏
+และขอขอบคุณผู้สนับสนุนทุกท่าน! 🙏
 
 <a href="https://opencollective.com/dayjs/backer/0/website?requireActive=false" target="_blank"><img width="35" src="https://opencollective.com/dayjs/backer/0/avatar.svg?requireActive=false"></a>
 <a href="https://opencollective.com/dayjs/backer/1/website?requireActive=false" target="_blank"><img width="35" src="https://opencollective.com/dayjs/backer/1/avatar.svg?requireActive=false"></a>
@@ -171,6 +170,6 @@ And thank you to all our backers! 🙏
 <br />
 <a href="https://opencollective.com/dayjs#backers" target="_blank"><img src="https://opencollective.com/dayjs/contributors.svg?width=890" /></a>
 
-## License
+## ลิขสิทธิ์
 
-Day.js is licensed under a [MIT License](./LICENSE).
+Day.js ได้รับอนุญาตภายใต้ [สัญญาอนุญาต MIT](../../LICENSE)


### PR DESCRIPTION
### Description

- Added a new file: `docs/th/README-th.md`, which is a Thai translation of the original English README.
- Covers all sections: project introduction, features, installation, API examples, I18n usage, plugin usage, sponsors, contributors, and license.
- Preserves Markdown formatting, links, images, and code samples as in the original.

### Motivation

To help Thai users better understand and use Day.js.

### Related Issue

Helps with #171 

### Checklist

- [x] Translated README.md to Thai
- [x] Created README-th.md at docs/th/README-th.md with translated content
- [x] Verified completeness and formatting of README-th.md