### PR TITLE
fix(utc): parse timezone-less strings as UTC wall time

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -79,7 +79,23 @@ const parseDate = (cfg) => {
     }
   }
 
-  return new Date(date) // everything else
+  const parsed = new Date(date)
+  if (utc && typeof date === 'string' && !Number.isNaN(parsed.getTime())) {
+    const hasTimezone = /(?:Z|[+-]\d{2}(?::?\d{2})?\s*$|\b(?:GMT|UTC)\b)/i.test(date)
+    if (!hasTimezone) {
+      return new Date(Date.UTC(
+        parsed.getFullYear(),
+        parsed.getMonth(),
+        parsed.getDate(),
+        parsed.getHours(),
+        parsed.getMinutes(),
+        parsed.getSeconds(),
+        parsed.getMilliseconds()
+      ))
+    }
+  }
+
+  return parsed
 }
 
 class Dayjs {

--- a/test/plugin/utc.test.js
+++ b/test/plugin/utc.test.js
@@ -85,6 +85,12 @@ describe('Parse UTC ', () => {
     expect(dayjs.utc(d2).format()).toEqual(moment.utc(d2).format())
   })
 
+  it('Parse RFC2822-like date string in utc mode (#2819)', () => {
+    const d = 'Fri, Jan 28 2025'
+    expect(dayjs.utc(d).format('YYYY-MM-DD')).toEqual('2025-01-28')
+    expect(dayjs.utc(d).format('YYYY-MM-DD')).toEqual(moment.utc(d).format('YYYY-MM-DD'))
+  })
+
   it('Parse date string set utc in config', () => {
     const d = '2018-09-06T19:34:28Z'
     expect(dayjs(d, { utc: true }).format()).toEqual('2018-09-06T19:34:28Z')


### PR DESCRIPTION
## Summary
- When `dayjs.utc()` receives a timezone-less string that does not match the ISO regex (e.g. `Fri, Jan 28 2025`), treat the parsed date components as UTC wall time
- Matches `moment.utc()` behavior and prevents off-by-one day errors in non-UTC environments

## Problem
```js
dayjs.utc('Fri, Jan 28 2025').format('YYYY-MM-DD') // was '2025-01-27' in GMT+2
```

Native `Date` parsing interprets the string in local time, but UTC mode then reads UTC fields from that timestamp, shifting the calendar date.

## Test plan
- [x] Added regression test in `test/plugin/utc.test.js`
- [x] Existing utc + parse tests pass

Fixes #2819