### PR TITLE
fix(duration): normalize ISO8601 time components when parsing

### DIFF
--- a/src/plugin/duration/index.js
+++ b/src/plugin/duration/index.js
@@ -94,6 +94,7 @@ class Duration {
           this.$d.minutes,
           this.$d.seconds
         ] = numberD
+        this.normalizeIsoTimeComponents()
         this.calMilliseconds()
         return this
       }
@@ -105,6 +106,25 @@ class Duration {
     this.$ms = Object.keys(this.$d).reduce((total, unit) => (
       total + ((this.$d[unit] || 0) * (unitToMS[unit]))
     ), 0)
+  }
+
+  normalizeIsoTimeComponents() {
+    if (this.$d.seconds) {
+      this.$d.minutes = (this.$d.minutes || 0) + Math.trunc(this.$d.seconds / 60)
+      this.$d.seconds %= 60
+      if (this.$d.seconds < 0) {
+        this.$d.seconds += 60
+        this.$d.minutes -= 1
+      }
+    }
+    if (this.$d.minutes) {
+      this.$d.hours = (this.$d.hours || 0) + Math.trunc(this.$d.minutes / 60)
+      this.$d.minutes %= 60
+      if (this.$d.minutes < 0) {
+        this.$d.minutes += 60
+        this.$d.hours -= 1
+      }
+    }
   }
 
   parseFromMilliseconds() {

--- a/test/plugin/duration.test.js
+++ b/test/plugin/duration.test.js
@@ -95,6 +95,16 @@ describe('Parse ISO string', () => {
   it('Part ISO string', () => {
     expect(dayjs.duration('PT2777H46M40S').toISOString()).toBe('PT2777H46M40S')
   })
+  it('Normalize ISO time components', () => {
+    expect(dayjs.duration('PT75M').minutes()).toBe(15)
+    expect(dayjs.duration('PT75M').hours()).toBe(1)
+    expect(dayjs.duration('PT75M').format('H:m')).toBe('1:15')
+    expect(dayjs.duration('PT70M').hours()).toBe(1)
+    expect(dayjs.duration('PT70M').minutes()).toBe(10)
+    expect(dayjs.duration('PT90S').minutes()).toBe(1)
+    expect(dayjs.duration('PT90S').seconds()).toBe(30)
+    expect(dayjs.duration('PT75M').asMinutes()).toBe(75)
+  })
   it('Formatting missing components', () => {
     expect(dayjs.duration('PT1H').format('YYYY-MM-DDTHH:mm:ss')).toBe('0000-00-00T01:00:00')
   })


### PR DESCRIPTION
## Summary
- Normalize overflow seconds into minutes and minutes into hours when parsing ISO8601 duration strings
- Preserves large hour values (e.g. `PT2777H46M40S`) without rolling into days

## Problem
`dayjs.duration('PT75M').minutes()` returned `75` and `.hours()` returned `0`, while moment returns `15` and `1` respectively.

## Test plan
- [x] Added tests for `PT75M`, `PT70M`, and `PT90S`
- [x] Verified `PT2777H46M40S` still round-trips via `toISOString()`
- [x] `npx jest test/plugin/duration.test.js` passes

Fixes #2985