### PR TITLE
fix(timezone): preserve +00:00 format for non-UTC zero-offset zones

### DIFF
--- a/src/plugin/timezone/index.js
+++ b/src/plugin/timezone/index.js
@@ -98,13 +98,18 @@ export default (o, c, d) => {
     const target = date.toLocaleString('en-US', { timeZone: timezone })
     const diff = Math.round((date - new Date(target)) / 1000 / 60)
     const offset = (-Math.round(date.getTimezoneOffset() / 15) * 15) - diff
-    const isUTC = !Number(offset)
+    const isUtcTimezone = timezone === 'UTC' || timezone === 'Etc/UTC' || timezone === 'Etc/GMT'
     let ins
-    if (isUTC) { // if utcOffset is 0, turn it to UTC mode
+    if (!Number(offset) && isUtcTimezone) { // if utcOffset is 0, turn it to UTC mode
       ins = this.utcOffset(0, keepLocalTime)
     } else {
       ins = d(target, { locale: this.$L }).$set(MS, this.$ms)
-        .utcOffset(offset, true)
+      if (offset === 0) {
+        ins.$offset = 0
+        ins.$u = false
+      } else {
+        ins = ins.utcOffset(offset, true)
+      }
       if (keepLocalTime) {
         const newOffset = ins.utcOffset()
         ins = ins.add(oldOffset - newOffset, MIN)

--- a/test/plugin/timezone.test.js
+++ b/test/plugin/timezone.test.js
@@ -120,6 +120,12 @@ describe('Convert', () => {
       expect(t.format('Z')).toBe('+09:00')
     })
   })
+
+  it('format +00:00 for non-UTC timezone with zero offset (#3068)', () => {
+    const s = '2021-10-31T15:00:00+00:00'
+    expect(dayjs(s).tz('Europe/London').format()).toBe('2021-10-31T15:00:00+00:00')
+    expect(dayjs(s).tz('UTC').format()).toBe('2021-10-31T15:00:00Z')
+  })
 })
 
 


### PR DESCRIPTION
## Summary
- Only enter UTC mode in `tz()` when the target timezone is `UTC`, `Etc/UTC`, or `Etc/GMT`
- For other timezones with a zero offset (e.g. `Europe/London` during GMT), keep `$u = false` and set `$offset = 0` directly instead of calling `utcOffset(0)`, which incorrectly forces UTC formatting (`Z`)

## Problem
`dayjs('2021-10-31T15:00:00+00:00').tz('Europe/London').format()` returned `2021-10-31T15:00:00Z` instead of the expected `2021-10-31T15:00:00+00:00`.

## Test plan
- [x] Added regression test in `test/plugin/timezone.test.js`
- [x] All existing timezone plugin tests pass (`npx jest test/plugin/timezone.test.js`)

Fixes #3068