### PR TITLE
Fix: remove unnecessary RLM characters from Arabic locale format (fix…

### DIFF
--- a/src/locale/ar.js
+++ b/src/locale/ar.js
@@ -76,7 +76,7 @@ const locale = {
   formats: {
     LT: 'HH:mm',
     LTS: 'HH:mm:ss',
-    L: 'D/‏M/‏YYYY',
+    L: 'D/M/YYYY',
     LL: 'D MMMM YYYY',
     LLL: 'D MMMM YYYY HH:mm',
     LLLL: 'dddd D MMMM YYYY HH:mm'


### PR DESCRIPTION
🟢 Title

Remove unnecessary Right-to-Left Mark (U+200F) from Arabic locale format L

📝 Description

This PR removes the Right-to-Left Mark characters (RLM, U+200F) from the Arabic (ar) locale’s L date format.

Reason

The L format currently contains RLM characters:

`L: 'D[U+200F]/M[U+200F]/YYYY'`


These characters are intended to adjust text direction, but:

Numbers and dates in Arabic are written left-to-right.

RLM is unnecessary for correct formatting.

When rendered in HTML or mixed-direction environments, these characters often cause dates to appear in the wrong order (e.g., year/month/day swapped or visually flipped).

The presence of hidden directional marks leads to inconsistent rendering across browsers and frameworks.

What this PR changes

Replaces the existing L format:

```
- L: 'D[U+200F]/M[U+200F]/YYYY',
+ L: 'D/M/YYYY',
```


No other locale settings are modified.

✅ Benefits

- Aligns the Arabic locale with real-world typographic rules.
- Prevents incorrect reordering of date components in browsers.
- Removes hidden characters that cause rendering issues in RTL/LTR mixed contexts.
- Makes the behavior consistent with other date libraries and expectations.

🔍 Related Issue

Fixes #2977 