### PR TITLE
fix: handle invalid duration humanize

### DIFF
--- a/src/plugin/duration/index.js
+++ b/src/plugin/duration/index.js
@@ -230,6 +230,10 @@ class Duration {
   }
 
   humanize(withSuffix) {
+    if (!Number.isFinite(this.$ms)) {
+      return 'invalid duration'
+    }
+
     return $d()
       .add(this.$ms, 'ms')
       .locale(this.$l)

--- a/test/plugin/duration.test.js
+++ b/test/plugin/duration.test.js
@@ -147,6 +147,11 @@ describe('Humanize', () => {
     expect(dayjs.duration(1, 'minutes').humanize(true)).toBe('en un minuto')
     dayjs.locale('en')
   })
+
+  it('Invalid duration', () => {
+    expect(dayjs.duration(NaN).humanize()).toBe('invalid duration')
+    expect(dayjs.duration(NaN).humanize(true)).toBe('invalid duration')
+  })
 })
 
 describe('Clone', () => {


### PR DESCRIPTION
## Summary
Return \invalid duration\ from \duration.humanize()\ when the duration value is not finite, instead of letting relative-time formatting turn \NaN\ into an incorrect humanized string.

## Changes
- guard \Duration#humanize\ against non-finite millisecond values
- add regression coverage for \dayjs.duration(NaN).humanize()\ with and without suffixes

## Testing
- \
px jest test/plugin/duration.test.js --runInBand\

Fixes #3006