### PR TITLE
fix: incorrect time separator in ms/ms-my/jv/tzl locales

### DIFF
--- a/src/locale/jv.js
+++ b/src/locale/jv.js
@@ -11,12 +11,12 @@ const locale = {
   weekdaysMin: 'Mg_Sn_Sl_Rb_Km_Jm_Sp'.split('_'),
   ordinal: n => n,
   formats: {
-    LT: 'HH.mm',
-    LTS: 'HH.mm.ss',
+    LT: 'HH:mm',
+    LTS: 'HH:mm:ss',
     L: 'DD/MM/YYYY',
     LL: 'D MMMM YYYY',
-    LLL: 'D MMMM YYYY [pukul] HH.mm',
-    LLLL: 'dddd, D MMMM YYYY [pukul] HH.mm'
+    LLL: 'D MMMM YYYY [pukul] HH:mm',
+    LLLL: 'dddd, D MMMM YYYY [pukul] HH:mm'
   },
   relativeTime: {
     future: 'wonten ing %s',

--- a/src/locale/ms-my.js
+++ b/src/locale/ms-my.js
@@ -11,12 +11,12 @@ const locale = {
   weekdaysMin: 'Ah_Is_Sl_Rb_Km_Jm_Sb'.split('_'),
   ordinal: n => n,
   formats: {
-    LT: 'HH.mm',
-    LTS: 'HH.mm.ss',
+    LT: 'HH:mm',
+    LTS: 'HH:mm:ss',
     L: 'DD/MM/YYYY',
     LL: 'D MMMM YYYY',
-    LLL: 'D MMMM YYYY [pukul] HH.mm',
-    LLLL: 'dddd, D MMMM YYYY [pukul] HH.mm'
+    LLL: 'D MMMM YYYY [pukul] HH:mm',
+    LLLL: 'dddd, D MMMM YYYY [pukul] HH:mm'
   },
   relativeTime: {
     future: 'dalam %s',

--- a/src/locale/ms.js
+++ b/src/locale/ms.js
@@ -10,12 +10,12 @@ const locale = {
   monthsShort: 'Jan_Feb_Mac_Apr_Mei_Jun_Jul_Ogs_Sep_Okt_Nov_Dis'.split('_'),
   weekStart: 1,
   formats: {
-    LT: 'HH.mm',
-    LTS: 'HH.mm.ss',
+    LT: 'HH:mm',
+    LTS: 'HH:mm:ss',
     L: 'DD/MM/YYYY',
     LL: 'D MMMM YYYY',
-    LLL: 'D MMMM YYYY HH.mm',
-    LLLL: 'dddd, D MMMM YYYY HH.mm'
+    LLL: 'D MMMM YYYY HH:mm',
+    LLLL: 'dddd, D MMMM YYYY HH:mm'
   },
   relativeTime: {
     future: 'dalam %s',

--- a/src/locale/tzl.js
+++ b/src/locale/tzl.js
@@ -11,12 +11,12 @@ const locale = {
   weekdaysMin: 'Sú_Lú_Ma_Má_Xh_Vi_Sá'.split('_'),
   ordinal: n => n,
   formats: {
-    LT: 'HH.mm',
-    LTS: 'HH.mm.ss',
+    LT: 'HH:mm',
+    LTS: 'HH:mm:ss',
     L: 'DD.MM.YYYY',
     LL: 'D. MMMM [dallas] YYYY',
-    LLL: 'D. MMMM [dallas] YYYY HH.mm',
-    LLLL: 'dddd, [li] D. MMMM [dallas] YYYY HH.mm'
+    LLL: 'D. MMMM [dallas] YYYY HH:mm',
+    LLLL: 'dddd, [li] D. MMMM [dallas] YYYY HH:mm'
   }
 }
 


### PR DESCRIPTION
## Summary
The `formats` in `ms`, `ms-my`, `jv`, and `tzl` locales used '.' as the time separator (`'HH.mm'` / `'HH.mm.ss'`), producing `12.34` instead of `12:34` for `LT`/`LTS` (and `LLL`/`LLLL`).

## Fix
Replace `HH.mm` → `HH:mm` and `HH.mm.ss` → `HH:mm:ss` in the four locales' formats. Date dots (`DD.MM.YYYY`) and prefixes like `[pukul]`/`[dallas]` are preserved.

Fixes #3139, #3141, #3143