### PR TITLE
fix(locale): Add ordinals for french canadian

### DIFF
--- a/src/locale/fr-ca.js
+++ b/src/locale/fr-ca.js
@@ -8,8 +8,15 @@ const locale = {
   weekdaysShort: 'dim._lun._mar._mer._jeu._ven._sam.'.split('_'),
   monthsShort: 'janv._févr._mars_avr._mai_juin_juil._août_sept._oct._nov._déc.'.split('_'),
   weekdaysMin: 'di_lu_ma_me_je_ve_sa'.split('_'),
-  ordinal: (n) => {
-    const o = n === 1 ? 'er' : ''
+  ordinal: (n, p) => {
+    const isFirst = n === 1
+
+    if (p === 'W') {
+      const o = isFirst ? 're' : 'e'
+      return `${n}${o}`
+    }
+
+    const o = isFirst ? 'er' : ''
     return `${n}${o}`
   },
   formats: {

--- a/src/locale/fr-ca.js
+++ b/src/locale/fr-ca.js
@@ -8,7 +8,10 @@ const locale = {
   weekdaysShort: 'dim._lun._mar._mer._jeu._ven._sam.'.split('_'),
   monthsShort: 'janv._févr._mars_avr._mai_juin_juil._août_sept._oct._nov._déc.'.split('_'),
   weekdaysMin: 'di_lu_ma_me_je_ve_sa'.split('_'),
-  ordinal: n => n,
+  ordinal: (n) => {
+    const o = n === 1 ? 'er' : ''
+    return `${n}${o}`
+  },
   formats: {
     LT: 'HH:mm',
     LTS: 'HH:mm:ss',

--- a/test/locale/fr-ca.test.js
+++ b/test/locale/fr-ca.test.js
@@ -1,0 +1,16 @@
+import dayjs from '../../src'
+import advancedFormat from '../../src/plugin/advancedFormat'
+import weekOfYear from '../../src/plugin/weekOfYear'
+import '../../src/locale/fr-ca'
+
+dayjs.extend(advancedFormat).extend(weekOfYear)
+
+test('ordinal', () => {
+  const firstDayFirstWeek = dayjs('2022-01-01').locale('fr-ca')
+  const secondDaySecondWeek = dayjs('2022-01-02').locale('fr-ca')
+
+  expect(firstDayFirstWeek.format('Do')).toEqual('1er')
+  expect(firstDayFirstWeek.format('wo')).toEqual('1re')
+  expect(secondDaySecondWeek.format('Do')).toEqual('2')
+  expect(secondDaySecondWeek.format('wo')).toEqual('2e')
+})


### PR DESCRIPTION
For the day, just like in #2010, in Québec we say 1er only for the first day.

https://vitrinelinguistique.oqlf.gouv.qc.ca/21242/la-typographie/nombres/ecriture-des-dates-et-des-heures-dans-les-lettres-et-les-textes-courants