### PR TITLE
fix(duration): subtract duration objects with weeks and ms

### DIFF
--- a/src/plugin/duration/index.js
+++ b/src/plugin/duration/index.js
@@ -193,6 +193,9 @@ class Duration {
     let base = this.$ms
     const pUnit = prettyUnit(unit)
     if (pUnit === 'milliseconds') {
+      if (this.$d.milliseconds != null) {
+        return this.$d.milliseconds || 0
+      }
       base %= 1000
     } else if (pUnit === 'weeks') {
       base = roundNumber(base / unitToMS[pUnit])
@@ -261,11 +264,12 @@ class Duration {
 const manipulateDuration = (date, duration, k) =>
   date.add(duration.years() * k, 'y')
     .add(duration.months() * k, 'M')
+    .add((duration.$d.weeks || 0) * k, 'w')
     .add(duration.days() * k, 'd')
     .add(duration.hours() * k, 'h')
     .add(duration.minutes() * k, 'm')
     .add(duration.seconds() * k, 's')
-    .add(duration.milliseconds() * k, 'ms')
+    .add((duration.$d.milliseconds != null ? duration.$d.milliseconds : 0) * k, 'ms')
 
 export default (option, Dayjs, dayjs) => {
   $d = dayjs

--- a/test/plugin/duration.test.js
+++ b/test/plugin/duration.test.js
@@ -1,11 +1,13 @@
 import MockDate from 'mockdate'
 import dayjs from '../../src'
 import duration from '../../src/plugin/duration'
+import utc from '../../src/plugin/utc'
 import relativeTime from '../../src/plugin/relativeTime'
 import '../../src/locale/fr'
 import '../../src/locale/es'
 
 dayjs.extend(relativeTime)
+dayjs.extend(utc)
 dayjs.extend(duration)
 
 beforeEach(() => {
@@ -225,6 +227,17 @@ test('Subtract duration', () => {
   const b = dayjs('2023-03-02 02:02:02')
   const p = dayjs.duration('P1Y1M1DT1H1M1S')
   expect(b.subtract(p).format('YYYY-MM-DD HH:mm:ss')).toBe('2022-02-01 01:01:01')
+})
+
+test('Subtract duration with weeks and milliseconds', () => {
+  const base = dayjs.utc('2018-06-27T00:00:00.000Z')
+
+  expect(base.subtract(dayjs.duration({ milliseconds: 1000 })).toISOString())
+    .toBe('2018-06-26T23:59:59.000Z')
+  expect(base.subtract(dayjs.duration({ weeks: 2 })).toISOString())
+    .toBe('2018-06-13T00:00:00.000Z')
+  expect(base.subtract(dayjs.duration({ weeks: 1, days: 3 })).toISOString())
+    .toBe('2018-06-17T00:00:00.000Z')
 })
 
 describe('Seconds', () => {


### PR DESCRIPTION
## Summary

Fixes #3042

`dayjs().subtract(dayjs.duration({ weeks: 2 }))` and `{ milliseconds: 1000 }` previously had no effect because `manipulateDuration()` omitted weeks and dropped object-specified millisecond values.

## Test plan

- [x] Added regression tests for weeks, milliseconds, and mixed durations
- [x] `npx jest test/plugin/duration.test.js` — 31 tests passed