### PR TITLE
fix: handle Dayjs object input in dayjs.utc()

### DIFF
--- a/src/plugin/utc/index.js
+++ b/src/plugin/utc/index.js
@@ -24,6 +24,7 @@ function offsetFromString(value = '') {
 export default (option, Dayjs, dayjs) => {
   const proto = Dayjs.prototype
   dayjs.utc = function (date) {
+    if (dayjs.isDayjs(date)) date = date.toDate()
     const cfg = { date, utc: true, args: arguments } // eslint-disable-line prefer-rest-params
     return new Dayjs(cfg) // eslint-disable-line no-use-before-define
   }


### PR DESCRIPTION
## Problem

When passing a Dayjs object to `dayjs.utc()`, the result is incorrect — it returns today's date instead of the passed date.

```js
const d = dayjs(2018-09-06)
dayjs.utc(d).format() // expected: 2018-09-06T00:00:00Z, actual: wrong date
```

This happens because `dayjs.utc()` passes the raw Dayjs object directly to the config, which goes through `parseDate()` → `new Date(date)`, producing incorrect results.

## Solution

Add an `isDayjs` check at the top of `dayjs.utc()` to convert to a native Date first:

```js
dayjs.utc = function (date) {
    if (dayjs.isDayjs(date)) date = date.toDate()
    ...
}
```

This mirrors how the core `dayjs()` function already handles Dayjs input.

Fixes #1241