### PR TITLE
fix(customParseFormat): keep UTC mode when format is an array

### DIFF
--- a/src/plugin/customParseFormat/index.js
+++ b/src/plugin/customParseFormat/index.js
@@ -252,9 +252,10 @@ export default (o, C, d) => {
       locale = {}
     } else if (format instanceof Array) {
       const len = format.length
+      const parse = utc && d.utc ? d.utc : d
       for (let i = 1; i <= len; i += 1) {
         args[1] = format[i - 1]
-        const result = d.apply(this, args)
+        const result = parse.apply(this, args)
         if (result.isValid()) {
           this.$d = result.$d
           this.$L = result.$L

--- a/test/plugin/customParseFormat.test.js
+++ b/test/plugin/customParseFormat.test.js
@@ -8,10 +8,12 @@ import customParseFormat from '../../src/plugin/customParseFormat'
 import advancedFormat from '../../src/plugin/advancedFormat'
 import localizedFormats from '../../src/plugin/localizedFormat'
 import weekOfYear from '../../src/plugin/weekOfYear'
+import utc from '../../src/plugin/utc'
 
 dayjs.extend(customParseFormat)
 dayjs.extend(localizedFormats)
 dayjs.extend(weekOfYear) // test parse w, ww
+dayjs.extend(utc)
 
 beforeEach(() => {
   MockDate.set(new Date())
@@ -331,6 +333,18 @@ describe('Array format support', () => {
     const input = '2018 三月 12'
     const format = ['YYYY', 'MM', 'YYYY MMMM DD']
     expect(dayjs(input, format, 'zh-cn', true).format('YYYY MMMM DD')).toBe(input)
+  })
+  it('keeps UTC mode with dayjs.utc (issue #3013)', () => {
+    const input = '1995-05-01'
+    const format = ['YYYY-MM-DD', 'YYYY-M-D']
+    // the array path must parse in UTC, exactly like the single-format path;
+    // without the fix it falls back to the local-time constructor, so the
+    // instant is shifted by the host offset (observable off-UTC, e.g. the
+    // Europe/London / Pacific/Auckland / America/Whitehorse CI runs).
+    expect(dayjs.utc(input, format).isUTC()).toBe(true)
+    expect(dayjs.utc(input, format).toISOString()).toBe('1995-05-01T00:00:00.000Z')
+    expect(dayjs.utc(input, format).toISOString())
+      .toBe(dayjs.utc(input, 'YYYY-MM-DD').toISOString())
   })
 })
 


### PR DESCRIPTION
Closes #3013

`dayjs.utc(date, [formats])` silently parsed in **local** time instead of UTC.

```js
dayjs.extend(utc); dayjs.extend(customParseFormat)

dayjs.utc('1995-05-01', 'YYYY-MM-DD').toISOString()
// '1995-05-01T00:00:00.000Z'  ✅

dayjs.utc('1995-05-01', ['YYYY-MM-DD', 'YYYY-M-D']).toISOString()
// '1995-04-30T23:00:00.000Z'  ❌ (in UTC+1) — local midnight
```

**Cause:** the array branch in `proto.parse` always used the default constructor (`d.apply`), ignoring the requested `utc` mode. The single-format branch already threads `utc` correctly.

**Fix:** use the UTC constructor (`d.utc`) for each candidate format when utc mode is requested, so the array path matches the single-format path. The non-utc path is unchanged.

Added a regression test under `Array format support` (fails without the fix in the off-UTC CI runs).