### PR TITLE
fix: keep calendar date when subtracting years across historical TZ change

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,8 +5,9 @@
   "main": "dayjs.min.js",
   "types": "index.d.ts",
   "scripts": {
-    "test": "cross-env TZ=Pacific/Auckland npm run test-tz && cross-env TZ=Europe/London npm run test-tz && cross-env TZ=America/Whitehorse npm run test-tz && npm run test-tz && jest --coverage --coverageThreshold=\"{ \\\"global\\\": { \\\"lines\\\": 100} }\"",
+    "test": "cross-env TZ=Pacific/Auckland npm run test-tz && cross-env TZ=Europe/London npm run test-tz && cross-env TZ=America/Whitehorse npm run test-tz && cross-env TZ=Asia/Kuala_Lumpur npm run test-tz-kl && npm run test-tz && jest --coverage --coverageThreshold=\"{ \\\"global\\\": { \\\"lines\\\": 100} }\"",
     "test-tz": "date && jest test/timezone.test --coverage=false",
+    "test-tz-kl": "date && jest test/plugin/timezone.test.js --coverage=false",
     "lint": "./node_modules/.bin/eslint src/* test/* build/*",
     "prettier": "prettier --write \"docs/**/*.md\"",
     "babel": "cross-env BABEL_ENV=build babel src --out-dir esm --copy-files && node build/esm",

--- a/src/index.js
+++ b/src/index.js
@@ -389,7 +389,9 @@ class Dayjs {
   }
 
   daysInMonth() {
-    return this.endOf(C.M).$D
+    // Calendar length; local endOf('month') 23:59:59.999 can land on the next
+    // day after historical midnight offset changes (e.g. Asia/Kuala_Lumpur 1981).
+    return new Date(Date.UTC(this.$y, this.$M + 1, 0)).getUTCDate()
   }
 
   $locale() { // get locale object

--- a/test/plugin/timezone.test.js
+++ b/test/plugin/timezone.test.js
@@ -352,3 +352,17 @@ describe('UTC timezone', () => {
     expect(dayjs2.format()).toBe(moment2.format())
   })
 })
+
+describe('Historical timezone offset change', () => {
+  // Also run this file with TZ=Asia/Kuala_Lumpur (see package.json test-tz-kl).
+  it('subtract(years) keeps the calendar date across Malaysia 1981 UTC+7:30 to UTC+8', () => {
+    const parsed = dayjs('20811225', 'YYYYMMDD')
+    const subtracted = parsed.subtract(100, 'years')
+    expect(subtracted.format('YYYY-MM-DD')).toBe('1981-12-25')
+    expect(subtracted.date()).toBe(25)
+
+    const fromTz = dayjs.tz('2081-12-25', 'Asia/Kuala_Lumpur').subtract(100, 'years')
+    expect(fromTz.format('YYYY-MM-DD')).toBe('1981-12-25')
+    expect(fromTz.date()).toBe(25)
+  })
+})


### PR DESCRIPTION
`subtract(100, 'years')` on `2081-12-25` in `Asia/Kuala_Lumpur` returned `1981-12-01` instead of `1981-12-25`.

Year/month `set` clamps the day with `daysInMonth()`, which used `endOf('month')`. That builds local `23:59:59.999`, and Malaysia’s 1981-12-31 midnight jump (`UTC+7:30` → `UTC+8`) moves that instant onto `1982-01-01`, so `daysInMonth()` becomes `1`.

`daysInMonth()` now uses the UTC calendar month length, which is independent of that local last-millisecond construction.

Fixes #3137