### PR TITLE
fix: ja locale date format

### DIFF
--- a/src/locale/ja.js
+++ b/src/locale/ja.js
@@ -16,7 +16,7 @@ const locale = {
     LL: 'YYYY年M月D日',
     LLL: 'YYYY年M月D日 HH:mm',
     LLLL: 'YYYY年M月D日 dddd HH:mm',
-    l: 'YYYY/MM/DD',
+    l: 'YYYY/M/D',
     ll: 'YYYY年M月D日',
     lll: 'YYYY年M月D日 HH:mm',
     llll: 'YYYY年M月D日(ddd) HH:mm'


### PR DESCRIPTION
A modification of format 'l'.

Closes #3038