### PR TITLE
fix: reject invalid zoned dates

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -7,6 +7,13 @@ const Ls = {} // global loaded locale
 Ls[L] = en
 
 const IS_DAYJS = '$isDayjsObject'
+const REGEX_PARSE_WITH_ZONE = /^(\d{4})[-/](\d{1,2})[-/](\d{1,2})[Tt\s].*(?:[Zz]|[+-]\d\d:?\d\d)$/
+
+const isInvalidParsedDate = (d) => {
+  const m = +d[2]
+  const day = +d[3]
+  return m < 1 || m > 12 || day < 1 || day > new Date(d[1], m, 0).getDate()
+}
 
 // eslint-disable-next-line no-use-before-define
 const isDayjs = d => d instanceof Dayjs || !!(d && d[IS_DAYJS])
@@ -65,17 +72,21 @@ const parseDate = (cfg) => {
   if (date === null) return new Date(NaN) // null is invalid
   if (Utils.u(date)) return new Date() // today
   if (date instanceof Date) return new Date(date)
-  if (typeof date === 'string' && !/Z$/i.test(date)) {
-    const d = date.match(C.REGEX_PARSE)
-    if (d) {
-      const m = d[2] - 1 || 0
-      const ms = (d[7] || '0').substring(0, 3)
-      if (utc) {
-        return new Date(Date.UTC(d[1], m, d[3]
-          || 1, d[4] || 0, d[5] || 0, d[6] || 0, ms))
+  if (typeof date === 'string') {
+    const zonedDate = date.match(REGEX_PARSE_WITH_ZONE)
+    if (zonedDate && isInvalidParsedDate(zonedDate)) return new Date(NaN)
+    if (!/Z$/i.test(date)) {
+      const d = date.match(C.REGEX_PARSE)
+      if (d) {
+        const m = d[2] - 1 || 0
+        const ms = (d[7] || '0').substring(0, 3)
+        if (utc) {
+          return new Date(Date.UTC(d[1], m, d[3]
+            || 1, d[4] || 0, d[5] || 0, d[6] || 0, ms))
+        }
+        return new Date(d[1], m, d[3]
+          || 1, d[4] || 0, d[5] || 0, d[6] || 0, ms)
       }
-      return new Date(d[1], m, d[3]
-        || 1, d[4] || 0, d[5] || 0, d[6] || 0, ms)
     }
   }
 

--- a/test/parse.test.js
+++ b/test/parse.test.js
@@ -47,6 +47,12 @@ describe('Parse', () => {
     expect(dayjs(time).valueOf()).toBe(moment(time).valueOf())
   })
 
+  it('rejects out-of-range ISO 8601 dates with zone', () => {
+    const time = '2024-02-31T22:03:08Z'
+    expect(moment(time).isValid()).toBe(false)
+    expect(dayjs(time).isValid()).toBe(false)
+  })
+
   it('String RFC 2822, time and zone', () => {
     const time = 'Mon, 11 Feb 2019 09:46:50 GMT+1'
     const expected = '2019-02-11T08:46:50.000Z'

--- a/test/plugin/customParseFormat.test.js
+++ b/test/plugin/customParseFormat.test.js
@@ -307,6 +307,12 @@ describe('Strict mode', () => {
     expect(dayjs('2020-Jan-01', 'YYYY-MMM-DD', true).isValid()).toBe(true)
     expect(dayjs('30/1/2020 10:59 PM', 'D/M/YYYY h:mm A', true).isValid()).toBe(true)
   })
+  it('rejects out-of-range dates with zone in strict mode', () => {
+    const input = '2024-02-31T22:03:08Z'
+    const format = 'YYYY-MM-DDTHH:mm:ssZ'
+    expect(moment(input, format, true).isValid()).toBe(false)
+    expect(dayjs(input, format, true).isValid()).toBe(false)
+  })
   it('with locale', () => {
     const input = '2018 三月 99'
     const format = 'YYYY MMMM DD'


### PR DESCRIPTION
### Description

Fixes #2607.

This prevents zoned ISO strings with impossible calendar dates from being treated as valid when the native `Date` parser normalizes them. For example, `2024-02-31T22:03:08Z` now returns an invalid Day.js instance instead of rolling over into March.

I kept the validation scoped to zoned ISO strings so existing lenient parsing for non-zoned input is not changed.

### Tests

- `npx jest test/parse.test.js -t 'rejects out-of-range ISO 8601 dates with zone' --coverage=false --runInBand`
- `npx jest test/plugin/customParseFormat.test.js -t 'rejects out-of-range dates with zone in strict mode' --coverage=false --runInBand`
- `npx jest test/parse.test.js test/plugin/customParseFormat.test.js --coverage=false --runInBand`
- `./node_modules/.bin/eslint src/index.js test/parse.test.js test/plugin/customParseFormat.test.js`
- `npm test -- --runInBand`
- `NODE_OPTIONS=--openssl-legacy-provider npm run build`
- `git diff --check`
