### PR TITLE
feat(locale): add Odia (or) locale support

### DIFF
--- a/src/locale/or.js
+++ b/src/locale/or.js
@@ -1,1 +1,44 @@
+import dayjs from "dayjs";
 
+const locale = {
+  name: "or",
+  weekdays: "ରବିବାର_ସୋମବାର_ମଙ୍ଗଳବାର_ବୁଧବାର_ଗୁରୁବାର_ଶୁକ୍ରବାର_ଶନିବାର".split("_"),
+  months:
+    "ଜାନୁଆରୀ_ଫେବୃଆରୀ_ମାର୍ଚ୍ଚ_ଅପ୍ରେଲ_ମେ_ଜୁନ_ଜୁଲାଇ_ଅଗଷ୍ଟ_ସେପ୍ଟେମ୍ବର_ଅକ୍ଟୋବର_ନଭେମ୍ବର_ଡିସେମ୍ବର".split(
+      "_",
+    ),
+  weekdaysShort: "ରବି_ସୋମ_ମଙ୍ଗଳ_ବୁଧ_ଗୁରୁ_ଶୁକ୍ର_ଶନି".split("_"),
+  monthsShort:
+    "ଜାନୁ._ଫେବ୍._ମାର୍._ଅପ୍ରେ._ମେ_ଜୁନ୍_ଜୁଲା._ଅଗ._ସେପ୍._ଅକ୍ଟୋ._ନଭେ._ଡିସେ.".split(
+      "_",
+    ),
+  weekdaysMin: "ର_ସୋ_ମଂ_ବୁ_ଗୁ_ଶୁ_ଶ".split("_"),
+  ordinal: (n) => n,
+  formats: {
+    LT: "A h:mm",
+    LTS: "A h:mm:ss",
+    L: "DD/MM/YYYY",
+    LL: "D MMMM YYYY",
+    LLL: "D MMMM YYYY, A h:mm",
+    LLLL: "dddd, D MMMM YYYY, A h:mm",
+  },
+  relativeTime: {
+    future: "%s ପରେ",
+    past: "%s ପୂର୍ବରୁ",
+    s: "କିଛି ମୁହୂର୍ତ୍ତ",
+    m: "ଏକ ମିନିଟ୍",
+    mm: "%d ମିନିଟ୍",
+    h: "ଏକ ଘଣ୍ଟା",
+    hh: "%d ଘଣ୍ଟା",
+    d: "ଏକ ଦିନ",
+    dd: "%d ଦିନ",
+    M: "ଏକ ମାସ",
+    MM: "%d ମାସ",
+    y: "ଏକ ବର୍ଷ",
+    yy: "%d ବର୍ଷ",
+  },
+};
+
+dayjs.locale(locale, undefined, true);
+
+export default locale;


### PR DESCRIPTION
### Summary
This pull request introduces full locale support for **Odia (ଓଡ଼ିଆ)** by adding a
new `or.js` locale file. Odia is an Indo‑Aryan language spoken by more than
40 million people, primarily in the Indian state of Odisha. Day.js currently
does not include an Odia locale, and this addition enables developers to
provide accurate date, time, and relative‑time formatting for Odia‑speaking
users.

### Details
The new locale definition includes:

- Full month names and abbreviated month names in Odia
- Full weekday names, short forms, and minimal forms
- Odia‑appropriate long date formats (LT, LTS, L, LL, LLL, LLLL)
- Natural Odia relative‑time expressions for past and future
- Locale metadata (`name: "or"`)
- Registration via `dayjs.locale(locale, undefined, true)`

All translations follow standard Odia usage and Unicode‑consistent spellings.

### Rationale
Odia is an officially recognized language of India (8th Schedule) and widely
used across government, legal, educational, and consumer applications. Adding
native support in Day.js improves accessibility and localization coverage for
a large user base across India and the Odia‑speaking diaspora.

### Notes
- Odia does not use a suffix equivalent to “बजे” (Hindi), so time formats
  follow natural Odia structure without additional markers.
- Relative‑time strings are based on common modern usage and verified against
  widely accepted Odia linguistic conventions.

### Checklist
- [x] Added `or.js` locale file
- [x] Verified translations for months, weekdays, and relative time
- [x] Ensured formatting consistency with other Indian language locales
- [x] Locale registered correctly with `dayjs.locale()`

