### PR TITLE
fix(locale): remove unnecessary RLM characters from Arabic locale format L

### DIFF
--- a/src/locale/ar.js
+++ b/src/locale/ar.js
@@ -76,7 +76,7 @@ const locale = {
   formats: {
     LT: 'HH:mm',
     LTS: 'HH:mm:ss',
-    L: 'D/‏M/‏YYYY',
+    L: 'D/M/YYYY',
     LL: 'D MMMM YYYY',
     LLL: 'D MMMM YYYY HH:mm',
     LLLL: 'dddd D MMMM YYYY HH:mm'


### PR DESCRIPTION
## Summary
Removes unnecessary Right-to-Left Mark (U+200F) characters from the Arabic locale `L` date format.

## Problem
The Arabic locale format `L` contained RLM characters (`D/‏M/‏YYYY`) that caused:
- Incorrect date rendering in HTML contexts
- Visual reordering or misalignment of day, month, and year
- The order of date components appearing incorrectly depending on surrounding text direction

## Solution
Removed the RLM characters from the format: `D/M/YYYY`

This is the correct approach because numbers and dates are written left-to-right in Arabic typography and should not have their direction altered by RLM characters.

## Test plan
- [x] Verified format no longer contains hidden Unicode characters
- [x] Date formatting produces clean output without direction control characters

Fixes #2977

Contribution by Gittensor, see my contribution statistics at https://gittensor.io/miners/details?githubId=101010297