### PR TITLE
docs(ru): fix Hebrew README link

### DIFF
--- a/docs/ru/README-ru.md
+++ b/docs/ru/README-ru.md
@@ -1,4 +1,4 @@
-Русский | [English](../../README.md) | [简体中文](../zh-cn/README.zh-CN.md) | [日本語](../ja/README-ja.md) | [Português Brasileiro](../pt-br/README-pt-br.md) | [한국어](../ko/README-ko.md) | [Español (España)](../es-es/README-es-es.md)| [עברית](./docs/he/README-he.md)
+Русский | [English](../../README.md) | [简体中文](../zh-cn/README.zh-CN.md) | [日本語](../ja/README-ja.md) | [Português Brasileiro](../pt-br/README-pt-br.md) | [한국어](../ko/README-ko.md) | [Español (España)](../es-es/README-es-es.md) | [עברית](../he/README-he.md)
 
 <p align="center"><a href="https://day.js.org/ru/" target="_blank" rel="noopener noreferrer"><img width="550"
                                                                              src="https://user-images.githubusercontent.com/17680888/39081119-3057bbe2-456e-11e8-862c-646133ad4b43.png"


### PR DESCRIPTION
### Summary
Fix the Hebrew README link in the Russian README language switcher.

### Details
`docs/ru/README-ru.md` was linking to Hebrew using an incorrect relative path (`./docs/he/README-he.md`), which doesn’t resolve correctly from the RU docs folder.

This PR updates it to the correct path:
- `../he/README-he.md`

Also normalizes spacing around the `|` separators for consistency.