### PR TITLE
fix: correct week calculation when date is before year start week

### DIFF
--- a/src/plugin/weekOfYear/index.js
+++ b/src/plugin/weekOfYear/index.js
@@ -19,7 +19,12 @@ export default (o, c, d) => {
     const yearStartWeek = yearStartDay.startOf(W).subtract(1, MS)
     const diffInWeek = this.diff(yearStartWeek, W, true)
     if (diffInWeek < 0) {
-      return d(this).startOf('week').week()
+      // Date is before the year start week, so it belongs to the previous year's last week
+      // Calculate the previous year's year start day
+      const prevYearStartDay = d(this).startOf(Y).subtract(1, Y).date(yearStart)
+      const prevYearStartWeek = prevYearStartDay.startOf(W).subtract(1, MS)
+      const prevDiffInWeek = this.diff(prevYearStartWeek, W, true)
+      return Math.ceil(prevDiffInWeek)
     }
     return Math.ceil(diffInWeek)
   }

--- a/test/plugin/weekOfYear.test.js
+++ b/test/plugin/weekOfYear.test.js
@@ -60,3 +60,35 @@ it('Format w ww wo', () => {
   const M = moment(day)
   expect(D.format('w ww wo')).toBe(M.format('w ww wo'))
 })
+
+it('Issue #2987: Week number after subtracting one week from January 4, 2026', () => {
+  dayjs.locale('en')
+  moment.locale('en')
+  // Subtracting one week from January 4, 2026 should give December 28, 2025
+  const result = dayjs('2026-01-04').subtract(1, 'w')
+  const momentResult = moment('2026-01-04').subtract(1, 'w')
+
+  // Check the week number matches moment.js
+  expect(result.week()).toBe(momentResult.week())
+
+  // Check the format matches moment.js
+  expect(result.format('YYYY年w周')).toBe(momentResult.format('YYYY年w周'))
+})
+
+it('Issue #2987: Week number with en-gb locale (yearStart: 4)', () => {
+  dayjs.locale('en-gb')
+  moment.locale('en-gb')
+  // With yearStart: 4, December 28, 2025 should be week 52 of 2025, not week 1
+  const result = dayjs('2026-01-04').subtract(1, 'w')
+  const momentResult = moment('2026-01-04').subtract(1, 'w')
+
+  // Check the week number matches moment.js
+  expect(result.week()).toBe(momentResult.week())
+
+  // Check the format matches moment.js
+  expect(result.format('YYYY年w周')).toBe(momentResult.format('YYYY年w周'))
+
+  // With en-gb locale, it should be 2025年52周, not 2025年1周
+  const formatted = result.format('YYYY年w周')
+  expect(formatted).toBe('2025年52周')
+})


### PR DESCRIPTION
 Closes #2987

When subtracting one week from January 4, 2026, the week number was incorrectly calculated as week 1 of 2025 instead of the correct week (52 or 53 depending on locale).

The issue was in the recursive call when diffInWeek < 0. This fix replaces the recursive call with proper calculation based on the previous year's year start.

- Fix week calculation for dates before year start week
- Add test cases for issue #2987

Contribution by Gittensor, see my contribution statistics at https://gittensor.io/miners/details?githubId=102175066