### PR TITLE
fix: resolve #529 — Replace Moment.js in Ant Design (Antd) with Day.js

### DIFF
--- a/docs/en/Installation.md
+++ b/docs/en/Installation.md
@@ -1,3 +1,10 @@
 ### Note
 
 The documents are moved to  [https://day.js.org](https://day.js.org).
+
+### Ant Design Compatibility
+
+If you are using Ant Design, you can use Day.js to replace Moment.js.
+
+- [Ant Design official replacement guide](https://ant.design/docs/react/replace-moment)
+- [antd-dayjs-webpack-plugin](https://github.com/ant-design/antd-dayjs-webpack-plugin)


### PR DESCRIPTION
## Summary

fix: resolve #529 — Replace Moment.js in Ant Design (Antd) with Day.js

## Problem

**Severity**: `Medium` | **File**: `docs/en/Installation.md`

Many users want to use Day.js with Ant Design (Antd). This change adds a dedicated section to the English installation documentation, providing clear instructions and links to the official Antd replacement guide and the webpack plugin.

## Solution

Add the following section at the end of the file:

## Changes

- `docs/en/Installation.md` (modified)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced

---
*Generated by [ContribAI](https://github.com/tang-vu/ContribAI) v5.7.1*