### PR TITLE
test: cover timezone startOf across DST change

### DIFF
--- a/test/plugin/timezone.test.js
+++ b/test/plugin/timezone.test.js
@@ -313,6 +313,11 @@ describe('startOf and endOf', () => {
     expect(startOfDay.valueOf()).toEqual(originalDay.valueOf())
   })
 
+  it('uses the date offset for startOf across DST changes', () => {
+    const startOfDay = dayjs.tz('2021-04-15 08:00', 'Australia/Melbourne').startOf('day')
+    expect(startOfDay.format()).toEqual('2021-04-15T00:00:00+10:00')
+  })
+
   it('corrects for timezone offset in endOf', () => {
     const originalDay = dayjs.tz('2009-12-31 23:59:59.999', NY)
     const endOfDay = originalDay.endOf('day')


### PR DESCRIPTION
### Description

Adds a focused regression test for the timezone `startOf('day')` DST case described in #1437.

The covered scenario uses `Australia/Melbourne` after DST has ended and asserts that `startOf('day')` uses the target date offset (`+10:00`) rather than the prior DST offset.

Current `dev` already passes this case; this PR only preserves the expected behavior with explicit coverage.

### Tests

- `npx jest test/plugin/timezone.test.js --runInBand --coverage=false`
- `TZ=Australia/Melbourne npx jest test/plugin/timezone.test.js --runInBand --coverage=false`

Closes #1437 if maintainers consider the original bug fixed and this regression coverage sufficient.