### PR TITLE
fix in timezone: ensure UTC chain is not affected by host DST in startOf

### DIFF
--- a/src/plugin/timezone/index.js
+++ b/src/plugin/timezone/index.js
@@ -126,9 +126,13 @@ export default (o, c, d) => {
     if (!this.$x || !this.$x.$timezone) {
       return oldStartOf.call(this, units, startOf)
     }
-
-    const withoutTz = d(this.format('YYYY-MM-DD HH:mm:ss:SSS'), { locale: this.$L })
-    const startOfWithoutTz = oldStartOf.call(withoutTz, units, startOf)
+    let ins
+    if (this.$x.$timezone.toUpperCase() === 'UTC') {
+      ins = d(this.format('YYYY-MM-DD HH:mm:ss:SSS'), {locale: this.$L, utc: true })
+    } else {
+      ins = d(this.format('YYYY-MM-DD HH:mm:ss:SSS'), { locale: this.$L })
+    }
+    const startOfWithoutTz = oldStartOf.call(ins, units, startOf)
     return startOfWithoutTz.tz(this.$x.$timezone, true)
   }
 

--- a/test/plugin/transitionDSTtoUTC.test.js
+++ b/test/plugin/transitionDSTtoUTC.test.js
@@ -1,0 +1,29 @@
+import dayjs from '../../src'
+import utc from '../../src/plugin/utc'
+import timezone from '../../src/plugin/timezone'
+
+dayjs.extend(utc)
+dayjs.extend(timezone)
+
+describe('timezone', () => {
+  it('should preserve UTC semantics for startOf(day) across host DST transitions', () => {
+    // 2024-11-03 is the DST fall-back date in America/Los_Angeles.
+    // When the host timezone is set to America/Los_Angeles,
+    // dayjs.tz(ms, 'UTC') should still behave exactly like dayjs.utc(ms).
+
+    const ms = Date.parse('2024-11-03T23:00:00.000Z')
+
+    const tzResult = dayjs
+      .tz(ms, 'UTC')
+      .startOf('day')
+      .valueOf()
+
+    const utcResult = dayjs
+      .utc(ms)
+      .startOf('day')
+      .valueOf()
+
+    expect(tzResult).toBe(utcResult)
+    expect(tzResult).toBe(Date.parse('2024-11-03T00:00:00.000Z'))
+  })
+})


### PR DESCRIPTION
**Description**
This PR fixes a bug in the `timezone` plugin where calling `.startOf('day')` on a UTC instance returns an incorrect date if the host machine's local time is undergoing a Daylight Saving Time (DST) transition on that specific date.

**The Problem**
In the original implementation, `proto.startOf` handles timezone shifting by formatting the date into a naive string (`YYYY-MM-DD HH:mm:ss:SSS`) and parsing it back using the default factory `d()`. 

When the target timezone is `UTC` but the host system (e.g., `America/Los_Angeles`) experiences a DST transition (such as a 25-hour day), the core's default parsing falls back to the host's local clock constraints. This causes the underlying local `Date` mathematics to miscalculate the midnight boundary, leaking the host's DST anomaly into the final UTC object.

**Solution presented**
When `this.$x.$timezone` is `'UTC'`:
I use `{ utc: true }` in the configuration.

**Type of Change**
- [x] Change in the plugin timezone.js
- [x] Added the following test: transitionDSTtoUTC

Addresses [#3123](https://github.com/iamkun/dayjs/issues/3123#issue-4618852197)