### PR TITLE
feat(plugin:duration): Add duration.asObject() method

### DIFF
--- a/src/plugin/duration/index.js
+++ b/src/plugin/duration/index.js
@@ -236,6 +236,18 @@ class Duration {
       .fromNow(!withSuffix)
   }
 
+  asObject() {
+    return {
+      years: this.years(),
+      months: this.months(),
+      days: this.days(),
+      hours: this.hours(),
+      minutes: this.minutes(),
+      seconds: this.seconds(),
+      milliseconds: this.milliseconds()
+    }
+  }
+
   valueOf() {
     return this.asMilliseconds()
   }

--- a/test/plugin/duration.test.js
+++ b/test/plugin/duration.test.js
@@ -309,3 +309,32 @@ describe('Format', () => {
       .toBe('2/02.0002TEST9:09:6:06:8:08:5:05:1:01:010')
   })
 })
+
+it('duration.asObject()', () => {
+  const d = dayjs.duration({
+    years: 1,
+    months: 2,
+    days: 3,
+    hours: 4,
+    minutes: 5,
+    seconds: 6,
+    milliseconds: 7
+  })
+
+  const expectedObject = {
+    years: 1,
+    months: 2,
+    days: 3,
+    hours: 4,
+    minutes: 5,
+    seconds: 6,
+    milliseconds: 7
+  }
+
+  expect(d.asObject()).toEqual(expectedObject)
+
+  // Test from milliseconds (as suggested in issue)
+  const dFromMs = dayjs.duration(1000 * 60 * 60) // 1 hour
+  expect(dFromMs.asObject().hours).toBe(1)
+  expect(dFromMs.asObject().minutes).toBe(0)
+})

--- a/types/plugin/duration.d.ts
+++ b/types/plugin/duration.d.ts
@@ -25,12 +25,24 @@ declare namespace plugin {
     & ((ISO_8601: string) => Duration)
   type AddDurationType = CreateDurationType & ((duration: Duration) => Duration)
 
+  interface DurationAsObject {
+    years: number;
+    months: number;
+    days: number;
+    hours: number;
+    minutes: number;
+    seconds: number;
+    milliseconds: number;
+  }
+
   interface Duration {
     new (input: string | number | object, unit?: string, locale?: string): Duration
 
     clone(): Duration
 
     humanize(withSuffix?: boolean): string
+
+    asObject(): DurationAsObject
 
     milliseconds(): number
     asMilliseconds(): number


### PR DESCRIPTION
Hi maintainers,

This PR adds the new duration.asObject() method, as requested in issue #2971.

Closes: #2971

Summary
Adds the asObject() method to the Duration class in src/plugin/duration/index.js.

Updates types/plugin/duration.d.ts with a new DurationAsObject interface and the asObject() method.

Adds a new test suite to test/plugin/duration.test.js to validate the new method.

This change passes all npm run lint and npm test checks and maintains 100% test coverage.

Happy to make any adjustments!