### PR TITLE
test(timezone): cover DST startOf regression

### DIFF
--- a/test/plugin/timezone.test.js
+++ b/test/plugin/timezone.test.js
@@ -313,6 +313,14 @@ describe('startOf and endOf', () => {
     expect(startOfDay.valueOf()).toEqual(originalDay.valueOf())
   })
 
+  it('preserves the target timezone after DST ends in Melbourne', () => {
+    const beforeDstEnd = dayjs.tz('2021-04-01 08:00', 'Australia/Melbourne').startOf('day')
+    const afterDstEnd = dayjs.tz('2021-04-15 08:00', 'Australia/Melbourne').startOf('day')
+
+    expect(beforeDstEnd.format()).toBe('2021-04-01T00:00:00+11:00')
+    expect(afterDstEnd.format()).toBe('2021-04-15T00:00:00+10:00')
+  })
+
   it('corrects for timezone offset in endOf', () => {
     const originalDay = dayjs.tz('2009-12-31 23:59:59.999', NY)
     const endOfDay = originalDay.endOf('day')


### PR DESCRIPTION
Closes #1437

This adds a focused regression test for the timezone `startOf('day')` DST case described in #1437.

The covered scenario uses `Australia/Melbourne` after DST has ended and asserts that `startOf('day')` preserves the target date boundary and timezone offset instead of drifting back into the prior day.

Tests:
- `npx jest test/plugin/timezone.test.js --runInBand --coverage=false`
- `TZ=Australia/Melbourne npx jest test/plugin/timezone.test.js --runInBand --coverage=false`
