### PR TITLE
docs: add noopener to external links

### DIFF
--- a/docs/fr/README-fr.md
+++ b/docs/fr/README-fr.md
@@ -101,7 +101,7 @@ dayjs().format('Q Do k kk X x') // more available formats
 
 ### Tendance d'utilisation
 
-<a href="https://npm-compare.com/moment,dayjs/#timeRange=THREE_YEARS" target="_blank">
+<a href="https://npm-compare.com/moment,dayjs/#timeRange=THREE_YEARS" target="_blank" rel="noopener noreferrer">
   <img src="https://user-images.githubusercontent.com/3455798/270162667-c7bd2ebe-675e-45c6-a2c9-dc67f3b65d6e.png">
 </a>
 

--- a/docs/sw/README-sw.md
+++ b/docs/sw/README-sw.md
@@ -100,7 +100,7 @@ dayjs().format('Q Do k kk X x') // njia zaidi zilizopo
 
 ### Trend Zinazoweza Tumika
 
-<a href="https://npm-compare.com/moment,dayjs/#timeRange=THREE_YEARS" target="_blank">
+<a href="https://npm-compare.com/moment,dayjs/#timeRange=THREE_YEARS" target="_blank" rel="noopener noreferrer">
   <img src="https://user-images.githubusercontent.com/3455798/270162667-c7bd2ebe-675e-45c6-a2c9-dc67f3b65d6e.png">
 </a>
 


### PR DESCRIPTION
### Summary
Add `rel="noopener noreferrer"` to external links that use `target="_blank"` to prevent `window.opener` security issues (tabnabbing) and reduce referrer leakage.

### What changed
- Updated the npm-compare “usage trend” links in:
  - `docs/fr/README-fr.md`
  - `docs/sw/README-sw.md`
to include `rel="noopener noreferrer"`.

### Why
Using `target="_blank"` without `rel="noopener"` can allow the opened page to access `window.opener` and potentially redirect the originating tab. Adding `noopener noreferrer` is a common best-practice for external links in docs.