### PR TITLE
fix(utc): handle short UTC offset format without minutes

### DIFF
--- a/src/plugin/utc/index.js
+++ b/src/plugin/utc/index.js
@@ -11,7 +11,7 @@ function offsetFromString(value = '') {
   }
 
   const [indicator, hoursOffset, minutesOffset] = `${offset[0]}`.match(REGEX_OFFSET_HOURS_MINUTES_FORMAT) || ['-', 0, 0]
-  const totalOffsetInMinutes = (+hoursOffset * 60) + (+minutesOffset)
+  const totalOffsetInMinutes = (+hoursOffset * 60) + (+(minutesOffset || 0))
 
   if (totalOffsetInMinutes === 0) {
     return 0


### PR DESCRIPTION
## Summary

`utcOffset('+08')` and `utcOffset('-05')` return `NaN` instead of the correct offset in minutes.

The validation regex `REGEX_VALID_OFFSET_FORMAT` correctly accepts short offsets like `+08` (minutes are optional via `(?::?\d\d)?`), but the parsing regex `REGEX_OFFSET_HOURS_MINUTES_FORMAT` only captures `['+', '08']` — `minutesOffset` is `undefined`, causing `(+8 * 60) + (+undefined)` = `NaN`.

## Reproduction

```js
dayjs().utcOffset('+08')    // broken: internal offset becomes NaN
dayjs().utcOffset('+08:00') // works: 480
dayjs().utcOffset('-05')    // broken: NaN
dayjs().utcOffset('-05:00') // works: -300
```

## Fix

Default `minutesOffset` to `0` when no minutes group is captured:

```diff
- const totalOffsetInMinutes = (+hoursOffset * 60) + (+minutesOffset)
+ const totalOffsetInMinutes = (+hoursOffset * 60) + (+(minutesOffset || 0))
```