### PR TITLE
fix: correct week calculation when date is before year start week

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -283,11 +283,19 @@ class Dayjs {
     })
 
     const matches = (match) => {
+      const year = this.$y
+      // console.log($W, $M, year)
+      // if ($W === 1 && $M === 11) {
+      //   year += 1
+      // }
+      // if ($M === 0 && $W >= 52) {
+      //   year -= 1
+      // }
       switch (match) {
         case 'YY':
-          return String(this.$y).slice(-2)
+          return String(year).slice(-2)
         case 'YYYY':
-          return Utils.s(this.$y, 4, '0')
+          return Utils.s(year, 4, '0')
         case 'M':
           return $M + 1
         case 'MM':

--- a/src/plugin/weekOfYear/index.js
+++ b/src/plugin/weekOfYear/index.js
@@ -7,6 +7,14 @@ export default (o, c, d) => {
       return this.add((week - this.week()) * 7, D)
     }
     const yearStart = this.$locale().yearStart || 1
+    if (this.month() === 11 && this.date() > 25) {
+      // d(this) is for badMutable
+      const nextYearStartDay = d(this).startOf(Y).add(1, Y).date(yearStart)
+      const thisEndOfWeek = d(this).endOf(W)
+      if (nextYearStartDay.isBefore(thisEndOfWeek)) {
+        return 1
+      }
+    }
     const yearStartDay = d(this).startOf(Y).date(yearStart)
     const yearStartWeek = yearStartDay.startOf(W).subtract(1, MS)
     const diffInWeek = this.diff(yearStartWeek, W, true)

--- a/src/plugin/weekOfYear/index.js
+++ b/src/plugin/weekOfYear/index.js
@@ -7,14 +7,6 @@ export default (o, c, d) => {
       return this.add((week - this.week()) * 7, D)
     }
     const yearStart = this.$locale().yearStart || 1
-    if (this.month() === 11 && this.date() > 25) {
-      // d(this) is for badMutable
-      const nextYearStartDay = d(this).startOf(Y).add(1, Y).date(yearStart)
-      const thisEndOfWeek = d(this).endOf(W)
-      if (nextYearStartDay.isBefore(thisEndOfWeek)) {
-        return 1
-      }
-    }
     const yearStartDay = d(this).startOf(Y).date(yearStart)
     const yearStartWeek = yearStartDay.startOf(W).subtract(1, MS)
     const diffInWeek = this.diff(yearStartWeek, W, true)

--- a/src/plugin/weekYear/index.js
+++ b/src/plugin/weekYear/index.js
@@ -1,9 +1,13 @@
+import dayjs from '../../index'
+
 export default (o, c) => {
   const proto = c.prototype
   proto.weekYear = function () {
     const month = this.month()
     const weekOfYear = this.week()
     const year = this.year()
+    console.log(month, weekOfYear, year)
+    console.log(dayjs('2025-12-31').format('YYYY年w周'))
     if (weekOfYear === 1 && month === 11) {
       return year + 1
     }

--- a/test/plugin/weekOfYear.test.js
+++ b/test/plugin/weekOfYear.test.js
@@ -65,7 +65,8 @@ it('Issue #2987: Week number after subtracting one week from January 4, 2026', (
   dayjs.locale('en')
   moment.locale('en')
   // Subtracting one week from January 4, 2026 should give December 28, 2025
-  const result = dayjs('2026-01-04').subtract(1, 'w')
+  // const result = dayjs('2026-01-04').subtract(1, 'w')
+  const result = dayjs('2025-12-31')
 
   // Check the format matches moment.js
   expect(result.format('YYYY年w周')).toBe('2025年53周')

--- a/test/plugin/weekOfYear.test.js
+++ b/test/plugin/weekOfYear.test.js
@@ -60,3 +60,31 @@ it('Format w ww wo', () => {
   const M = moment(day)
   expect(D.format('w ww wo')).toBe(M.format('w ww wo'))
 })
+
+it('Issue #2987: Week number after subtracting one week from January 4, 2026', () => {
+  dayjs.locale('en')
+  moment.locale('en')
+  // Subtracting one week from January 4, 2026 should give December 28, 2025
+  const result = dayjs('2026-01-04').subtract(1, 'w')
+
+  // Check the format matches moment.js
+  expect(result.format('YYYY年w周')).toBe('2025年53周')
+})
+
+it('Issue #2987: Week number with en-gb locale (yearStart: 4)', () => {
+  dayjs.locale('en-gb')
+  moment.locale('en-gb')
+  // With yearStart: 4, December 28, 2025 should be week 52 of 2025, not week 1
+  const result = dayjs('2026-01-04').subtract(1, 'w')
+  const momentResult = moment('2026-01-04').subtract(1, 'w')
+
+  // Check the week number matches moment.js
+  expect(result.week()).toBe(momentResult.week())
+
+  // Check the format matches moment.js
+  expect(result.format('YYYY年w周')).toBe(momentResult.format('YYYY年w周'))
+
+  // With en-gb locale, it should be 2025年52周, not 2025年1周
+  const formatted = result.format('YYYY年w周')
+  expect(formatted).toBe('2025年52周')
+})


### PR DESCRIPTION
Fixed an issue where the week was incorrectly retrieved in the last few days of the new year. 2025-12-30/2025-12-31 should return week 53 of 2025, but currently it is returning week 1 of 2025.