### PR TITLE
fix: updated correct abbreviation for short form of August

### DIFF
--- a/src/locale/id.js
+++ b/src/locale/id.js
@@ -6,7 +6,7 @@ const locale = {
   weekdays: 'Minggu_Senin_Selasa_Rabu_Kamis_Jumat_Sabtu'.split('_'),
   months: 'Januari_Februari_Maret_April_Mei_Juni_Juli_Agustus_September_Oktober_November_Desember'.split('_'),
   weekdaysShort: 'Min_Sen_Sel_Rab_Kam_Jum_Sab'.split('_'),
-  monthsShort: 'Jan_Feb_Mar_Apr_Mei_Jun_Jul_Agt_Sep_Okt_Nov_Des'.split('_'),
+  monthsShort: 'Jan_Feb_Mar_Apr_Mei_Jun_Jul_Agu_Sep_Okt_Nov_Des'.split('_'),
   weekdaysMin: 'Mg_Sn_Sl_Rb_Km_Jm_Sb'.split('_'),
   weekStart: 1,
   formats: {


### PR DESCRIPTION
`Agt` is commonly seen in Malay or informal/local usage, but it is not the standard Indonesian abbreviation used in official Indonesian locale data. The correct abbreviation is `Agu`
https://www.unicode.org/cldr/charts/44/summary/id.html#3cb5a7caab50ce56