### PR TITLE
fix: resolve #1119 — Timezone plugin different output

### DIFF
--- a/src/plugin/timezone/index.js
+++ b/src/plugin/timezone/index.js
@@ -140,6 +140,9 @@ export default (o, c, d) => {
       // timestamp number || js Date || Day.js
       return d(input).tz(timezone)
     }
+    if (/(\+|-)\d\d(?::?\d\d)?|Z$/i.test(input)) {
+      return d(input, parseFormat).tz(timezone)
+    }
     const localTs = d.utc(input, parseFormat).valueOf()
     const [targetTs, targetOffset] = fixOffset(localTs, previousOffset, timezone)
     const ins = d(targetTs).utcOffset(targetOffset)


### PR DESCRIPTION
## Summary

fix: resolve #1119 — Timezone plugin different output

## Problem

**Severity**: `Medium` | **File**: `src/plugin/timezone/index.js`

When `dayjs.tz()` is called with a string that includes a timezone offset (e.g., "2018-09-17T05:38:46-07:00"), it currently fails to parse the time correctly relative to the target timezone. It appears to parse the string into UTC but then incorrectly treats that UTC time as the local time of the target zone, or fails to adjust the offset because it assumes the input was "local" to the target zone. To match Moment.js behavior and ensure correctness, `dayjs.tz` should detect if a string input contains an offset. If it does, it should parse the absolute time and then convert it to the target timezone, rather than attempting to parse the string "in" that timezone.

## Solution

In `src/plugin/timezone/index.js`, update the `dayjs.tz` function to check for an offset in string inputs.

## Changes

- `src/plugin/timezone/index.js` (modified)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced

---
*Generated by [ContribAI](https://github.com/tang-vu/ContribAI) v5.7.1*