### PR TITLE
fix: parse fractional seconds shorter than 3 digits as a decimal fraction

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -69,7 +69,7 @@ const parseDate = (cfg) => {
     const d = date.match(C.REGEX_PARSE)
     if (d) {
       const m = d[2] - 1 || 0
-      const ms = (d[7] || '0').substring(0, 3)
+      const ms = `${d[7] || '0'}00`.substring(0, 3) // '.5' is 500ms: pad before truncating
       if (utc) {
         return new Date(Date.UTC(d[1], m, d[3]
           || 1, d[4] || 0, d[5] || 0, d[6] || 0, ms))

--- a/test/parse.test.js
+++ b/test/parse.test.js
@@ -89,6 +89,16 @@ describe('Parse', () => {
     expect(ds.millisecond()).toEqual(ms.millisecond())
   })
 
+  it('parses millisecond with fewer than 3 digits as a decimal fraction', () => {
+    const dates = ['2019-03-25T06:41:00.5', '2019-03-25T06:41:00.05', '2019-03-25T06:41:00.005']
+    dates.forEach((date) => {
+      const ds = dayjs(date)
+      const ms = moment(date)
+      expect(ds.valueOf()).toEqual(ms.valueOf())
+      expect(ds.millisecond()).toEqual(ms.millisecond())
+    })
+  })
+
   it('String Other, Undefined and Null and isValid', () => {
     global.console.warn = jest.genMockFunction()// moment.js otherString will throw warn
     expect(dayjs('otherString').toString().toLowerCase()).toBe(moment('otherString').toString().toLowerCase())


### PR DESCRIPTION
`REGEX_PARSE` captures fractional seconds as bare digits and `parseDate`
truncates them with `substring(0, 3)` without right-padding, so a fraction
shorter than three digits is read as an integer count of milliseconds:

```js
dayjs('2019-03-25T06:41:00.5').millisecond()  // 5  - moment and new Date() give 500
dayjs('2019-03-25T06:41:00.05').millisecond() // 5  - moment and new Date() give 50
```

ISO 8601 fractional seconds are a decimal fraction. Strings with a trailing
`Z` already take the native `Date` path and are unaffected; only the regex
path is hit.

Fix: right-pad the capture to three digits before truncating. Fractions of
three or more digits are unchanged (`.999999999` still parses as `999`), and
the no-fraction path still yields `0`.

Test: one new case in `test/parse.test.js` beside the existing
`parses unlimited millisecond` test, comparing `valueOf()` and
`millisecond()` against moment for 1-, 2-, and 3-digit fractions. Without
the fix it fails (1 failed, 26 passed in the file); with it the file is 27
passed and the full suite is 774 passed across 93 suites, line coverage
unchanged at 100%.
