### PR TITLE
fix(duration): handle weeks and milliseconds in add/subtract

### DIFF
--- a/src/plugin/duration/index.js
+++ b/src/plugin/duration/index.js
@@ -193,7 +193,9 @@ class Duration {
     let base = this.$ms
     const pUnit = prettyUnit(unit)
     if (pUnit === 'milliseconds') {
-      base %= 1000
+      // Use the stored value when available so that inputs like
+      // { milliseconds: 1000 } are not silently truncated to 0.
+      base = this.$d.milliseconds !== undefined ? this.$d.milliseconds : (base % 1000)
     } else if (pUnit === 'weeks') {
       base = roundNumber(base / unitToMS[pUnit])
     } else {
@@ -261,6 +263,7 @@ class Duration {
 const manipulateDuration = (date, duration, k) =>
   date.add(duration.years() * k, 'y')
     .add(duration.months() * k, 'M')
+    .add(duration.weeks() * k, 'w')
     .add(duration.days() * k, 'd')
     .add(duration.hours() * k, 'h')
     .add(duration.minutes() * k, 'm')


### PR DESCRIPTION
## Two related bugs in the `duration` plugin

### 1. Weeks silently ignored in `date.subtract(duration)` / `date.add(duration)`

`manipulateDuration` applies years, months, days, hours, minutes, seconds, and milliseconds, but **has no `.add(..., 'w')` call** for weeks. Any duration that includes `weeks` is silently dropped.

```js
const d = dayjs('2024-01-28').subtract(dayjs.duration({ weeks: 1 }))
// Expected: 2024-01-21
// Actual:   2024-01-28  (unchanged)
```

**Fix:** Add `.add(duration.weeks() * k, 'w')` to `manipulateDuration`.

---

### 2. Milliseconds ≥ 1000 collapse to zero

`get('milliseconds')` uses `$ms % 1000`. When a duration is constructed from an object like `{ milliseconds: 1000 }`:

- `$ms = 1000`
- `get('milliseconds')` → `1000 % 1000 = 0`
- `manipulateDuration` adds `0 ms` → nothing is subtracted

```js
const d = dayjs('2024-01-28T00:00:00').subtract(dayjs.duration({ milliseconds: 1000 }))
// Expected: 2024-01-27T23:59:59
// Actual:   2024-01-28T00:00:00  (unchanged)
```

**Fix:** When `$d.milliseconds` was populated from an object input, use that value directly instead of `$ms % 1000`. (For string/number inputs `parseFromMilliseconds` already normalises `$d.milliseconds` to `< 1000`, so the behaviour is unchanged for those cases.)

Closes #3042