### PR TITLE
fix(isBetween): return false for invalid date

### DIFF
--- a/src/plugin/isBetween/index.js
+++ b/src/plugin/isBetween/index.js
@@ -1,5 +1,6 @@
 export default (o, c, d) => {
   c.prototype.isBetween = function (a, b, u, i) {
+    if (!this.isValid()) return false
     const dA = d(a)
     const dB = d(b)
     i = i || '()'

--- a/test/plugin/isBetween.test.js
+++ b/test/plugin/isBetween.test.js
@@ -17,6 +17,17 @@ test('bounds can be swapped', () => {
   expect(dayjs('2018-01-01').isBetween(dayjs('2018-01-02'), dayjs('2017-12-31'))).toBeTruthy()
 })
 
+test('invalid date is never between', () => {
+  const a = dayjs('2022-01-28')
+  const b = dayjs('2022-02-28')
+  const inclusivities = ['()', '[]', '[)', '(]']
+  inclusivities.forEach((i) => {
+    expect(dayjs(null).isBetween(a, b, 'day', i)).toBe(false)
+    expect(dayjs('not a date').isBetween(a, b, 'day', i)).toBe(false)
+    expect(dayjs(null).isBetween(a, b, null, i)).toBe(false)
+  })
+})
+
 test('bounds can be swapped with inclusivity', () => {
   expect(dayjs('2018-01-01').isBetween(dayjs('2017-12-31'), dayjs('2018-01-01'), null, '[]')).toBeTruthy()
   expect(dayjs('2018-01-01').isBetween(dayjs('2018-01-01'), dayjs('2017-12-31'), null, '[]')).toBeTruthy()


### PR DESCRIPTION
## Summary

`isBetween` returns `true` for an **Invalid Date** subject when the inclusivity option includes a closed bound (`[]`, `[)`, `(]`). It should always return `false` for an invalid date, matching Moment.js.

```js
dayjs(null).isBetween(dayjs('2022-01-28'), dayjs('2022-02-28'), 'day', '[]')          // true  ❌  (expected false)
dayjs('random string').isBetween(dayjs('2022-01-28'), dayjs('2022-02-28'), 'day', '[]') // true  ❌  (expected false)
dayjs('random string').isBetween(dayjs('2022-01-28'), dayjs('2022-02-28'), 'day', '()') // false ✅
```

Moment.js returns `false` for an invalid date for every inclusivity mode (`()`, `[]`, `[)`, `(]`).

## Root cause

For inclusive bounds, `isBetween` relies on the negation of `isBefore`/`isAfter`:

```js
(dAi ? this.isAfter(dA, u) : !this.isBefore(dA, u)) && (dBi ? this.isBefore(dB, u) : !this.isAfter(dB, u))
```

When the subject is an Invalid Date, both `isBefore` and `isAfter` are `false` (NaN comparisons), so `!isBefore(...) && !isAfter(...)` evaluates to `true`. The exclusive modes happen to return `false` because they use the non-negated comparisons, which is why the result is inconsistent across inclusivity options.

## Fix

Guard at the top of `isBetween`: if the subject is invalid, return `false`. This is additive and does not change behavior for valid dates.

## Tests

Added a deterministic test (TZ-independent, passes under `Pacific/Auckland`, `Europe/London`, `America/Whitehorse`, and `UTC`) covering all four inclusivity modes for both `dayjs(null)` and `dayjs('not a date')`. The test fails on the current `dev` branch and passes with the fix. Full suite (774 tests) passes.

Closes #2097