### PR TITLE
fix: 2 improvements across 2 files

### DIFF
--- a/src/plugin/isToday/index.js
+++ b/src/plugin/isToday/index.js
@@ -1,9 +1,6 @@
 export default (o, c, d) => {
   const proto = c.prototype
   proto.isToday = function () {
-    const comparisonTemplate = 'YYYY-MM-DD'
-    const now = d()
-
-    return this.format(comparisonTemplate) === now.format(comparisonTemplate)
+    return this.isSame(d(), 'day')
   }
 }

--- a/src/plugin/negativeYear/index.js
+++ b/src/plugin/negativeYear/index.js
@@ -5,7 +5,7 @@ export default (_, c, dayjs) => {
     const { date, utc } = cfg
     if (typeof date === 'string' && date.charAt(0) === '-') {
       const normalData = date.slice(1)
-      let newDate = dayjs(normalData)
+      let newDate
       if (utc) {
         newDate = dayjs.utc(normalData)
       } else {


### PR DESCRIPTION
## Summary

fix: 2 improvements across 2 files

## Problem

**Severity**: `Medium` | **File**: `src/plugin/isToday/index.js:L3`

The plugins `isToday`, `isTomorrow`, and `isYesterday` use string formatting ('YYYY-MM-DD') to compare dates. This is computationally expensive as it involves multiple string allocations and formatting logic for every call, rather than comparing numeric timestamps or date components directly.

## Solution

Use numeric comparison or the existing `isSame` method with the 'day' unit. For example: `return this.isSame(d(), 'day')`.

## Changes

- `src/plugin/isToday/index.js` (modified)
- `src/plugin/negativeYear/index.js` (modified)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced

---
*Generated by [ContribAI](https://github.com/tang-vu/ContribAI) v5.7.1*