### PR TITLE
feat(DayOfYear): add DDD and DDDD day-of-year format tokens

### DIFF
--- a/src/plugin/dayOfYear/index.js
+++ b/src/plugin/dayOfYear/index.js
@@ -1,8 +1,30 @@
+import { FORMAT_DEFAULT } from '../../constant'
+
 export default (o, c, d) => {
   const proto = c.prototype
   proto.dayOfYear = function (input) {
     // d(this) is for badMutable
     const dayOfYear = Math.round((d(this).startOf('day') - d(this).startOf('year')) / 864e5) + 1
     return input == null ? dayOfYear : this.add(input - dayOfYear, 'day')
+  }
+
+  const oldFormat = proto.format
+  proto.format = function (formatStr) {
+    if (!this.isValid()) {
+      return oldFormat.bind(this)(formatStr)
+    }
+    const utils = this.$utils()
+    const str = formatStr || FORMAT_DEFAULT
+    const result = str.replace(/\[([^\]]+)]|DDDD|DDD/g, (match) => {
+      switch (match) {
+        case 'DDD':
+          return this.dayOfYear()
+        case 'DDDD':
+          return utils.s(this.dayOfYear(), 3, '0')
+        default: // escaped text such as [DDD] is passed through untouched
+          return match
+      }
+    })
+    return oldFormat.bind(this)(result)
   }
 }

--- a/test/plugin/dayOfYear.test.js
+++ b/test/plugin/dayOfYear.test.js
@@ -48,3 +48,29 @@ it('DayOfYear set', () => {
     .dayOfYear(365)
     .toISOString()).toBe('2015-12-31T00:00:00.000Z')
 })
+
+it('DayOfYear format DDD / DDDD matches moment', () => {
+  const dates = ['2015-01-01', '2015-02-01', '2015-12-31',
+    '2020-02-29', '2020-12-31', '2021-07-15']
+  dates.forEach((s) => {
+    expect(dayjs(s).format('DDD')).toBe(moment(s).format('DDD'))
+    expect(dayjs(s).format('DDDD')).toBe(moment(s).format('DDDD'))
+  })
+})
+
+it('DayOfYear format DDD / DDDD explicit output', () => {
+  // DDD is un-padded, DDDD is zero-padded to 3 digits
+  expect(dayjs('2015-01-01').format('DDD')).toBe('1')
+  expect(dayjs('2015-01-01').format('DDDD')).toBe('001')
+  expect(dayjs('2015-02-01').format('DDD')).toBe('32')
+  expect(dayjs('2015-02-01').format('DDDD')).toBe('032')
+  // leap year: Dec 31 is day 366
+  expect(dayjs('2020-12-31').format('DDD')).toBe('366')
+  expect(dayjs('2020-12-31').format('DDDD')).toBe('366')
+  // mixes with other tokens and preserves escaped literals
+  expect(dayjs('2015-02-01').format('[DDD] DDDD-DD')).toBe('DDD 032-01')
+  // default format (no argument) is unaffected by the plugin
+  expect(dayjs('2015-06-15').format()).toBe(dayjs('2015-06-15').format('YYYY-MM-DDTHH:mm:ssZ'))
+  // invalid dates fall through unchanged
+  expect(dayjs('not a date').format('DDD')).toBe('Invalid Date')
+})


### PR DESCRIPTION
## Description

The `dayOfYear` plugin exposes `.dayOfYear()` but not the corresponding **format tokens**, so `DDD` / `DDDD` were never handled. They fell through to the core `DD` + `D` tokens and produced incorrect output:

```js
dayjs.extend(dayOfYear)

dayjs('2021-01-01').format('DDD')   // was "011"  -> now "1"
dayjs('2021-01-01').format('DDDD')  // was "0101" -> now "001"
dayjs('2020-12-31').format('DDD')   // was "3131" -> now "366"
```

Moment.js supports these tokens (`DDD` = day of year, `DDDD` = day of year padded to 3 digits), so this brings dayjs to parity.

Closes #2767

## Change

`DDD` and `DDDD` are added to the `dayOfYear` plugin's `format` override (the plugin already owns the day-of-year computation). The override only consumes these two tokens and delegates everything else to the existing formatter, so:

- escaped literals such as `[DDD]` are preserved,
- invalid dates are unchanged,
- plugin load order (e.g. together with `advancedFormat`) does not matter.

## Tests

Added tests in `test/plugin/dayOfYear.test.js`:

- parity with Moment.js for `DDD` / `DDDD` across the year, including a leap year,
- explicit expected output (padding, leap-year day 366),
- escaping (`[DDD] DDDD-DD`) and invalid-date handling.

Verified locally:

- `jest test/plugin/dayOfYear.test.js` — plugin at 100% statements/branches/functions/lines,
- full suite: **775 passed / 93 suites**, global line coverage still 100%,
- `eslint src/plugin/dayOfYear/index.js test/plugin/dayOfYear.test.js` — clean.

Happy to also add a note to the docs site if you'd like.
