### PR TITLE
fix: support Windows test execution using cross-env

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "dayjs.min.js",
   "types": "index.d.ts",
   "scripts": {
-    "test": "TZ=Pacific/Auckland npm run test-tz && TZ=Europe/London npm run test-tz && TZ=America/Whitehorse npm run test-tz && npm run test-tz && jest --coverage --coverageThreshold='{ \"global\": { \"lines\": 100} }'",
+    "test": "cross-env TZ=Pacific/Auckland npm run test-tz && cross-env TZ=Europe/London npm run test-tz && cross-env TZ=America/Whitehorse npm run test-tz && npm run test-tz && jest --coverage --coverageThreshold=\"{ \\\"global\\\": { \\\"lines\\\": 100} }\"",
     "test-tz": "date && jest test/timezone.test --coverage=false",
     "lint": "./node_modules/.bin/eslint src/* test/* build/*",
     "prettier": "prettier --write \"docs/**/*.md\"",


### PR DESCRIPTION
## Summary

This PR fixes test execution on Windows environments.

## Problem

The existing test script used Unix-style environment variable syntax:

```bash
TZ=Pacific/Auckland npm run test-tz
```

This fails on Windows CMD environments.

## Solution

Replaced environment variable handling with `cross-env` for cross-platform compatibility.

## Result

Tests now run correctly on:

* Windows
* macOS
* Linux