### PR TITLE
fix(duration): apply the leading sign when parsing a negative ISO duration

### DIFF
--- a/src/plugin/duration/index.js
+++ b/src/plugin/duration/index.js
@@ -84,7 +84,9 @@ class Duration {
       const d = input.match(DURATION_REGEX_PARSE)
       if (d) {
         const properties = d.slice(2)
-        const numberD = properties.map(value => (value != null ? Number(value) : 0));
+        const signMultiplier = d[1] === '-' ? -1 : 1
+        const numberD = properties.map(value =>
+          (value != null ? Number(value) * signMultiplier : 0));
         [
           this.$d.years,
           this.$d.months,

--- a/test/plugin/duration.test.js
+++ b/test/plugin/duration.test.js
@@ -108,6 +108,13 @@ describe('Parse ISO string', () => {
   it('Invalid ISO string', () => {
     expect(dayjs.duration('Invalid').toISOString()).toBe('P0D')
   })
+  it('Negative ISO string round-trips', () => {
+    expect(dayjs.duration('-P1Y').asYears()).toBe(-1)
+    expect(dayjs.duration('-P1DT2H').asHours()).toBe(-26)
+    expect(dayjs.duration('-PT59S').toISOString()).toBe('-PT59S')
+    const d = dayjs.duration(-1, 'years')
+    expect(dayjs.duration(d.toISOString()).asMilliseconds()).toBe(d.asMilliseconds())
+  })
 })
 
 it('Is duration', () => {


### PR DESCRIPTION
## Problem

Parsing a negative ISO-8601 duration string drops the leading sign:

```js
dayjs.duration('-P1Y').asYears()   // returns 1, expected -1
dayjs.duration('-P1DT2H').asHours() // returns 26, expected -26
```

The parser does `d.slice(2)` over the regex match and never reads the sign captured in `d[1]`. Because `toISOString()` correctly emits `-P...`, the round-trip invariant breaks:

```js
const d = dayjs.duration(-1, 'years')
dayjs.duration(d.toISOString()).asMilliseconds() === d.asMilliseconds() // false before this fix
```

Refs #1516.

## Fix

Derive a sign multiplier from `d[1] === '-'` and apply it to each parsed component, so the serialized output parses back to the original value.

## Scope

Leading-sign case only. Per-component signs (e.g. `P-6M3D`) are a separate serializer limitation and are out of scope here.

## Tests

Added a round-trip test covering `asYears`, `asHours`, `toISOString`, and the `duration(d.toISOString()) === d` invariant. Red before the fix, green after; duration suite 31/31, duration + relativeTime 40/40.