### PR TITLE
fix: preserve timezone wall-clock date when setting year

### DIFF
--- a/src/plugin/timezone/index.js
+++ b/src/plugin/timezone/index.js
@@ -132,6 +132,25 @@ export default (o, c, d) => {
     return startOfWithoutTz.tz(this.$x.$timezone, true)
   }
 
+  const old$set = proto.$set
+  proto.$set = function (units, int) {
+    if (!this.$x || !this.$x.$timezone) {
+      return old$set.call(this, units, int)
+    }
+
+    // Apply the mutation in wall-clock time to avoid system timezone drift.
+    const withoutTz = d(this.format('YYYY-MM-DD HH:mm:ss:SSS'), { locale: this.$L })
+    const withSet = old$set.call(withoutTz, units, int)
+    const withTz = withSet.tz(this.$x.$timezone, true)
+
+    this.$d = withTz.$d
+    this.$offset = withTz.$offset
+    this.$u = withTz.$u
+    this.$x = withTz.$x
+    this.init()
+    return this
+  }
+
   d.tz = function (input, arg1, arg2) {
     const parseFormat = arg2 && arg1
     const timezone = arg2 || arg1 || defaultTimezone

--- a/test/timezone.test.js
+++ b/test/timezone.test.js
@@ -80,3 +80,14 @@ it('UTC diff in DST', () => {
   expect(day1.diff(day2, 'd'))
     .toBe(-3)
 })
+
+it('Timezone year set keeps month/day and local time', () => {
+  const base = dayjs.utc('2022-04-17T15:30:00Z').tz('America/Chicago')
+  const byYear = base.year(2020)
+  const bySet = base.set('year', 2020)
+
+  expect(byYear.format()).toBe(moment.parseZone(base.format()).year(2020).format())
+  expect(bySet.format()).toBe(moment.parseZone(base.format()).year(2020).format())
+  expect(byYear.format('YYYY-MM-DD HH:mm')).toBe('2020-04-17 10:30')
+  expect(bySet.format('YYYY-MM-DD HH:mm')).toBe('2020-04-17 10:30')
+})


### PR DESCRIPTION
Apply timezone-aware set operations in wall-clock time for tz instances so year edits do not drift the day based on system timezone, and add a regression test covering the America/Chicago case from issue #3014.
