### PR TITLE
fix(duration): return invalid duration for non-finite humanize

### DIFF
--- a/src/plugin/duration/index.js
+++ b/src/plugin/duration/index.js
@@ -230,6 +230,9 @@ class Duration {
   }
 
   humanize(withSuffix) {
+    if (!Number.isFinite(this.$ms)) {
+      return 'invalid duration'
+    }
     return $d()
       .add(this.$ms, 'ms')
       .locale(this.$l)

--- a/test/plugin/duration.test.js
+++ b/test/plugin/duration.test.js
@@ -147,6 +147,12 @@ describe('Humanize', () => {
     expect(dayjs.duration(1, 'minutes').humanize(true)).toBe('en un minuto')
     dayjs.locale('en')
   })
+
+  it('Invalid duration', () => {
+    expect(dayjs.duration(NaN).humanize()).toBe('invalid duration')
+    expect(dayjs.duration(NaN).humanize(true)).toBe('invalid duration')
+    expect(dayjs.duration(Infinity).humanize()).toBe('invalid duration')
+  })
 })
 
 describe('Clone', () => {


### PR DESCRIPTION
## Summary

- `duration.humanize()` now returns `"invalid duration"` when the underlying milliseconds are not finite (e.g. `NaN`, `Infinity`)
- Prevents misleading output such as `"a month"` for invalid durations

## Example

```js
dayjs.duration(NaN).humanize()
// 'invalid duration' (was 'a month')
```

Fixes #3006

## Test plan

- [x] `npx jest --runInBand` — 774 passing
- [x] Added regression cases in `test/plugin/duration.test.js`