### PR TITLE
docs: use npm test in contributing guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,4 +21,4 @@ Our open source community strives to be nice, welcoming and professional. Instan
 
 * Feel free to create a new `test/*.test.js` file if none of the existing test files suits your test case.
 * Help us keep 100% test coverage :D.
-* You can use `npm run test` before submitting a pull request.
+* You can use `npm test` before submitting a pull request.


### PR DESCRIPTION
## Problem

The Tests section of `CONTRIBUTING.md` (line 24) tells contributors to run `npm run test` before submitting a pull request. The README "Contributing" section, however, links to the docs site instruction, which says `npm test`. Both commands are equivalent in npm, but the inconsistency between the repo guide and the docs site can confuse first-time contributors about which command the maintainers intend.

## Solution

Use `npm test` in `CONTRIBUTING.md`, matching the docs site instruction. Behavior is unchanged (`npm run test` and `npm test` run the same script); this is a pure consistency fix.

## Verification

The only change is the one documented command:

```
$ git diff
- * You can use `npm run test` before submitting a pull request.
+ * You can use `npm test` before submitting a pull request.
```

`npm test` invokes the same `test` script defined in `package.json` (timezone-sweep jest runs plus coverage-gated jest), so the guidance remains correct.
