### PR TITLE
fix: treat digit-only strings of 9+ chars as invalid (#2955)

### DIFF
--- a/src/constant.js
+++ b/src/constant.js
@@ -26,5 +26,5 @@ export const FORMAT_DEFAULT = 'YYYY-MM-DDTHH:mm:ssZ'
 export const INVALID_DATE_STRING = 'Invalid Date'
 
 // regex
-export const REGEX_PARSE = /^(\d{4})[-/]?(\d{1,2})?[-/]?(\d{0,2})[Tt\s]*(\d{1,2})?:?(\d{1,2})?:?(\d{1,2})?[.:]?(\d+)?$/
+export const REGEX_PARSE = /^(?!\d{9,}$)(\d{4})[-/]?(\d{1,2})?[-/]?(\d{0,2})[Tt\s]*(\d{1,2})?:?(\d{1,2})?:?(\d{1,2})?[.:]?(\d+)?$/
 export const REGEX_FORMAT = /\[([^\]]+)]|YYYY|YY|M{1,4}|D{1,2}|d{1,4}|H{1,2}|h{1,2}|a|A|m{1,2}|s{1,2}|Z{1,2}|SSS/g

--- a/test/parse.test.js
+++ b/test/parse.test.js
@@ -213,3 +213,18 @@ describe('REGEX_PARSE', () => {
     expect(d).toBe(null)
   })
 })
+
+describe('Timestamp string', () => {
+  // #2955
+  it('timestamp passed as string is invalid', () => {
+    expect(dayjs('1762232987879').isValid()).toBe(false)
+    expect(dayjs('1581314281').isValid()).toBe(false)
+    expect(dayjs('123456789').isValid()).toBe(false)
+  })
+  it('digit-only date formats still parse', () => {
+    expect(dayjs('2018').year()).toBe(2018)
+    expect(dayjs('201805').format('YYYY-MM')).toBe('2018-05')
+    expect(dayjs('20180517').format('YYYY-MM-DD')).toBe('2018-05-17')
+    expect(dayjs('20210102T012345').isValid()).toBe(true)
+  })
+})


### PR DESCRIPTION
A ms timestamp passed as a string ('1762232987879') matched the date
regex and parsed as year 1762, but still reported isValid() true.
String input is documented as ISO 8601, so let these fall through to
the Date constructor and return Invalid Date, same as moment.
