### PR TITLE
docs: add Deno to install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,8 @@ You can find more details, API, and other docs on [day.js.org](https://day.js.or
 
 ```console
 npm install dayjs --save
+# or
+deno install dayjs
 ```
 
 📚[Installation Guide](https://day.js.org/docs/en/installation/installation)


### PR DESCRIPTION
👋 Bartek from the Deno team here.

The README shows `npm install dayjs`. Since Deno is a drop-in replacement for npm these days, this adds a Deno line alongside it:

```sh
deno install dayjs
```

Docs-only change (dayjs resolves and installs the same way under Deno). Totally fine to close this if you'd rather keep it npm-only. Happy to adjust.

_Disclosure: I work on Deno, so I have an interest here. The goal is parity with the package managers you already list, not promotion. This PR was prepared with AI assistance under human supervision: I review every change myself and personally respond to any comments or review feedback._
