### PR TITLE
Documentation: Fix pronoun inconsistency in Plugin section

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ dayjs().isBefore(dayjs()) // query
 
 Day.js has great support for internationalization.
 
-But none of them will be included in your build unless you use it.
+But none of them will be included in your build unless you use them.
 
 ```javascript
 import 'dayjs/locale/es' // load on demand


### PR DESCRIPTION
## Description
There's a pronoun inconsistency in the Plugin section of the README that makes the sentence ambiguous.

## Current
"But none of them will be included in your build unless you use it."

## Expected
"But none of these will be included in your build unless you use them."

## Details
The original sentence mixes plural ("them") with singular ("it"), creating ambiguity about what "it" refers to. This is particularly confusing for non-native English speakers.

**Problems with the current wording:**
- "them" = plural (plugins)
- "it" = singular and unclear (does it refer to a single plugin? the plugin system?)

**Solution:**
- Use "these" (plural) and "them" (plural) to maintain pronoun consistency
- Makes the intent immediately clear: plugins are only bundled when you use them

## Type
Documentation / Minor enhancement


Fixes #2997 