### PR TITLE
fix: format YY for single digit yr

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -285,7 +285,9 @@ class Dayjs {
     const matches = (match) => {
       switch (match) {
         case 'YY':
-          return String(this.$y).slice(-2)
+          return String(this.$y)
+            .slice(-2)
+            .padStart(2, '0')
         case 'YYYY':
           return Utils.s(this.$y, 4, '0')
         case 'M':

--- a/test/display.test.js
+++ b/test/display.test.js
@@ -28,6 +28,11 @@ it('Format Year YY YYYY', () => {
   expect(dayjs().format('YYY')).toBe(`${moment().format('YY')}Y`)
 })
 
+it('Format single digit Year YY YYYY', () => {
+  const date = '0001-01-01T01:01:01.000Z'
+  expect(dayjs(date).format('YY')).toBe(moment(date).format('YY'))
+})
+
 it('Format Month M MM MMM MMMM', () => {
   expect(dayjs().format('M')).toBe(moment().format('M'))
   expect(dayjs().format('MM')).toBe(moment().format('MM'))


### PR DESCRIPTION
```
console.log(dayjs().set('year', 2009).format('YY')); // 09
console.log(dayjs().set('year', 9).format('YY')); // 09
```