### PR TITLE
fix(locale): add yearStart for pt-br week numbering

### DIFF
--- a/src/locale/pt-br.js
+++ b/src/locale/pt-br.js
@@ -9,6 +9,8 @@ const locale = {
   months: 'janeiro_fevereiro_março_abril_maio_junho_julho_agosto_setembro_outubro_novembro_dezembro'.split('_'),
   monthsShort: 'jan_fev_mar_abr_mai_jun_jul_ago_set_out_nov_dez'.split('_'),
   ordinal: n => `${n}º`,
+  weekStart: 1,
+  yearStart: 4,
   formats: {
     LT: 'HH:mm',
     LTS: 'HH:mm:ss',

--- a/test/locale/week-53-pt-br.test.js
+++ b/test/locale/week-53-pt-br.test.js
@@ -1,0 +1,11 @@
+import dayjs from '../../src'
+import weekOfYear from '../../src/plugin/weekOfYear'
+import '../../src/locale/pt-br'
+
+dayjs.extend(weekOfYear)
+
+it('week 53 for pt-br on 2020-12-31', () => {
+  dayjs.locale('pt-br')
+
+  expect(dayjs('2020-12-31').week()).toBe(53)
+})


### PR DESCRIPTION
## Summary

Fixes #3055

Adds `weekStart: 1` and `yearStart: 4` to `pt-br` so `week()` returns ISO week 53 for edge dates such as `2020-12-31`.

## Test plan

- [x] Added `test/locale/week-53-pt-br.test.js`
- [x] `npx jest test/locale/week-53-pt-br.test.js` — 1 test passed