### PR TITLE
fix(locale): add yearStart for ISO week numbering

### DIFF
--- a/src/locale/de-at.js
+++ b/src/locale/de-at.js
@@ -32,6 +32,7 @@ const locale = {
   monthsShort: 'Jän._Feb._März_Apr._Mai_Juni_Juli_Aug._Sep._Okt._Nov._Dez.'.split('_'),
   ordinal: n => `${n}.`,
   weekStart: 1,
+  yearStart: 4,
   formats: {
     LTS: 'HH:mm:ss',
     LT: 'HH:mm',

--- a/src/locale/de-ch.js
+++ b/src/locale/de-ch.js
@@ -32,6 +32,7 @@ const locale = {
   monthsShort: 'Jan._Feb._März_Apr._Mai_Juni_Juli_Aug._Sep._Okt._Nov._Dez.'.split('_'),
   ordinal: n => `${n}.`,
   weekStart: 1,
+  yearStart: 4,
   formats: {
     LT: 'HH:mm',
     LTS: 'HH:mm:ss',

--- a/src/locale/nl-be.js
+++ b/src/locale/nl-be.js
@@ -7,6 +7,7 @@ const locale = {
   months: 'januari_februari_maart_april_mei_juni_juli_augustus_september_oktober_november_december'.split('_'),
   monthsShort: 'jan._feb._mrt._apr._mei_jun._jul._aug._sep._okt._nov._dec.'.split('_'),
   weekStart: 1,
+  yearStart: 4,
   weekdaysShort: 'zo._ma._di._wo._do._vr._za.'.split('_'),
   weekdaysMin: 'zo_ma_di_wo_do_vr_za'.split('_'),
   ordinal: n => n,

--- a/test/locale/week-53.test.js
+++ b/test/locale/week-53.test.js
@@ -1,0 +1,20 @@
+import moment from 'moment'
+import dayjs from '../../src'
+import weekOfYear from '../../src/plugin/weekOfYear'
+import '../../src/locale/de-at'
+import '../../src/locale/de-ch'
+import '../../src/locale/nl-be'
+
+dayjs.extend(weekOfYear)
+
+const locales = ['de-at', 'de-ch', 'nl-be']
+
+locales.forEach((locale) => {
+  it(`week 53 for ${locale} matches moment on 2020-12-31`, () => {
+    dayjs.locale(locale)
+    moment.locale(locale)
+
+    expect(dayjs('2020-12-31').week()).toBe(53)
+    expect(dayjs('2020-12-31').week()).toBe(moment('2020-12-31').week())
+  })
+})


### PR DESCRIPTION
## Summary

Fixes #3048, #3049, #3054

Regional locales `de-at`, `de-ch`, and `nl-be` had `weekStart: 1` but were missing `yearStart: 4` already used by their parent locales (`de`, `nl`). This caused `week()` to return `1` instead of `53` for dates like `2020-12-31`.

## Test plan

- [x] Added `test/locale/week-53.test.js` for the three locales
- [x] `npx jest test/locale/week-53.test.js` — 3 tests passed