### PR TITLE
fix(locale): add meridiem to Ukrainian (uk) locale

### DIFF
--- a/src/locale/uk.js
+++ b/src/locale/uk.js
@@ -61,6 +61,16 @@ const locale = {
     yy: relativeTimeWithPlural
   },
   ordinal: n => n,
+  meridiem: (hour) => {
+    if (hour < 4) {
+      return 'ночі'
+    } else if (hour < 12) {
+      return 'ранку'
+    } else if (hour < 17) {
+      return 'дня'
+    }
+    return 'вечора'
+  },
   formats: {
     LT: 'HH:mm',
     LTS: 'HH:mm:ss',

--- a/test/locale/uk.test.js
+++ b/test/locale/uk.test.js
@@ -57,3 +57,10 @@ it('hour', () => {
   const result2 = dayjs(str).locale('uk').to(str0, true)
   expect(result2).toEqual('година') // different from moment.js
 })
+
+it('Meridiem', () => {
+  expect(dayjs('2026-01-01 03:00:00').locale('uk').format('A')).toEqual('ночі')
+  expect(dayjs('2026-01-01 11:00:00').locale('uk').format('A')).toEqual('ранку')
+  expect(dayjs('2026-01-01 16:00:00').locale('uk').format('A')).toEqual('дня')
+  expect(dayjs('2026-01-01 20:00:00').locale('uk').format('A')).toEqual('вечора')
+})


### PR DESCRIPTION
## Description

The Ukrainian (`uk`) locale was missing a `meridiem` function, so `format('A')`
fell back to the core default and returned English `AM` / `PM`.

Ukrainian expresses the time of day with words rather than AM/PM
(e.g. "8 вечора", "11 ранку"). This PR adds a `meridiem` function to the `uk` locale.

## Behavior

| Hour    | Before | After    |
|---------|--------|----------|
| `< 4`   | `AM`   | `ночі`   |
| `< 12`  | `AM`   | `ранку`  |
| `< 17`  | `PM`   | `дня`    |
| `>= 17` | `PM`   | `вечора` |

## Changes

- `src/locale/uk.js` — add the `meridiem` function.
- `test/locale/uk.test.js` — add a `Meridiem` test covering all four branches.

## Checklist

- [x] `npm run lint` passes
- [x] `npm run test` passes
- [x] Test coverage maintained