### PR TITLE
fix(updateLocale): merge nested objects for partial locale updates

### DIFF
--- a/src/plugin/updateLocale/index.js
+++ b/src/plugin/updateLocale/index.js
@@ -5,7 +5,15 @@ export default (option, Dayjs, dayjs) => {
     if (!localeConfig) return
     const customConfigKeys = customConfig ? Object.keys(customConfig) : []
     customConfigKeys.forEach((c) => {
-      localeConfig[c] = customConfig[c]
+      if (localeConfig[c] && customConfig[c] && typeof localeConfig[c] === 'object' && typeof customConfig[c] === 'object'
+        && !Array.isArray(localeConfig[c])) {
+        localeConfig[c] = {
+          ...localeConfig[c],
+          ...customConfig[c]
+        }
+      } else {
+        localeConfig[c] = customConfig[c]
+      }
     })
     return localeConfig // eslint-disable-line consistent-return
   }

--- a/test/plugin/updateLocale.test.js
+++ b/test/plugin/updateLocale.test.js
@@ -69,6 +69,35 @@ describe('Update locale', () => {
       .toEqual(moment().format(formatString))
   })
 
+  it('Partial update to nested object (formats)', () => {
+    dayjs.locale('en')
+    // First, get the original formats
+    const originalLocale = dayjs.Ls.en
+    const originalLT = originalLocale.formats && originalLocale.formats.LT
+
+    // Update only L format
+    dayjs.updateLocale('en', {
+      formats: {
+        L: 'DD/MM/YYYY'
+      }
+    })
+
+    const updatedLocale = dayjs.Ls.en
+    // The updated key should have the new value
+    expect(updatedLocale.formats.L).toBe('DD/MM/YYYY')
+    // Other keys in formats should be preserved
+    expect(updatedLocale.formats.LT).toBe(originalLT)
+  })
+
+  it('Non-object values should still be replaced entirely', () => {
+    const newMonths = new Array(12).fill('newMonth')
+    dayjs.updateLocale('en', {
+      months: newMonths
+    })
+    const updatedLocale = dayjs.Ls.en
+    expect(updatedLocale.months).toEqual(newMonths)
+  })
+
   it('Update invalid date string', () => {
     const locale = 'en'
     const localeSetting = { invalidDate: 'bad date' }


### PR DESCRIPTION
## Summary
- Fixes the `updateLocale` plugin to shallow-merge nested object properties (like `formats`, `relativeTime`) instead of replacing the entire object when only a subset of keys is provided
- Arrays and non-object values continue to be replaced entirely, preserving existing behavior
- Adds tests for partial nested object updates and array replacement

Fixes #1118

## Test plan
- [x] Existing `updateLocale` tests continue to pass
- [x] New test: partial update to `formats` preserves unmodified keys (e.g., updating only `L` keeps `LT`, `LL`, etc.)
- [x] New test: array values (like `months`) are still replaced entirely, not merged
- [x] 100% code coverage on the updateLocale plugin