### PR TITLE
fix(customParseFormat): match MMM/MMMM against locale month names

### DIFF
--- a/src/plugin/customParseFormat/index.js
+++ b/src/plugin/customParseFormat/index.js
@@ -43,6 +43,23 @@ const getLocalePart = (name) => {
     part.indexOf ? part : part.s.concat(part.f)
   )
 }
+const escapeRegExp = str => str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+// Build a regex that matches the actual month names of the active locale.
+// Using the concrete names (longest first) prevents a generic "word" match
+// from greedily swallowing a following separator such as `.` (issue #2818),
+// while still supporting locales whose month names contain a `.` (e.g. gl).
+const matchMonthName = (token) => {
+  const months = getLocalePart('months')
+  const monthsShort = getLocalePart('monthsShort')
+  const names = token === 'MMMM'
+    ? months
+    : (monthsShort || months.map(m => m.slice(0, 3)))
+  return new RegExp(names
+    .slice()
+    .sort((a, b) => b.length - a.length)
+    .map(escapeRegExp)
+    .join('|'))
+}
 const meridiemMatch = (input, isLowerCase) => {
   let isAfternoon
   const { meridiem } = locale
@@ -153,7 +170,10 @@ function makeParser(format) {
     const regex = parseTo && parseTo[0]
     const parser = parseTo && parseTo[1]
     if (parser) {
-      array[i] = { regex, parser }
+      array[i] = {
+        regex: (token === 'MMM' || token === 'MMMM') ? matchMonthName(token) : regex,
+        parser
+      }
     } else {
       array[i] = token.replace(/^\[|\]$/g, '')
     }

--- a/test/plugin/customParseFormat.test.js
+++ b/test/plugin/customParseFormat.test.js
@@ -4,6 +4,7 @@ import dayjs from '../../src'
 import '../../src/locale/ru'
 import uk from '../../src/locale/uk'
 import '../../src/locale/zh-cn'
+import '../../src/locale/gl'
 import customParseFormat from '../../src/plugin/customParseFormat'
 import advancedFormat from '../../src/plugin/advancedFormat'
 import localizedFormats from '../../src/plugin/localizedFormat'
@@ -424,6 +425,39 @@ describe('parse with special separator characters', () => {
     expect(resultDayjs.isValid()).toBe(true)
     expect(resultDayjs.format('DD-MM-YYYY')).toBe('20-11-2022')
     expect(resultMoment.format('DD-MM-YYYY')).toBe('20-11-2022')
+  })
+  // issue 2818 - dot separator swallowed the following month-name token
+  it('parse MMM month name with dot separator', () => {
+    const input = '29.Jul.2021'
+    const format = 'DD.MMM.YYYY'
+    const resultDayjs = dayjs(input, format)
+    const resultMoment = moment(input, format)
+    expect(resultDayjs.isValid()).toBe(true)
+    expect(resultDayjs.valueOf()).toBe(resultMoment.valueOf())
+    expect(resultDayjs.format('YYYY-MM-DD')).toBe('2021-07-29')
+  })
+  it('parse MMMM month name with dot separator', () => {
+    const input = '29.July.2021'
+    const format = 'DD.MMMM.YYYY'
+    const resultDayjs = dayjs(input, format)
+    const resultMoment = moment(input, format)
+    expect(resultDayjs.isValid()).toBe(true)
+    expect(resultDayjs.valueOf()).toBe(resultMoment.valueOf())
+    expect(resultDayjs.format('YYYY-MM-DD')).toBe('2021-07-29')
+  })
+  it('parse locale short month that itself contains a dot (gl) with dot separator', () => {
+    const input = '29.xan..2021' // gl monthsShort for January is "xan."
+    const format = 'DD.MMM.YYYY'
+    const resultDayjs = dayjs(input, format, 'gl')
+    expect(resultDayjs.isValid()).toBe(true)
+    expect(resultDayjs.format('YYYY-MM-DD')).toBe('2021-01-29')
+  })
+  it('parse locale short month that itself contains a dot (gl) with space separator', () => {
+    const input = '29 xan. 2021'
+    const format = 'DD MMM YYYY'
+    const resultDayjs = dayjs(input, format, 'gl')
+    expect(resultDayjs.isValid()).toBe(true)
+    expect(resultDayjs.format('YYYY-MM-DD')).toBe('2021-01-29')
   })
 })
 


### PR DESCRIPTION
## Problem

When parsing with `customParseFormat`, the generic "word" regex used for the `MMM`/`MMMM` month-name tokens excludes the `-_:/,()` separators and whitespace, but not `.`. As a result, an input like `dayjs('29.Jul.2021', 'DD.MMM.YYYY')` caused the month token to greedily capture `Jul.` (swallowing the trailing separator dot), which matches no month name and produced an `Invalid Date`. This is a regression from older versions and a divergence from moment, which parses the same input correctly.

## Fix

Rather than naively adding `.` to the exclusion list (which would break locales whose short month names legitimately contain a dot, e.g. `gl`'s `xan.`), `MMM`/`MMMM` now match against the actual locale month names, sorted longest-first. Because the captured value is now exactly one of the real month names, it can no longer swallow a trailing separator, while dotted month names continue to parse correctly.

Changes in `src/plugin/customParseFormat/index.js`:
- Added an `escapeRegExp` helper.
- Added `matchMonthName(token)` which builds a regex from the active locale's `months` (for `MMMM`) or `monthsShort` (for `MMM`, falling back to the first 3 chars of `months`), escaped and joined longest-first.
- The parser now uses this month-name regex for the `MMM`/`MMMM` tokens instead of the generic word regex.

## Testing

Added tests in `test/plugin/customParseFormat.test.js`:
- `29.Jul.2021` with `DD.MMM.YYYY` parses to `2021-07-29` and matches moment.
- `29.July.2021` with `DD.MMMM.YYYY` parses to `2021-07-29` and matches moment.
- `gl` locale short month containing a dot (`xan.`) parses correctly with both dot and space separators (`29.xan..2021` / `29 xan. 2021` → `2021-01-29`).

Closes #2818
