### PR TITLE
fix: duration add/subtract with weeks and milliseconds (#3042)

### DIFF
--- a/src/plugin/duration/index.js
+++ b/src/plugin/duration/index.js
@@ -261,11 +261,13 @@ class Duration {
 const manipulateDuration = (date, duration, k) =>
   date.add(duration.years() * k, 'y')
     .add(duration.months() * k, 'M')
+    // use raw values here: milliseconds() is a remainder, and weeks would be skipped
+    .add((duration.$d.weeks || 0) * k, 'w')
     .add(duration.days() * k, 'd')
     .add(duration.hours() * k, 'h')
     .add(duration.minutes() * k, 'm')
     .add(duration.seconds() * k, 's')
-    .add(duration.milliseconds() * k, 'ms')
+    .add((duration.$d.milliseconds || 0) * k, 'ms')
 
 export default (option, Dayjs, dayjs) => {
   $d = dayjs

--- a/test/issues/issue3042.test.js
+++ b/test/issues/issue3042.test.js
@@ -1,0 +1,38 @@
+import dayjs from '../../src'
+import utc from '../../src/plugin/utc'
+import duration from '../../src/plugin/duration'
+
+dayjs.extend(utc)
+dayjs.extend(duration)
+
+const BASE = dayjs.utc('2018-06-27T00:00:00.000Z')
+
+const subtracted = input => BASE.subtract(input).toISOString()
+const added = input => BASE.add(input).toISOString()
+
+describe('issue 3042 - subtract duration object with weeks and milliseconds', () => {
+  it('subtracts milliseconds duration objects', () => {
+    expect(subtracted(dayjs.duration({ milliseconds: 1000 })))
+      .toBe('2018-06-26T23:59:59.000Z')
+  })
+
+  it('subtracts weeks duration objects', () => {
+    expect(subtracted(dayjs.duration({ weeks: 2 })))
+      .toBe('2018-06-13T00:00:00.000Z')
+  })
+
+  it('subtracts mixed week and day duration objects', () => {
+    expect(subtracted(dayjs.duration({ weeks: 1, days: 3 })))
+      .toBe('2018-06-17T00:00:00.000Z')
+  })
+
+  it('adds milliseconds duration objects', () => {
+    expect(added(dayjs.duration({ milliseconds: 1000 })))
+      .toBe('2018-06-27T00:00:01.000Z')
+  })
+
+  it('adds weeks duration objects', () => {
+    expect(added(dayjs.duration({ weeks: 2 })))
+      .toBe('2018-07-11T00:00:00.000Z')
+  })
+})


### PR DESCRIPTION
Fixes #3042

This PR fixes duration object manipulation when using weeks and milliseconds.

Before this change:

- `subtract(dayjs.duration({ weeks: 2 }))` ignored weeks
- `subtract(dayjs.duration({ milliseconds: 1000 }))` ignored milliseconds because `milliseconds()` returns the modulo component

This fix uses raw duration object values for weeks and milliseconds in the shared duration manipulation path, so both `add(duration)` and `subtract(duration)` are covered.

Tests added for:

- subtract milliseconds
- subtract weeks
- subtract mixed weeks + days
- add milliseconds
- add weeks