### PR TITLE
fix: updated correct abbreviation for short form of Thursday

### DIFF
--- a/src/locale/sv-fi.js
+++ b/src/locale/sv-fi.js
@@ -4,7 +4,7 @@ import dayjs from 'dayjs'
 const locale = {
   name: 'sv-fi',
   weekdays: 'söndag_måndag_tisdag_onsdag_torsdag_fredag_lördag'.split('_'),
-  weekdaysShort: 'sön_mån_tis_ons_tor_fre_lör'.split('_'),
+  weekdaysShort: 'sön_mån_tis_ons_tors_fre_lör'.split('_'),
   weekdaysMin: 'sö_må_ti_on_to_fr_lö'.split('_'),
   months: 'januari_februari_mars_april_maj_juni_juli_augusti_september_oktober_november_december'.split('_'),
   monthsShort: 'jan_feb_mar_apr_maj_jun_jul_aug_sep_okt_nov_dec'.split('_'),

--- a/src/locale/sv.js
+++ b/src/locale/sv.js
@@ -4,7 +4,7 @@ import dayjs from 'dayjs'
 const locale = {
   name: 'sv',
   weekdays: 'söndag_måndag_tisdag_onsdag_torsdag_fredag_lördag'.split('_'),
-  weekdaysShort: 'sön_mån_tis_ons_tor_fre_lör'.split('_'),
+  weekdaysShort: 'sön_mån_tis_ons_tors_fre_lör'.split('_'),
   weekdaysMin: 'sö_må_ti_on_to_fr_lö'.split('_'),
   months: 'januari_februari_mars_april_maj_juni_juli_augusti_september_oktober_november_december'.split('_'),
   monthsShort: 'jan_feb_mar_apr_maj_jun_jul_aug_sep_okt_nov_dec'.split('_'),


### PR DESCRIPTION
In Swedish (sv), the standard short form for torsdag (Thursday) is:`tors`
https://unicode.org/cldr/cldr-aux/charts/32/summary/sv.html