### PR TITLE
fix: pad milliseconds to 3 digits when parsing (fixes #1331)

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -69,7 +69,7 @@ const parseDate = (cfg) => {
     const d = date.match(C.REGEX_PARSE)
     if (d) {
       const m = d[2] - 1 || 0
-      const ms = (d[7] || '0').substring(0, 3)
+      const ms = (d[7] || '0').padEnd(3, '0').substring(0, 3)
       if (utc) {
         return new Date(Date.UTC(d[1], m, d[3]
           || 1, d[4] || 0, d[5] || 0, d[6] || 0, ms))

--- a/test/milliseconds-padding.test.js
+++ b/test/milliseconds-padding.test.js
@@ -1,0 +1,35 @@
+import dayjs from '../src'
+
+describe('Milliseconds padding bug (Issue #1331)', () => {
+  it('parses 2-digit milliseconds correctly (.62 should be 620ms not 62ms)', () => {
+    const timestamp = '2026-01-01T10:00:00.62'
+    const expected = new Date(timestamp).getTime() // 620ms
+    const actual = dayjs(timestamp).valueOf()
+
+    expect(actual).toBe(expected)
+  })
+
+  it('parses 1-digit milliseconds correctly (.6 should be 600ms not 6ms)', () => {
+    const timestamp = '2026-01-01T10:00:00.6'
+    const expected = new Date(timestamp).getTime() // 600ms
+    const actual = dayjs(timestamp).valueOf()
+
+    expect(actual).toBe(expected)
+  })
+
+  it('parses 3-digit milliseconds correctly (existing behavior)', () => {
+    const timestamp = '2026-01-01T10:00:00.620'
+    const expected = new Date(timestamp).getTime()
+    const actual = dayjs(timestamp).valueOf()
+
+    expect(actual).toBe(expected)
+  })
+
+  it('handles missing milliseconds', () => {
+    const timestamp = '2026-01-01T10:00:00'
+    const expected = new Date(timestamp).getTime()
+    const actual = dayjs(timestamp).valueOf()
+
+    expect(actual).toBe(expected)
+  })
+})


### PR DESCRIPTION
## Fix milliseconds parsing for 1-2 digit values (fixes #1331)

### Problem

When parsing ISO 8601 timestamps with 1- or 2-digit milliseconds, dayjs incorrectly interprets them as literal values instead of left-padding to 3 digits.

**Example:**

```js
dayjs('2026-01-01T10:00:00.62').valueOf()
// Current:  1767258000062  (.62 interpreted as 62ms)
// Expected: 1767258000620  (.62 should be 620ms)

dayjs('2026-01-01T10:00:00.6').valueOf()
// Current:  1767258000006  (.6 interpreted as 6ms)
// Expected: 1767258000600  (.6 should be 600ms)
```

This differs from native `Date()` behavior and causes sorting/comparison bugs when SQL Server (or other systems) trim trailing zeros from datetime serialization (`.620` → `.62`).

**Root cause:**

The regex parser extracts milliseconds as-is and truncates to 3 characters, but doesn't pad:

```js
const ms = (d[7] || '0').substring(0, 3)
// '.62' → '62' → 62ms (wrong)
```

---

### Solution

Pad the milliseconds string to 3 digits **before** truncating:

```js
const ms = (d[7] || '0').padEnd(3, '0').substring(0, 3)
// '.62' → '620' → 620ms (correct)
// '.6'  → '600' → 600ms (correct)
// '.620' → '620' → 620ms (unchanged)
```

This aligns dayjs parsing with:
- Native `Date()` behavior
- ISO 8601 standard (fractional seconds are right-padded)
- User expectations documented in #1331

---

### Tests

Added comprehensive test coverage in `test/milliseconds-padding.test.js`:
- ✅ 2-digit milliseconds (`.62` → 620ms)
- ✅ 1-digit milliseconds (`.6` → 600ms)
- ✅ 3-digit milliseconds (`.620` → unchanged)
- ✅ Missing milliseconds (fallback to 0)

---

**Closes #1331**