### PR TITLE
Add iso week setter

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -285,7 +285,9 @@ class Dayjs {
     const matches = (match) => {
       switch (match) {
         case 'YY':
-          return String(this.$y).slice(-2)
+          return String(this.$y)
+            .slice(-2)
+            .padStart(2, '0')
         case 'YYYY':
           return Utils.s(this.$y, 4, '0')
         case 'M':

--- a/src/plugin/isoWeek/index.js
+++ b/src/plugin/isoWeek/index.js
@@ -16,7 +16,22 @@ export default (o, c, d) => {
 
   const proto = c.prototype
 
-  proto.isoWeekYear = function () {
+  proto.isoWeekYear = function (year) {
+    if (!this.$utils().u(year)) {
+      const currentIsoWeek = this.isoWeek()
+      const currentIsoWeekday = this.isoWeekday()
+
+      const newYearThursday = getYearFirstThursday(year, this.$u)
+
+      const newDate = newYearThursday
+        .add(currentIsoWeek - 1, W)
+        .isoWeekday(currentIsoWeekday)
+
+      this.$d = newDate.toDate()
+      this.init()
+
+      return this
+    }
     const nowWeekThursday = getCurrentWeekThursday(this)
     return nowWeekThursday.year()
   }

--- a/test/display.test.js
+++ b/test/display.test.js
@@ -28,6 +28,11 @@ it('Format Year YY YYYY', () => {
   expect(dayjs().format('YYY')).toBe(`${moment().format('YY')}Y`)
 })
 
+it('Format single digit Year YY YYYY', () => {
+  const date = '0001-01-01T01:01:01.000Z'
+  expect(dayjs(date).format('YY')).toBe(moment(date).format('YY'))
+})
+
 it('Format Month M MM MMM MMMM', () => {
   expect(dayjs().format('M')).toBe(moment().format('M'))
   expect(dayjs().format('MM')).toBe(moment().format('MM'))

--- a/test/plugin/isoWeek.test.js
+++ b/test/plugin/isoWeek.test.js
@@ -28,6 +28,48 @@ it('get isoWeekYear', () => {
   expect(dayjs().isoWeekYear()).toBe(moment().isoWeekYear())
 })
 
+it('2024-12-29 to ISO Year 2025, ISO Week 1, then +1 week', () => {
+  const testCase = {
+    initialDate: '2024-12-29',
+    targetIsoYear: 2025,
+    targetIsoWeek: 1,
+    addWeeks: 1
+  }
+
+  const momentResult = moment(testCase.initialDate)
+    .isoWeekYear(testCase.targetIsoYear)
+    .isoWeek(testCase.targetIsoWeek)
+    .add(testCase.addWeeks, 'week')
+
+  const dayjsResult = dayjs(testCase.initialDate)
+    .isoWeekYear(testCase.targetIsoYear)
+    .isoWeek(testCase.targetIsoWeek)
+    .add(testCase.addWeeks, 'week')
+
+  expect(dayjsResult.valueOf()).toBe(momentResult.valueOf())
+})
+
+it('2024-01-01 to ISO Year 2023, ISO Week 2, then -1 week', () => {
+  const testCase = {
+    initialDate: '2024-01-01',
+    targetIsoYear: 2023,
+    targetIsoWeek: 52,
+    weeks: 1
+  }
+
+  const momentResult = moment(testCase.initialDate)
+    .isoWeekYear(testCase.targetIsoYear)
+    .isoWeek(testCase.targetIsoWeek)
+    .subtract(testCase.weeks, 'week')
+
+  const dayjsResult = dayjs(testCase.initialDate)
+    .isoWeekYear(testCase.targetIsoYear)
+    .isoWeek(testCase.targetIsoWeek)
+    .subtract(testCase.weeks, 'week')
+
+  expect(dayjsResult.valueOf()).toBe(momentResult.valueOf())
+})
+
 it('startOf/endOf isoWeek', () => {
   const ISOWEEK = 'isoWeek'
   expect(dayjs().startOf(ISOWEEK).valueOf()).toBe(moment().startOf(ISOWEEK).valueOf())


### PR DESCRIPTION
This pull request introduces an isoWeekYear setter, allowing the ISO week year to be adjusted while preserving the current isoWeek and isoWeekday values. This change ensures consistent ISO-based date calculations and avoids unexpected behavior when using native .year() in combination with ISO week methods.

```
import dayjs from 'dayjs'
import isoWeek from 'dayjs/plugin/isoWeek'
dayjs.extend(isoWeek)

// This snippet may produce an unexpected date (e.g., "2026-01-04")
// instead of the expected date in 2025.
const result = dayjs('2024-12-29')
  .year(2025)      // sets the local year, not the ISO year
  .isoWeek(1)
  .add(1, 'week')  // adds one week based on local calculations

console.log(result.format()) 
// Unintentionally outputs something like "2026-01-04"
```