### PR TITLE
fix: expose moment-compatible date fields on Day.js instances

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -105,6 +105,15 @@ class Dayjs {
     this.$m = $d.getMinutes()
     this.$s = $d.getSeconds()
     this.$ms = $d.getMilliseconds()
+
+    // moment.js interop: moment reads own date fields from object inputs
+    this.y = this.$y
+    this.M = this.$M
+    this.D = this.$D
+    this.h = this.$H
+    this.m = this.$m
+    this.s = this.$s
+    this.ms = this.$ms
   }
 
   // eslint-disable-next-line class-methods-use-this

--- a/test/parse.test.js
+++ b/test/parse.test.js
@@ -212,4 +212,10 @@ describe('REGEX_PARSE', () => {
     expect(dayjs(date).valueOf()).toBe(moment(date).valueOf())
     expect(d).toBe(null)
   })
+
+  it('moment accepts a Day.js instance as input', () => {
+    const d = dayjs('2026-03-01')
+    expect(moment(d).valueOf()).toBe(d.valueOf())
+    expect(moment(d).format('YYYY-MM-DD')).toBe('2026-03-01')
+  })
 })


### PR DESCRIPTION
## Summary

- When a Day.js instance is passed to `moment()`, moment treats it as a plain object and reads own date-unit fields
- Day.js now exposes moment alias fields (`y`, `M`, `D`, `h`, `m`, `s`, `ms`) on each instance during `init()`
- Shorthand aliases avoid clashing with Day.js getters like `.year()` and the pluralGetSet plugin's `.years()` methods

## Example

```js
const d = dayjs('2026-03-01')
moment(d).format('YYYY-MM-DD') // '2026-03-01' (was today's date)
```

Fixes #3025

## Test plan

- [x] `npx jest --runInBand` — 774 passing
- [x] Added regression test in `test/parse.test.js`