### PR TITLE
fix(locale): remove Russian year suffix "г." from az formats

### DIFF
--- a/src/locale/az.js
+++ b/src/locale/az.js
@@ -13,9 +13,9 @@ const locale = {
     LT: 'H:mm',
     LTS: 'H:mm:ss',
     L: 'DD.MM.YYYY',
-    LL: 'D MMMM YYYY г.',
-    LLL: 'D MMMM YYYY г., H:mm',
-    LLLL: 'dddd, D MMMM YYYY г., H:mm'
+    LL: 'D MMMM YYYY',
+    LLL: 'D MMMM YYYY H:mm',
+    LLLL: 'dddd, D MMMM YYYY H:mm'
   },
   relativeTime: {
     future: '%s sonra',


### PR DESCRIPTION
The `az` locale's `LL` / `LLL` / `LLLL` format strings ended with `г.` — the Cyrillic abbreviation for the Russian word "год" ("year"). This is a leftover from when [`src/locale/az.js`](src/locale/az.js) was seeded from [`src/locale/ru.js`](src/locale/ru.js): `г.` has no meaning in Azerbaijani (which is written in Latin script) and produced output like:

```
27 May 2026 г.
27 May 2026 г., 14:30
Çərşənbə axşamı, 27 May 2026 г., 14:30
```

instead of the expected:

```
27 May 2026
27 May 2026 14:30
Çərşənbə axşamı, 27 May 2026 14:30
```

### Fix

Remove `г.` and its trailing comma from all three format strings. The resulting shape matches the convention used by other Latin-script Turkic locales — e.g. [`src/locale/tr.js`](src/locale/tr.js) uses `'D MMMM YYYY'`, `'D MMMM YYYY HH:mm'`, `'dddd, D MMMM YYYY HH:mm'`.

```diff
-    LL: 'D MMMM YYYY г.',
-    LLL: 'D MMMM YYYY г., H:mm',
-    LLLL: 'dddd, D MMMM YYYY г., H:mm'
+    LL: 'D MMMM YYYY',
+    LLL: 'D MMMM YYYY H:mm',
+    LLLL: 'dddd, D MMMM YYYY H:mm'
```

The fix is intentionally minimal — only the spurious `г.` is removed. No other fields (months, weekdays, relativeTime, ordinal) are touched.
