### PR TITLE
fix(locale): use single-digit month/day for ja short date format

### DIFF
--- a/src/locale/ja.js
+++ b/src/locale/ja.js
@@ -16,7 +16,7 @@ const locale = {
     LL: 'YYYY年M月D日',
     LLL: 'YYYY年M月D日 HH:mm',
     LLLL: 'YYYY年M月D日 dddd HH:mm',
-    l: 'YYYY/MM/DD',
+    l: 'YYYY/M/D',
     ll: 'YYYY年M月D日',
     lll: 'YYYY年M月D日 HH:mm',
     llll: 'YYYY年M月D日(ddd) HH:mm'

--- a/test/locale/ja.test.js
+++ b/test/locale/ja.test.js
@@ -2,9 +2,11 @@ import MockDate from 'mockdate'
 import moment from 'moment'
 import dayjs from '../../src'
 import relativeTime from '../../src/plugin/relativeTime'
+import localizedFormat from '../../src/plugin/localizedFormat'
 import '../../src/locale/ja'
 
 dayjs.extend(relativeTime)
+dayjs.extend(localizedFormat)
 
 beforeEach(() => {
   MockDate.set(new Date())
@@ -41,5 +43,12 @@ it('Finnish locale relative time in past and future', () => {
     .toBe('10日')
   expect(dayjs().add(-10, 'd').locale('ja').fromNow(true))
     .toBe(moment().add(-10, 'd').locale('ja').fromNow(true))
+})
+
+it('Japanese locale date formats', () => {
+  expect(dayjs('2019-02-01').locale('ja').format('L'))
+    .toBe('2019/02/01')
+  expect(dayjs('2019-02-01').locale('ja').format('l'))
+    .toBe('2019/2/1')
 })
 


### PR DESCRIPTION
## Summary

Fixes #3038

The `ja` locale used `YYYY/MM/DD` for both `L` and `l` formats. This aligns `l` with `zh`/`zh-cn`/`zh-tw` by using `YYYY/M/D` for unpadded month and day.

## Test plan

- [x] Extended `test/locale/ja.test.js` with localized format assertions
- [x] `npx jest test/locale/ja.test.js` — 2 tests passed