### PR TITLE
fix(locale): correct meridiem boundary in all Arabic locales

### DIFF
--- a/src/locale/ar-dz.js
+++ b/src/locale/ar-dz.js
@@ -17,7 +17,7 @@ const locale = {
     LLL: 'D MMMM YYYY HH:mm',
     LLLL: 'dddd D MMMM YYYY HH:mm'
   },
-  meridiem: hour => (hour > 12 ? 'م' : 'ص'),
+  meridiem: hour => (hour >= 12 ? 'م' : 'ص'),
   relativeTime: {
     future: 'في %s',
     past: 'منذ %s',

--- a/src/locale/ar-iq.js
+++ b/src/locale/ar-iq.js
@@ -18,7 +18,7 @@ const locale = {
     LLL: 'D MMMM YYYY HH:mm',
     LLLL: 'dddd D MMMM YYYY HH:mm'
   },
-  meridiem: hour => (hour > 12 ? 'م' : 'ص'),
+  meridiem: hour => (hour >= 12 ? 'م' : 'ص'),
   relativeTime: {
     future: 'في %s',
     past: 'منذ %s',

--- a/src/locale/ar-kw.js
+++ b/src/locale/ar-kw.js
@@ -17,7 +17,7 @@ const locale = {
     LLL: 'D MMMM YYYY HH:mm',
     LLLL: 'dddd D MMMM YYYY HH:mm'
   },
-  meridiem: hour => (hour > 12 ? 'م' : 'ص'),
+  meridiem: hour => (hour >= 12 ? 'م' : 'ص'),
   relativeTime: {
     future: 'في %s',
     past: 'منذ %s',

--- a/src/locale/ar-ly.js
+++ b/src/locale/ar-ly.js
@@ -10,7 +10,7 @@ const locale = {
   monthsShort: 'يناير_فبراير_مارس_أبريل_مايو_يونيو_يوليو_أغسطس_سبتمبر_أكتوبر_نوفمبر_ديسمبر'.split('_'),
   weekdaysMin: 'ح_ن_ث_ر_خ_ج_س'.split('_'),
   ordinal: n => n,
-  meridiem: hour => (hour > 12 ? 'م' : 'ص'),
+  meridiem: hour => (hour >= 12 ? 'م' : 'ص'),
   formats: {
     LT: 'HH:mm',
     LTS: 'HH:mm:ss',

--- a/src/locale/ar-ma.js
+++ b/src/locale/ar-ma.js
@@ -18,7 +18,7 @@ const locale = {
     LLL: 'D MMMM YYYY HH:mm',
     LLLL: 'dddd D MMMM YYYY HH:mm'
   },
-  meridiem: hour => (hour > 12 ? 'م' : 'ص'),
+  meridiem: hour => (hour >= 12 ? 'م' : 'ص'),
   relativeTime: {
     future: 'في %s',
     past: 'منذ %s',

--- a/src/locale/ar-sa.js
+++ b/src/locale/ar-sa.js
@@ -17,7 +17,7 @@ const locale = {
     LLL: 'D MMMM YYYY HH:mm',
     LLLL: 'dddd D MMMM YYYY HH:mm'
   },
-  meridiem: hour => (hour > 12 ? 'م' : 'ص'),
+  meridiem: hour => (hour >= 12 ? 'م' : 'ص'),
   relativeTime: {
     future: 'في %s',
     past: 'منذ %s',

--- a/src/locale/ar-tn.js
+++ b/src/locale/ar-tn.js
@@ -18,7 +18,7 @@ const locale = {
     LLL: 'D MMMM YYYY HH:mm',
     LLLL: 'dddd D MMMM YYYY HH:mm'
   },
-  meridiem: hour => (hour > 12 ? 'م' : 'ص'),
+  meridiem: hour => (hour >= 12 ? 'م' : 'ص'),
   relativeTime: {
     future: 'في %s',
     past: 'منذ %s',

--- a/src/locale/ar.js
+++ b/src/locale/ar.js
@@ -43,7 +43,7 @@ const locale = {
   months,
   monthsShort: months,
   weekStart: 6,
-  meridiem: hour => (hour > 12 ? 'م' : 'ص'),
+  meridiem: hour => (hour >= 12 ? 'م' : 'ص'),
   relativeTime: {
     future: 'بعد %s',
     past: 'منذ %s',

--- a/test/locale/ar.test.js
+++ b/test/locale/ar.test.js
@@ -56,7 +56,7 @@ it('Format meridiem with locale function', () => {
     const hour = dayjs()
       .startOf('day')
       .add(i, 'hour')
-    const meridiem = i > 12 ? 'م' : 'ص'
+    const meridiem = i >= 12 ? 'م' : 'ص'
     expect(hour.locale('ar').format('A')).toBe(`${meridiem}`)
   }
 })


### PR DESCRIPTION
## What

Fixed the meridiem (AM/PM) boundary condition in all 8 Arabic locale files (`ar`, `ar-sa`, `ar-ma`, `ar-dz`, `ar-iq`, `ar-kw`, `ar-ly`, `ar-tn`).

## Why

I use day.js with Arabic locale in my projects and noticed that at exactly **12:00 noon**, the meridiem returns **ص (AM)** instead of **م (PM)**.

The issue is that all Arabic locales use `hour > 12` instead of `hour >= 12`:

```javascript
// Before (incorrect): hour 12 → ص (AM) ❌
meridiem: hour => (hour > 12 ? 'م' : 'ص')

// After (correct): hour 12 → م (PM) ✅
meridiem: hour => (hour >= 12 ? 'م' : 'ص')
```

This is inconsistent with:
- The **core default** meridiem in `src/index.js` which uses `hour < 12` (meaning `>= 12` is PM)
- Other locales like `ja`, `ko`, `br`, `ku` which all use `hour < 12`

In the 24-hour system, hour 12 is noon and should be PM (مساءً), not AM (صباحاً).

## Changes

- `src/locale/ar.js` — `> 12` → `>= 12`
- `src/locale/ar-sa.js` — `> 12` → `>= 12`
- `src/locale/ar-ma.js` — `> 12` → `>= 12`
- `src/locale/ar-dz.js` — `> 12` → `>= 12`
- `src/locale/ar-iq.js` — `> 12` → `>= 12`
- `src/locale/ar-kw.js` — `> 12` → `>= 12`
- `src/locale/ar-ly.js` — `> 12` → `>= 12`
- `src/locale/ar-tn.js` — `> 12` → `>= 12`
- `test/locale/ar.test.js` — fixed meridiem test assertion to match corrected behavior

## Testing

- All 93 test suites pass (773 tests)
- `npm run lint` passes with no errors