### PR TITLE
fix(locale): correct Khmer meridiem boundary and add meridiem to ILocale type

### DIFF
--- a/src/locale/km.js
+++ b/src/locale/km.js
@@ -33,7 +33,7 @@ const locale = {
     y: 'មួយឆ្នាំ',
     yy: '%d ឆ្នាំ'
   },
-  meridiem: hour => (hour > 12 ? 'ល្ងាច' : 'ព្រឹក')
+  meridiem: hour => (hour >= 12 ? 'ល្ងាច' : 'ព្រឹក')
 }
 
 dayjs.locale(locale, null, true)

--- a/test/locale/km.test.js
+++ b/test/locale/km.test.js
@@ -1,0 +1,20 @@
+import MockDate from 'mockdate'
+import dayjs from '../../src'
+import locale from '../../src/locale/km'
+
+beforeEach(() => {
+  MockDate.set(new Date())
+})
+
+afterEach(() => {
+  MockDate.reset()
+})
+
+it('Meridiem', () => {
+  dayjs.locale(locale)
+  expect(dayjs('2020-01-01 03:00:00').locale('km').format('A')).toEqual('ព្រឹក')
+  expect(dayjs('2020-01-01 11:00:00').locale('km').format('A')).toEqual('ព្រឹក')
+  expect(dayjs('2020-01-01 12:00:00').locale('km').format('A')).toEqual('ល្ងាច')
+  expect(dayjs('2020-01-01 16:00:00').locale('km').format('A')).toEqual('ល្ងាច')
+  expect(dayjs('2020-01-01 20:00:00').locale('km').format('A')).toEqual('ល្ងាច')
+})

--- a/types/locale/types.d.ts
+++ b/types/locale/types.d.ts
@@ -7,6 +7,7 @@ declare interface ILocale {
   monthsShort?: string[]
   weekdaysMin?: string[]
   ordinal?: (n: number) => number | string
+  meridiem?: (hour: number, minute?: number, isLowerCase?: boolean) => string
   formats: Partial<{
     LT: string
     LTS: string


### PR DESCRIPTION
## What

1. Fixed the Khmer (`km`) locale meridiem function boundary condition
2. Added the missing `meridiem` property to the TypeScript `ILocale` interface
3. Added test coverage for the Khmer locale meridiem

## Why

While investigating locale meridiem implementations across the codebase, I found that the Khmer locale uses `hour > 12` instead of `hour >= 12`. This causes noon (hour 12) to be incorrectly classified as morning (ព្រឹក) instead of afternoon (ល្ងាច).

The core default meridiem in `src/index.js` uses `hour < 12` (meaning `>= 12` is PM), and other locales like `ja`, `ko`, `br`, `ku` follow the same correct pattern.

Additionally, the `ILocale` TypeScript interface in `types/locale/types.d.ts` was missing the `meridiem` property, even though it is implemented by many locales and used by the core formatting logic with the signature `(hour, minute, isLowerCase) => string`.

## Changes

- `src/locale/km.js` — `hour > 12` → `hour >= 12`
- `types/locale/types.d.ts` — added optional `meridiem` property to `ILocale`
- `test/locale/km.test.js` — new test file for Khmer locale meridiem (includes hour 12 boundary test)

## Testing

- All 94 test suites pass (774 tests)
- `npm run lint` passes with no errors