### PR TITLE
fix(locale): use colon time separator in sv-fi

### DIFF
--- a/src/locale/sv-fi.js
+++ b/src/locale/sv-fi.js
@@ -16,16 +16,16 @@ const locale = {
     return `[${n}${o}]`
   },
   formats: {
-    LT: 'HH.mm',
-    LTS: 'HH.mm.ss',
+    LT: 'HH:mm',
+    LTS: 'HH:mm:ss',
     L: 'DD.MM.YYYY',
     LL: 'D. MMMM YYYY',
-    LLL: 'D. MMMM YYYY, [kl.] HH.mm',
-    LLLL: 'dddd, D. MMMM YYYY, [kl.] HH.mm',
+    LLL: 'D. MMMM YYYY, [kl.] HH:mm',
+    LLLL: 'dddd, D. MMMM YYYY, [kl.] HH:mm',
     l: 'D.M.YYYY',
     ll: 'D. MMM YYYY',
-    lll: 'D. MMM YYYY, [kl.] HH.mm',
-    llll: 'ddd, D. MMM YYYY, [kl.] HH.mm'
+    lll: 'D. MMM YYYY, [kl.] HH:mm',
+    llll: 'ddd, D. MMM YYYY, [kl.] HH:mm'
   },
   relativeTime: {
     future: 'om %s',

--- a/test/locale/sv-fi.test.js
+++ b/test/locale/sv-fi.test.js
@@ -7,9 +7,9 @@ dayjs.extend(localizedFormat)
 it('Finland Swedish locale', () => {
   // time
   expect(dayjs('2019-02-01 12:34:56').locale('sv-fi').format('LT'))
-    .toBe('12.34')
+    .toBe('12:34')
   expect(dayjs('2019-02-01 23:45:56').locale('sv-fi').format('LTS'))
-    .toBe('23.45.56')
+    .toBe('23:45:56')
 
   // date
   expect(dayjs('2019-02-01').locale('sv-fi').format('L'))
@@ -24,12 +24,12 @@ it('Finland Swedish locale', () => {
 
   // date and time
   expect(dayjs('2019-03-01 12:30').locale('sv-fi').format('LLL'))
-    .toBe('1. mars 2019, kl. 12.30')
+    .toBe('1. mars 2019, kl. 12:30')
   expect(dayjs('2021-06-12 17:30').locale('sv-fi').format('LLLL'))
-    .toBe('lördag, 12. juni 2021, kl. 17.30')
+    .toBe('lördag, 12. juni 2021, kl. 17:30')
   // short
   expect(dayjs('2019-03-01 12:30').locale('sv-fi').format('lll'))
-    .toBe('1. mar 2019, kl. 12.30')
+    .toBe('1. mar 2019, kl. 12:30')
   expect(dayjs('2021-06-01 17:30').locale('sv-fi').format('llll'))
-    .toBe('tis, 1. jun 2021, kl. 17.30')
+    .toBe('tis, 1. jun 2021, kl. 17:30')
 })


### PR DESCRIPTION
## Summary
- Change Finland Swedish (`sv-fi`) time formats from dot separators (`12.34`) to colons (`12:34`) in LT, LTS, and datetime formats
- Update locale tests to match the corrected output

Fixes #3142

## Test plan
- [x] Updated `test/locale/sv-fi.test.js` expectations
- [ ] `npm test -- test/locale/sv-fi.test.js` (not run locally due to disk constraints)