### PR TITLE
fix: add meridiem to Turkish locale

### DIFF
--- a/src/locale/tr.js
+++ b/src/locale/tr.js
@@ -17,6 +17,7 @@ const locale = {
     LLL: 'D MMMM YYYY HH:mm',
     LLLL: 'dddd, D MMMM YYYY HH:mm'
   },
+  meridiem: hour => (hour < 12 ? 'ÖÖ' : 'ÖS'),
   relativeTime: {
     future: '%s sonra',
     past: '%s önce',


### PR DESCRIPTION
## Summary

- Adds `meridiem` to the Turkish (`tr`) locale so 12-hour formatting uses correct Turkish AM/PM markers (`ÖÖ` / `ÖS`).

## Motivation

The Turkish locale was missing a `meridiem` function, which caused incorrect or missing output when formatting times with the `A` token in 12-hour mode.

## Test plan

- [x] `npm run lint`
- [x] `npx jest test/locale/keys.test.js`


Made with [Cursor](https://cursor.com)