### PR TITLE
fix(duration): normalize time components when parsing ISO8601 duratio…

### DIFF
--- a/src/plugin/duration/index.js
+++ b/src/plugin/duration/index.js
@@ -94,6 +94,7 @@ class Duration {
           this.$d.minutes,
           this.$d.seconds
         ] = numberD
+        this.normalizeTimeComponents()
         this.calMilliseconds()
         return this
       }
@@ -105,6 +106,21 @@ class Duration {
     this.$ms = Object.keys(this.$d).reduce((total, unit) => (
       total + ((this.$d[unit] || 0) * (unitToMS[unit]))
     ), 0)
+  }
+
+  normalizeTimeComponents() {
+    // Normalize seconds to minutes
+    if (this.$d.seconds >= 60 || this.$d.seconds <= -60) {
+      const minutesToAdd = roundNumber(this.$d.seconds / 60)
+      this.$d.minutes = (this.$d.minutes || 0) + minutesToAdd
+      this.$d.seconds = this.$d.seconds % 60
+    }
+    // Normalize minutes to hours
+    if (this.$d.minutes >= 60 || this.$d.minutes <= -60) {
+      const hoursToAdd = roundNumber(this.$d.minutes / 60)
+      this.$d.hours = (this.$d.hours || 0) + hoursToAdd
+      this.$d.minutes = this.$d.minutes % 60
+    }
   }
 
   parseFromMilliseconds() {

--- a/test/plugin/duration.test.js
+++ b/test/plugin/duration.test.js
@@ -108,6 +108,17 @@ describe('Parse ISO string', () => {
   it('Invalid ISO string', () => {
     expect(dayjs.duration('Invalid').toISOString()).toBe('P0D')
   })
+  it('ISO string with minutes exceeding 60 should normalize', () => {
+    const d = dayjs.duration('PT75M')
+    expect(d.minutes()).toBe(15)
+    expect(d.hours()).toBe(1)
+    expect(d.format('H:m')).toBe('1:15')
+  })
+  it('ISO string with 70 minutes should normalize to 1 hour 10 minutes', () => {
+    const d = dayjs.duration('PT70M')
+    expect(d.minutes()).toBe(10)
+    expect(d.hours()).toBe(1)
+  })
 })
 
 it('Is duration', () => {


### PR DESCRIPTION
…n strings

Fix issue where ISO8601 duration strings with minutes or seconds exceeding their normal ranges (e.g., PT75M) were not normalized, causing incorrect values to be returned by .minutes() and .hours() methods.

Changes:
- Add normalizeTimeComponents() method to normalize seconds->minutes and minutes->hours when parsing ISO8601 strings
- Only normalize time components (not date components like hours->days) to preserve existing behavior for large hour values
- Apply normalization after parsing ISO8601 strings, before calculating milliseconds

Fixes:
- dayjs.duration('PT75M').minutes() now returns 15 instead of 75
- dayjs.duration('PT75M').hours() now returns 1 instead of 0
- dayjs.duration('PT75M').format('H:m') now returns '1:15' instead of '0:75'

Tests:
- Add test cases for PT75M and PT70M normalization
- All existing tests continue to pass, including PT2777H46M40S which correctly preserves large hour values

Fixes #2985

Contribution by Gittensor, see my contribution statistics at https://gittensor.io/miners/details?githubId=102175066