### PR TITLE
fix(build): sort locale metadata deterministically

### DIFF
--- a/build/index.js
+++ b/build/index.js
@@ -30,7 +30,11 @@ async function listLocaleJson(localeArr) {
       name: localeData.match(localeNameRegex)[1]
     })
   }))
-  promisifyWriteFile(path.join(__dirname, '../locale.json'), JSON.stringify(localeListArr), 'utf8')
+  await promisifyWriteFile(
+    path.join(__dirname, '../locale.json'),
+    JSON.stringify(localeListArr.sort((a, b) => (a.key > b.key) - (a.key < b.key))),
+    'utf8'
+  )
 }
 
 (async () => {


### PR DESCRIPTION
Fixes #3163

Sort locale metadata by locale key before writing `locale.json`.

This makes the generated locale list independent of filesystem enumeration order and keeps build output reproducible.

Validation:
- `npm run lint`
- `NODE_OPTIONS=--openssl-legacy-provider npm run build`
- 92 test suites passed
- 766 tests passed