### PR TITLE
fix(test): make dayOfYear and localizedFormat tests timezone-independent

### DIFF
--- a/test/plugin/dayOfYear.test.js
+++ b/test/plugin/dayOfYear.test.js
@@ -24,27 +24,27 @@ it('DayOfYear get', () => {
 
 it('DayOfYear set', () => {
   expect(dayjs().dayOfYear(4).dayOfYear()).toBe(moment().dayOfYear(4).dayOfYear())
-  expect(dayjs('2015-01-01T00:00:00.000Z')
+  expect(dayjs('2015-01-01T00:00:00.000')
     .dayOfYear(4)
     .dayOfYear()).toBe(4)
 
-  expect(dayjs('2015-01-01T00:00:00.000Z')
+  expect(dayjs('2015-01-01T00:00:00.000')
     .dayOfYear(4)
-    .toISOString()).toBe('2015-01-04T00:00:00.000Z')
+    .format('YYYY-MM-DDTHH:mm:ss.SSS')).toBe('2015-01-04T00:00:00.000')
 
-  expect(dayjs('2015-01-01T00:00:00.000Z')
+  expect(dayjs('2015-01-01T00:00:00.000')
     .dayOfYear(32)
     .dayOfYear()).toBe(32)
 
-  expect(dayjs('2015-01-01T00:00:00.000Z')
+  expect(dayjs('2015-01-01T00:00:00.000')
     .dayOfYear(32)
-    .toISOString()).toBe('2015-02-01T00:00:00.000Z')
+    .format('YYYY-MM-DDTHH:mm:ss.SSS')).toBe('2015-02-01T00:00:00.000')
 
-  expect(dayjs('2015-01-01T00:00:00.000Z')
+  expect(dayjs('2015-01-01T00:00:00.000')
     .dayOfYear(365)
     .dayOfYear()).toBe(365)
 
-  expect(dayjs('2015-01-01T00:00:00.000Z')
+  expect(dayjs('2015-01-01T00:00:00.000')
     .dayOfYear(365)
-    .toISOString()).toBe('2015-12-31T00:00:00.000Z')
+    .format('YYYY-MM-DDTHH:mm:ss.SSS')).toBe('2015-12-31T00:00:00.000')
 })

--- a/test/plugin/localizedFormat.test.js
+++ b/test/plugin/localizedFormat.test.js
@@ -23,7 +23,7 @@ it('Declares English localized formats', () => {
 })
 
 it('Should not interpolate characters inside square brackets', () => {
-  const date = new Date(0)
+  const date = new Date(1970, 0, 1)
   const actualDate = dayjs(date)
   const expectedDate = moment(date)
 


### PR DESCRIPTION
### Summary

Fixes #3009

The `dayOfYear` and `localizedFormat` plugin tests fail when run in non-UTC timezones (e.g. `US/Pacific`). The issue is **not in the plugin code** but in the tests themselves, which implicitly assume `UTC` as the local timezone.

Two problems:

- **`dayOfYear.test.js`**: Uses UTC strings (`2015-01-01T00:00:00.000Z`) then asserts results with `toISOString()`. In UTC-8, this date resolves to Dec 31 2014 locally, so `dayOfYear(4)` operates on the wrong year.
- **`localizedFormat.test.js`**: Uses `new Date(0)` (epoch = Jan 1 1970 00:00 **UTC**), which in UTC-8 is Dec 31 1969. The test then asserts `YYYY` equals `1970`.

### Changes

- `dayOfYear.test.js`: Use local date strings (without `Z` suffix) and `format()` instead of `toISOString()`
- `localizedFormat.test.js`: Use `new Date(1970, 0, 1)` (local) instead of `new Date(0)` (UTC)

### Test plan

- [x] `npm run lint` passes
- [x] All tests pass in `TZ=UTC`
- [x] All tests pass in `TZ=US/Pacific`
- [x] All tests pass in `TZ=Asia/Kolkata`
- [x] All tests pass in `TZ=Pacific/Auckland`
