### PR TITLE
feat(duration): add format trim option for zero-value units

### DIFF
--- a/src/plugin/duration/index.js
+++ b/src/plugin/duration/index.js
@@ -12,6 +12,100 @@ const MILLISECONDS_A_MONTH = MILLISECONDS_A_YEAR / 12
 const DURATION_REGEX_PARSE = /^(-|\+)?P(?:([-+]?[0-9,.]*)Y)?(?:([-+]?[0-9,.]*)M)?(?:([-+]?[0-9,.]*)W)?(?:([-+]?[0-9,.]*)D)?(?:T(?:([-+]?[0-9,.]*)H)?(?:([-+]?[0-9,.]*)M)?(?:([-+]?[0-9,.]*)S)?)?$/
 const DURATION_REGEX_FORMAT = /\[([^\]]+)]|YYYY|YY|Y|M{1,2}|D{1,2}|H{1,2}|m{1,2}|s{1,2}|SSS/g
 
+const tokenizeFormatString = (str) => {
+  const parts = []
+  let lastIndex = 0
+  const re = new RegExp(DURATION_REGEX_FORMAT.source, 'g')
+  let match = re.exec(str)
+
+  while (match !== null) {
+    if (match.index > lastIndex) {
+      parts.push({ type: 'literal', value: str.slice(lastIndex, match.index) })
+    }
+    if (match[1] !== undefined) {
+      const [, literalValue] = match
+      parts.push({ type: 'literal', value: literalValue })
+    } else {
+      const [tokenValue] = match
+      parts.push({ type: 'token', value: tokenValue })
+    }
+    ({ lastIndex } = re)
+    match = re.exec(str)
+  }
+
+  if (lastIndex < str.length) {
+    parts.push({ type: 'literal', value: str.slice(lastIndex) })
+  }
+
+  return parts
+}
+
+const formatDurationWithTrim = (formatStr, matches, trim) => {
+  const trimLarge = trim === true || trim === 'large' || trim === 'both'
+  const trimSmall = trim === 'small' || trim === 'both'
+  const parts = tokenizeFormatString(formatStr)
+  const segments = []
+  let prefix = ''
+  let index = 0
+
+  while (index < parts.length && parts[index].type === 'literal') {
+    prefix += parts[index].value
+    index += 1
+  }
+
+  while (index < parts.length) {
+    const { value: tokenValue } = parts[index]
+    index += 1
+    let suffix = ''
+
+    while (index < parts.length && parts[index].type === 'literal') {
+      suffix += parts[index].value
+      index += 1
+    }
+
+    segments.push({
+      token: tokenValue,
+      suffix,
+      num: Number(matches[tokenValue]) || 0
+    })
+  }
+
+  if (segments.length === 0) {
+    return prefix
+  }
+
+  let start = 0
+  let end = segments.length
+
+  if (trimLarge) {
+    while (start < end - 1 && segments[start].num === 0) {
+      start += 1
+    }
+  }
+
+  if (trimSmall) {
+    while (end > start + 1 && segments[end - 1].num === 0) {
+      end -= 1
+    }
+  }
+
+  if (start >= end) {
+    const last = segments[segments.length - 1]
+    return prefix + String(matches[last.token]) + last.suffix
+  }
+
+  let result = prefix
+
+  for (let i = start; i < end; i += 1) {
+    result += String(matches[segments[i].token])
+    if (i < end - 1) {
+      result += segments[i].suffix
+    }
+  }
+
+  return result
+}
+
 const unitToMS = {
   years: MILLISECONDS_A_YEAR,
   months: MILLISECONDS_A_MONTH,
@@ -164,7 +258,7 @@ class Duration {
     return this.toISOString()
   }
 
-  format(formatStr) {
+  format(formatStr, options) {
     const str = formatStr || 'YYYY-MM-DDTHH:mm:ss'
     const matches = {
       Y: this.$d.years,
@@ -182,7 +276,13 @@ class Duration {
       ss: $u.s(this.$d.seconds, 2, '0'),
       SSS: $u.s(this.$d.milliseconds, 3, '0')
     }
-    return str.replace(DURATION_REGEX_FORMAT, (match, $1) => $1 || String(matches[match]))
+    const trim = options && options.trim
+
+    if (!trim) {
+      return str.replace(DURATION_REGEX_FORMAT, (match, $1) => $1 || String(matches[match]))
+    }
+
+    return formatDurationWithTrim(str, matches, trim)
   }
 
   as(unit) {

--- a/test/plugin/duration.test.js
+++ b/test/plugin/duration.test.js
@@ -313,4 +313,33 @@ describe('Format', () => {
     const d = dayjs.duration(2, 'years')
     expect(d.format('YYY')).toBe('022')
   })
+
+  test('trim large removes leading zero-value units', () => {
+    const d = dayjs.duration(123, 'minutes')
+    expect(d.format('D[d] H:mm:ss')).toBe('0d 2:03:00')
+    expect(d.format('D[d] H:mm:ss', { trim: true })).toBe('2:03:00')
+    expect(d.format('D[d] H:mm:ss', { trim: 'large' })).toBe('2:03:00')
+  })
+
+  test('trim large on default format keeps first non-zero unit', () => {
+    const d = dayjs.duration('PT1H')
+    expect(d.format()).toBe('0000-00-00T01:00:00')
+    expect(d.format(undefined, { trim: true })).toBe('01:00:00')
+  })
+
+  test('trim small removes trailing zero-value units', () => {
+    const d = dayjs.duration(90, 'minutes')
+    expect(d.format('H:mm:ss')).toBe('1:30:00')
+    expect(d.format('H:mm:ss', { trim: 'small' })).toBe('1:30')
+  })
+
+  test('trim both removes leading and trailing zero-value units', () => {
+    const d = dayjs.duration(90, 'minutes')
+    expect(d.format('D[d] H:mm:ss', { trim: 'both' })).toBe('1:30')
+  })
+
+  test('trim keeps smallest unit when duration is zero', () => {
+    const d = dayjs.duration(0)
+    expect(d.format('H:mm:ss', { trim: true })).toBe('00')
+  })
 })


### PR DESCRIPTION
## Summary
- Add optional `trim` parameter to `duration.format(formatStr, { trim })`
- Supports `true` / `'large'`, `'small'`, and `'both'` to drop leading and/or trailing zero-value units (similar to [moment-duration-format](https://github.com/jsmreese/moment-duration-format#trim))
- Keeps backward compatibility when `trim` is omitted

Fixes #2999

## Example
```js
dayjs.duration(123, 'minutes').format('D[d] H:mm:ss') // '0d 2:03:00'
dayjs.duration(123, 'minutes').format('D[d] H:mm:ss', { trim: true }) // '2:03:00'
```

## Test plan
- [x] `npx jest test/plugin/duration.test.js --runInBand`