### PR TITLE
feat: Add Pashto (ps) locale

### DIFF
--- a/src/locale/ps.js
+++ b/src/locale/ps.js
@@ -1,0 +1,39 @@
+// Pashto [ps]
+import dayjs from 'dayjs'
+
+const locale = {
+  name: 'ps',
+  weekdays: 'يونۍ_دونۍ_درېنۍ_څلرنۍ_پينځنۍ_جمعه_اونۍ'.split('_'),
+  weekdaysShort: 'يونۍ_دونۍ_درېنۍ_څلرنۍ_پينځنۍ_جمعه_اونۍ'.split('_'),
+  weekStart: 6,
+  months: 'جنوري_فبروري_مارچ_اپریل_مۍ_جون_جولای_اګست_سېپتمبر_اکتوبر_نومبر_دسمبر'.split('_'),
+  monthsShort: 'جنوري_فبروري_مارچ_اپریل_مۍ_جون_جولای_اګست_سېپتمبر_اکتوبر_نومبر_دسمبر'.split('_'),
+  ordinal: n => n,
+  formats: {
+    LT: 'HH:mm',
+    LTS: 'HH:mm:ss',
+    L: 'DD/MM/YYYY',
+    LL: 'D MMMM YYYY',
+    LLL: 'D MMMM YYYY HH:mm',
+    LLLL: 'dddd، D MMMM YYYY HH:mm'
+  },
+  relativeTime: {
+    future: 'په %s کې',
+    past: '%s مخکې',
+    s: 'څو ثانيې',
+    m: 'يوه دقيقه',
+    mm: '%d دقيقې',
+    h: 'يو ساعت',
+    hh: '%d ساعتونه',
+    d: 'يوه ورځ',
+    dd: '%d ورځې',
+    M: 'يوه مياشت',
+    MM: '%d مياشتې',
+    y: 'يو کال',
+    yy: '%d کاله'
+  }
+}
+
+dayjs.locale(locale, null, true)
+
+export default locale


### PR DESCRIPTION
Closes #171 (partially - adds one more requested locale)

## What does this PR do?
Adds the Pashto (`ps`) locale to Day.js, following the same structure 
as `fa.js`, `ur.js`, and `af.js`.

Pashto is spoken by 40-60 million people and is one of the two 
official languages of Afghanistan (alongside Dari/Persian), but was 
not yet supported.

## Data sources
Day/month names, week start (Saturday, matching Afghanistan 
convention), and relative time patterns were sourced directly from 
the Unicode CLDR dataset (`cldr-json/cldr-dates-full/main/ps/`) 
rather than transliterated from memory, to ensure accuracy.

## Notes for reviewers
- `weekdaysMin` was intentionally omitted, following the same pattern 
  as `fa`/`ur` - Day.js falls back to the first 2 characters of the 
  full weekday name when absent, which works correctly here.
- `ordinal` returns the number as-is (no suffix), matching the 
  precedent set by `fa.js`/`ur.js` for Perso-Arabic script locales.
- CLDR's weekday forms are numeral-based coinages. If maintainers or 
  native speakers prefer the more commonly-used Persian-loanword 
  forms instead, happy to update based on feedback.

## Checklist
- [x] Follows existing locale file structure/conventions
- [x] Sourced from authoritative CLDR data
- [x] No existing tests broken (Day.js has no central locale registry 
      requiring updates)