### PR TITLE
fix: duration humanize ignores leap years (fixed-unit decomposition)

### DIFF
--- a/src/plugin/duration/index.js
+++ b/src/plugin/duration/index.js
@@ -230,10 +230,62 @@ class Duration {
   }
 
   humanize(withSuffix) {
-    return $d()
-      .add(this.$ms, 'ms')
-      .locale(this.$l)
-      .fromNow(!withSuffix)
+    const loc = $d().locale(this.$l).$locale().relativeTime || {
+      future: 'in %s',
+      past: '%s ago',
+      s: 'a few seconds',
+      m: 'a minute',
+      mm: '%d minutes',
+      h: 'an hour',
+      hh: '%d hours',
+      d: 'a day',
+      dd: '%d days',
+      M: 'a month',
+      MM: '%d months',
+      y: 'a year',
+      yy: '%d years'
+    }
+    // 与 relativeTime 相同的阈值链，但按固定单位（365 天/年）分解 $ms，
+    // 避免日历 diff 引入闰年偏差（见 issue #3170）
+    const thresholds = [
+      { l: 's', r: 44, d: 'second' },
+      { l: 'm', r: 89 },
+      { l: 'mm', r: 44, d: 'minute' },
+      { l: 'h', r: 89 },
+      { l: 'hh', r: 21, d: 'hour' },
+      { l: 'd', r: 35 },
+      { l: 'dd', r: 25, d: 'day' },
+      { l: 'M', r: 45 },
+      { l: 'MM', r: 10, d: 'month' },
+      { l: 'y', r: 17 },
+      { l: 'yy', d: 'year' }
+    ]
+    let result
+    let out
+    let isFuture
+
+    for (let i = 0; i < thresholds.length; i += 1) {
+      let t = thresholds[i]
+      if (t.d) {
+        result = this.$ms / unitToMS[`${t.d}s`]
+      }
+      const abs = Math.round(Math.abs(result))
+      isFuture = result > 0
+      if (abs <= t.r || !t.r) {
+        if (abs <= 1 && i > 0) t = thresholds[i - 1]
+        const format = loc[t.l]
+        if (typeof format === 'string') {
+          out = format.replace('%d', abs)
+        } else {
+          out = format(abs, !withSuffix, t.l, isFuture)
+        }
+        break
+      }
+    }
+    if (!withSuffix) return out
+    const pastOrFuture = isFuture ? loc.future : loc.past
+    if (typeof pastOrFuture === 'function') return pastOrFuture(out)
+    return pastOrFuture.replace('%s', out)
   }
 
   valueOf() {

--- a/test/plugin/duration.test.js
+++ b/test/plugin/duration.test.js
@@ -133,6 +133,15 @@ describe('Humanize', () => {
     expect(dayjs.duration(-1, 'minutes').humanize(true)).toBe('a minute ago')
   })
 
+  it('Fixed unit decomposition (issue #3170)', () => {
+    // 闰年口径回归：humanize 与 asYears 一致（9999Y 不再因日历 diff 变 9992）
+    expect(dayjs.duration('P9999Y').humanize()).toBe('9999 years')
+    expect(dayjs.duration('P9999Y').humanize(true)).toBe('in 9999 years')
+    // 月量级由日历分数改为固定口径（与 moment 一致）
+    expect(dayjs.duration(18, 'months').humanize()).toBe('2 years')
+    expect(dayjs.duration(-18, 'months').humanize(true)).toBe('2 years ago')
+  })
+
   it('Locale', () => {
     expect(dayjs.duration(1, 'minutes').humanize(true)).toBe('in a minute')
     expect(dayjs.duration(1, 'minutes').locale('fr').humanize(true)).toBe('dans une minute')


### PR DESCRIPTION
## Summary
`humanize()` added the fixed-365-day `$ms` to a real calendar date and diffed it via `fromNow`, so durations computed with fixed units drifted with the calendar — `dayjs.duration('P9999Y').humanize()` rendered `'9992 years'`, and results varied with the current date (leap-year position).

## Fix
Decompose `$ms` into fixed units (`MILLISECONDS_A_YEAR` etc., the same basis as `asYears`) and format through the relativeTime locale templates, reproducing the threshold chain exactly (including the `'M'` no-d field and `abs<=1` fallback).

- `P9999Y` → `'9999 years'` (was `'9992 years'`)
- Month/year results are date-independent and match moment.js (`P18M` → `'2 years'`)
- Works without the relativeTime plugin (old implementation threw)

Fixes #3170