### PR TITLE
fix(duration): return 'invalid duration' for NaN input in humanize()

### DIFF
--- a/src/plugin/duration/index.js
+++ b/src/plugin/duration/index.js
@@ -230,6 +230,7 @@ class Duration {
   }
 
   humanize(withSuffix) {
+    if (Number.isNaN(this.$ms)) { return "invalid duration"; }
     return $d()
       .add(this.$ms, 'ms')
       .locale(this.$l)


### PR DESCRIPTION
## Problem
`dayjs.duration(NaN).humanize()` returns `"a month"` instead of indicating that the duration is invalid. This happens because NaN propagates through `.add()` and then falls through to the default threshold in `fromToBase()`, matching "M" (month).

## Changes
- Add `Number.isNaN(this.$ms)` guard in the `humanize()` method to return `"invalid duration"` early

Closes #3006