### PR TITLE
fix(locale): use correct English ordinal in en-ca, en-ie, en-il, en-sg

### DIFF
--- a/src/locale/en-ca.js
+++ b/src/locale/en-ca.js
@@ -8,7 +8,11 @@ const locale = {
   weekdaysShort: 'Sun_Mon_Tue_Wed_Thu_Fri_Sat'.split('_'),
   monthsShort: 'Jan_Feb_Mar_Apr_May_Jun_Jul_Aug_Sep_Oct_Nov_Dec'.split('_'),
   weekdaysMin: 'Su_Mo_Tu_We_Th_Fr_Sa'.split('_'),
-  ordinal: n => n,
+  ordinal: (n) => {
+    const s = ['th', 'st', 'nd', 'rd']
+    const v = n % 100
+    return `[${n}${(s[(v - 20) % 10] || s[v] || s[0])}]`
+  },
   formats: {
     LT: 'h:mm A',
     LTS: 'h:mm:ss A',

--- a/src/locale/en-ie.js
+++ b/src/locale/en-ie.js
@@ -9,7 +9,11 @@ const locale = {
   weekdaysShort: 'Sun_Mon_Tue_Wed_Thu_Fri_Sat'.split('_'),
   monthsShort: 'Jan_Feb_Mar_Apr_May_Jun_Jul_Aug_Sep_Oct_Nov_Dec'.split('_'),
   weekdaysMin: 'Su_Mo_Tu_We_Th_Fr_Sa'.split('_'),
-  ordinal: n => n,
+  ordinal: (n) => {
+    const s = ['th', 'st', 'nd', 'rd']
+    const v = n % 100
+    return `[${n}${(s[(v - 20) % 10] || s[v] || s[0])}]`
+  },
   formats: {
     LT: 'HH:mm',
     LTS: 'HH:mm:ss',

--- a/src/locale/en-il.js
+++ b/src/locale/en-il.js
@@ -8,7 +8,11 @@ const locale = {
   weekdaysShort: 'Sun_Mon_Tue_Wed_Thu_Fri_Sat'.split('_'),
   monthsShort: 'Jan_Feb_Mar_Apr_May_Jun_Jul_Aug_Sep_Oct_Nov_Dec'.split('_'),
   weekdaysMin: 'Su_Mo_Tu_We_Th_Fr_Sa'.split('_'),
-  ordinal: n => n,
+  ordinal: (n) => {
+    const s = ['th', 'st', 'nd', 'rd']
+    const v = n % 100
+    return `[${n}${(s[(v - 20) % 10] || s[v] || s[0])}]`
+  },
   formats: {
     LT: 'HH:mm',
     LTS: 'HH:mm:ss',

--- a/src/locale/en-sg.js
+++ b/src/locale/en-sg.js
@@ -9,7 +9,11 @@ const locale = {
   weekdaysShort: 'Sun_Mon_Tue_Wed_Thu_Fri_Sat'.split('_'),
   monthsShort: 'Jan_Feb_Mar_Apr_May_Jun_Jul_Aug_Sep_Oct_Nov_Dec'.split('_'),
   weekdaysMin: 'Su_Mo_Tu_We_Th_Fr_Sa'.split('_'),
-  ordinal: n => n,
+  ordinal: (n) => {
+    const s = ['th', 'st', 'nd', 'rd']
+    const v = n % 100
+    return `[${n}${(s[(v - 20) % 10] || s[v] || s[0])}]`
+  },
   formats: {
     LT: 'HH:mm',
     LTS: 'HH:mm:ss',

--- a/test/locale/en.test.js
+++ b/test/locale/en.test.js
@@ -1,11 +1,18 @@
+import moment from 'moment'
 import dayjs from '../../src'
 import '../../src/locale/en'
 import '../../src/locale/en-gb'
 import '../../src/locale/en-in'
 import '../../src/locale/en-tt'
+import '../../src/locale/en-ca'
+import '../../src/locale/en-ie'
+import '../../src/locale/en-il'
+import '../../src/locale/en-sg'
 import localizedFormat from '../../src/plugin/localizedFormat'
+import advancedFormat from '../../src/plugin/advancedFormat'
 
 dayjs.extend(localizedFormat)
+dayjs.extend(advancedFormat)
 
 const locales = [
   { locale: 'en', expectedDate: '12/25/2019' },
@@ -19,6 +26,19 @@ describe('English date formats', () => {
     it(`should correctly format date with locale - ${locale.locale}`, () => {
       const dayjsWithLocale = dayjs('2019-12-25').locale(locale.locale)
       expect(dayjsWithLocale.format('L')).toEqual(locale.expectedDate)
+    })
+  })
+})
+
+describe('English ordinal (Do) parity with moment', () => {
+  const ordinalLocales = ['en-ca', 'en-ie', 'en-il', 'en-sg']
+  ordinalLocales.forEach((locale) => {
+    it(`should format the ordinal day of month like moment - ${locale}`, () => {
+      for (let d = 1; d <= 31; d += 1) {
+        const date = `2021-01-${String(d).padStart(2, '0')}`
+        expect(dayjs(date).locale(locale).format('Do'))
+          .toEqual(moment(date).locale(locale).format('Do'))
+      }
     })
   })
 })


### PR DESCRIPTION
### What

`en-ca`, `en-ie`, `en-il` and `en-sg` still carry the placeholder `ordinal: n => n`, so `format('Do')` returns the bare day number for them:

```js
dayjs('2021-01-21').locale('en-au').format('Do') // "21st"
dayjs('2021-01-21').locale('en-ca').format('Do') // "21"  (expected "21st")
```

(`Do` comes from the `advancedFormat` plugin.)

The other English locales already define the standard English ordinal function: `en`, `en-au`, `en-gb`, `en-in`, `en-nz`, `en-tt`. English ordinals (1st/2nd/3rd, 11th/21st) are the same across these regions, so the four locales above were simply missing the function rather than intentionally different. This is the same change #2878 made for `en-au` ("Use the same ordinal as moment"); moment also defines the full ordinal for `en-ca`, `en-ie`, `en-il` and `en-sg`.

### Fix

Reuse the existing English ordinal function in the four locales.

### Test

Added an ordinal parity check in `test/locale/en.test.js` that compares `format('Do')` against moment for days 1 to 31 in each of the four locales. It fails on the old `n => n` and passes with the change. The full `jest` suite is green and `eslint` passes.
