### PR TITLE
fix(locale): use colon time separators for ms, ms-my, and jv

### DIFF
--- a/src/locale/jv.js
+++ b/src/locale/jv.js
@@ -11,12 +11,12 @@ const locale = {
   weekdaysMin: 'Mg_Sn_Sl_Rb_Km_Jm_Sp'.split('_'),
   ordinal: n => n,
   formats: {
-    LT: 'HH.mm',
-    LTS: 'HH.mm.ss',
+    LT: 'HH:mm',
+    LTS: 'HH:mm:ss',
     L: 'DD/MM/YYYY',
     LL: 'D MMMM YYYY',
-    LLL: 'D MMMM YYYY [pukul] HH.mm',
-    LLLL: 'dddd, D MMMM YYYY [pukul] HH.mm'
+    LLL: 'D MMMM YYYY [pukul] HH:mm',
+    LLLL: 'dddd, D MMMM YYYY [pukul] HH:mm'
   },
   relativeTime: {
     future: 'wonten ing %s',

--- a/src/locale/ms-my.js
+++ b/src/locale/ms-my.js
@@ -11,12 +11,12 @@ const locale = {
   weekdaysMin: 'Ah_Is_Sl_Rb_Km_Jm_Sb'.split('_'),
   ordinal: n => n,
   formats: {
-    LT: 'HH.mm',
-    LTS: 'HH.mm.ss',
+    LT: 'HH:mm',
+    LTS: 'HH:mm:ss',
     L: 'DD/MM/YYYY',
     LL: 'D MMMM YYYY',
-    LLL: 'D MMMM YYYY [pukul] HH.mm',
-    LLLL: 'dddd, D MMMM YYYY [pukul] HH.mm'
+    LLL: 'D MMMM YYYY [pukul] HH:mm',
+    LLLL: 'dddd, D MMMM YYYY [pukul] HH:mm'
   },
   relativeTime: {
     future: 'dalam %s',

--- a/src/locale/ms.js
+++ b/src/locale/ms.js
@@ -10,12 +10,12 @@ const locale = {
   monthsShort: 'Jan_Feb_Mac_Apr_Mei_Jun_Jul_Ogs_Sep_Okt_Nov_Dis'.split('_'),
   weekStart: 1,
   formats: {
-    LT: 'HH.mm',
-    LTS: 'HH.mm.ss',
+    LT: 'HH:mm',
+    LTS: 'HH:mm:ss',
     L: 'DD/MM/YYYY',
     LL: 'D MMMM YYYY',
-    LLL: 'D MMMM YYYY HH.mm',
-    LLLL: 'dddd, D MMMM YYYY HH.mm'
+    LLL: 'D MMMM YYYY HH:mm',
+    LLLL: 'dddd, D MMMM YYYY HH:mm'
   },
   relativeTime: {
     future: 'dalam %s',


### PR DESCRIPTION
## Summary
- `ms`, `ms-my`, and `jv` locales used `HH.mm` time formats.
- `Intl.DateTimeFormat` for these locales uses colon separators (`12:34:56`).
- Update `LT`/`LTS`/`LLL`/`LLLL` to `HH:mm` / `HH:mm:ss`.

Note: `sv-fi` correctly keeps dots (Finland Swedish / Finnish convention per Intl).

Fixes #3139
Fixes #3141

## Test plan
- [x] Locale format strings updated to match Intl for the affected locales