### PR TITLE
fix(timezone): preserve timezone context when adding calendar units

### DIFF
--- a/test/plugin/timezone.test.js
+++ b/test/plugin/timezone.test.js
@@ -352,3 +352,22 @@ describe('UTC timezone', () => {
     expect(dayjs2.format()).toBe(moment2.format())
   })
 })
+
+describe('Add with timezone', () => {
+  it('add day preserves timezone correctly', () => {
+    const time = 1762066800000
+    const tz = 'US/Pacific'
+
+    const a = dayjs.tz(time, tz).add(1, 'day')
+    const b = dayjs.tz(dayjs.tz(time, tz).add(1, 'day').valueOf(), tz)
+    const c = dayjs.tz(dayjs.tz(time, tz).add(1, 'day').startOf('millisecond').valueOf(), tz)
+
+    // All three should produce the same result
+    expect(a.valueOf()).toBe(b.valueOf())
+    expect(b.valueOf()).toBe(c.valueOf())
+    expect(a.format('YYYY-MM-DD HH:mm:ss')).toBe(b.format('YYYY-MM-DD HH:mm:ss'))
+    expect(b.format('YYYY-MM-DD HH:mm:ss')).toBe(c.format('YYYY-MM-DD HH:mm:ss'))
+    expect(a.valueOf()).toBe(1762156800000)
+    expect(a.format('YYYY-MM-DD HH:mm:ss')).toBe('2025-11-03 00:00:00')
+  })
+})


### PR DESCRIPTION
Fix issue where adding days/weeks/months/years to timezone-aware dayjs objects did not preserve timezone context correctly, causing incorrect valueOf() results when converting back to timezone.

The fix overrides the add() method for timezone-aware objects to:
1. Format the date in timezone context
2. Add calendar units without timezone conversion
3. Convert back to timezone with keepLocalTime=true

This ensures all three approaches produce identical results:
- dayjs.tz(time, tz).add(1, 'day')
- dayjs.tz(dayjs.tz(time, tz).add(1, 'day').valueOf(), tz)
- dayjs.tz(dayjs.tz(time, tz).add(1, 'day').startOf('millisecond').valueOf(), tz)

Fixes issue where valueOf() and format() results were inconsistent after adding calendar units to timezone-aware objects.

Linked Issue 
#2957