### PR TITLE
fix(customParseFormat): correct meridiem parsing for non-English locales

### DIFF
--- a/src/plugin/customParseFormat/index.js
+++ b/src/plugin/customParseFormat/index.js
@@ -49,10 +49,13 @@ const meridiemMatch = (input, isLowerCase) => {
   if (!meridiem) {
     isAfternoon = input === (isLowerCase ? 'pm' : 'PM')
   } else {
-    for (let i = 1; i <= 24; i += 1) {
-      // todo: fix input === meridiem(i, 0, isLowerCase)
+    // Iterate over a full 24-hour range so the meridiem string for each hour is
+    // checked. The previous loop started at hour 1 and used an `i > 12` check,
+    // but a PM string first matched at i=12 (12 > 12 === false) and was misread
+    // as AM for non-English locales such as `ko` (오전/오후). (#2031)
+    for (let i = 0; i <= 23; i += 1) {
       if (input.indexOf(meridiem(i, 0, isLowerCase)) > -1) {
-        isAfternoon = i > 12
+        isAfternoon = i >= 12
         break
       }
     }

--- a/test/plugin/customParseFormat.test.js
+++ b/test/plugin/customParseFormat.test.js
@@ -4,6 +4,7 @@ import dayjs from '../../src'
 import '../../src/locale/ru'
 import uk from '../../src/locale/uk'
 import '../../src/locale/zh-cn'
+import '../../src/locale/ko'
 import customParseFormat from '../../src/plugin/customParseFormat'
 import advancedFormat from '../../src/plugin/advancedFormat'
 import localizedFormats from '../../src/plugin/localizedFormat'
@@ -346,6 +347,26 @@ describe('meridiem locale', () => {
     const input = '2018-05-02 20:02:03'
     const date = dayjs(input).locale('zh-cn').format(format)
     expect(dayjs(date, format, 'zh-cn').format(format2)).toBe(input)
+  })
+})
+
+// issue 2031
+describe('parse localized meridiem (ko) in strict mode', () => {
+  const format = 'YYYY-MM-DD hh:mm A'
+  it('AM', () => {
+    expect(dayjs('2024-01-01 01:00 오전', format, 'ko', true).hour()).toBe(1)
+  })
+  it('PM', () => {
+    expect(dayjs('2024-01-01 01:00 오후', format, 'ko', true).hour()).toBe(13)
+  })
+  it('noon (12 PM)', () => {
+    expect(dayjs('2024-01-01 12:00 오후', format, 'ko', true).hour()).toBe(12)
+  })
+  it('midnight (12 AM)', () => {
+    expect(dayjs('2024-01-01 12:00 오전', format, 'ko', true).hour()).toBe(0)
+  })
+  it('11 PM', () => {
+    expect(dayjs('2024-01-01 11:00 오후', format, 'ko', true).hour()).toBe(23)
   })
 })
 


### PR DESCRIPTION
## Description

`customParseFormat`'s `meridiemMatch` misread PM strings as AM for locales that define a `meridiem` function (e.g. `ko` 오전/오후), causing strict-mode parsing to fail.

The loop iterated `1..24` and decided AM/PM with `i > 12`. Because dayjs uses a 12-hour clock, the PM string first matched at `i = 12`, where `12 > 12` is `false`, so it was treated as AM and strict parsing returned `Invalid Date`.

This changes the loop to iterate `0..23` and decide with `i >= 12`. The `indexOf` match is kept intact: with CJK formats such as `YYYY年M月D日A...` the literal separators bleed into the `A` token (the parser receives `"年月日晚上"`), so the partial match is required and the existing `zh-cn` behavior is preserved.

Fixes #2031

## Before

```js
dayjs('2024-01-01 01:00 오후', 'YYYY-MM-DD hh:mm A', 'ko', true).isValid()
// => false (should be 13:00)
```

## After

```js
dayjs('2024-01-01 01:00 오후', 'YYYY-MM-DD hh:mm A', 'ko', true).hour()
// => 13
```

## Tests

Added strict-mode `ko` meridiem cases (AM, PM, noon, midnight, 11 PM) in `test/plugin/customParseFormat.test.js`. Full suite passes (778 tests), including existing `zh-cn` AM/PM cases.