### PR TITLE
fix(customParseFormat): accept Z suffix in strict mode with Z token

### DIFF
--- a/src/plugin/customParseFormat/index.js
+++ b/src/plugin/customParseFormat/index.js
@@ -214,6 +214,21 @@ const parseFormattedInput = (input, format, utc, dayjs) => {
 }
 
 
+function passesStrictParseCheck(input, format, instance) {
+  const formatted = instance.format(format)
+  // eslint-disable-next-line eqeqeq
+  if (input == formatted) return true
+
+  // `Z` suffix is equivalent to `+00:00` when formatting with the `Z` token
+  if (format.includes('Z') && /Z$/i.test(input)) {
+    const normalized = input.replace(/Z$/i, '+00:00')
+    if (normalized === formatted) return true
+    if (normalized === instance.utc().format(format)) return true
+  }
+
+  return false
+}
+
 export default (o, C, d) => {
   d.p.customParseFormat = true
   if (o && o.parseTwoDigitYear) {
@@ -244,8 +259,7 @@ export default (o, C, d) => {
       if (pl && pl !== true) this.$L = this.locale(pl).$L
       // use != to treat
       // input number 1410715640579 and format string '1410715640579' equal
-      // eslint-disable-next-line eqeqeq
-      if (isStrict && date != this.format(format)) {
+      if (isStrict && !passesStrictParseCheck(date, format, this)) {
         this.$d = new Date('')
       }
       // reset global locale to make parallel unit test

--- a/test/plugin/customParseFormat.test.js
+++ b/test/plugin/customParseFormat.test.js
@@ -8,10 +8,14 @@ import customParseFormat from '../../src/plugin/customParseFormat'
 import advancedFormat from '../../src/plugin/advancedFormat'
 import localizedFormats from '../../src/plugin/localizedFormat'
 import weekOfYear from '../../src/plugin/weekOfYear'
+import utc from '../../src/plugin/utc'
+import timezone from '../../src/plugin/timezone'
 
 dayjs.extend(customParseFormat)
 dayjs.extend(localizedFormats)
 dayjs.extend(weekOfYear) // test parse w, ww
+dayjs.extend(utc)
+dayjs.extend(timezone)
 
 beforeEach(() => {
   MockDate.set(new Date())
@@ -312,6 +316,15 @@ describe('Strict mode', () => {
     const format = 'YYYY MMMM DD'
     expect(dayjs(input, format, 'zh-cn').isValid()).toBe(true)
     expect(dayjs(input, format, 'zh-cn', true).isValid()).toBe(false)
+  })
+  it('accepts Z suffix with Z format token (#2712)', () => {
+    const format = 'YYYY-MM-DDTHH:mm:ssZ'
+    const input = '2024-08-19T10:30:00Z'
+    dayjs.tz.setDefault('Asia/Shanghai')
+    expect(dayjs(input, format, true).isValid()).toBe(true)
+    expect(dayjs.utc(input, format, true).isValid()).toBe(true)
+    expect(dayjs(input, format, true).valueOf()).toBe(moment(input, format, true).valueOf())
+    expect(dayjs.utc(input, format, true).valueOf()).toBe(moment.utc(input, format, true).valueOf())
   })
 })
 


### PR DESCRIPTION
## Summary
- Add `passesStrictParseCheck()` for strict parsing validation
- Treat trailing `Z` as equivalent to `+00:00` when the format includes the `Z` token
- Compare against UTC formatted output for timezone-aware strict parses

## Problem
```js
dayjs.utc('2024-08-19T10:30:00Z', 'YYYY-MM-DDTHH:mm:ssZ', true).isValid() // false
```
Strict mode invalidated valid parses because `format()` renders `+00:00` instead of `Z`.

## Test plan
- [x] Added regression test in `test/plugin/customParseFormat.test.js`
- [x] Full customParseFormat test suite passes

Fixes #2712