### PR TITLE
D2M

### DIFF
--- a/src/plugin/timezone/index.js
+++ b/src/plugin/timezone/index.js
@@ -93,6 +93,7 @@ export default (o, c, d) => {
   const proto = c.prototype
 
   proto.tz = function (timezone = defaultTimezone, keepLocalTime) {
+    if (!this.isValid()) return this
     const oldOffset = this.utcOffset()
     const date = this.toDate()
     const target = date.toLocaleString('en-US', { timeZone: timezone })
@@ -140,6 +141,11 @@ export default (o, c, d) => {
       return d(input).tz(timezone)
     }
     const localTs = d.utc(input, parseFormat).valueOf()
+    if (Number.isNaN(localTs)) {
+      const ins = d(NaN)
+      ins.$x.$timezone = timezone
+      return ins
+    }
     const [targetTs, targetOffset] = fixOffset(localTs, previousOffset, timezone)
     const ins = d(targetTs).utcOffset(targetOffset)
     ins.$x.$timezone = timezone

--- a/test/plugin/timezone.test.js
+++ b/test/plugin/timezone.test.js
@@ -569,3 +569,15 @@ describe('DST edge cases vs moment', () => {
     })
   })
 })
+
+it('does not throw for invalid Day.js values (regression #111.22)', () => {
+  const invalid = dayjs('invalid')
+  expect(invalid.isValid()).toBe(false)
+  expect(() => invalid.tz('Europe/Skopje')).not.toThrow()
+  expect(invalid.tz('Europe/Skopje').isValid()).toBe(false)
+})
+
+it('does not throw for invalid string in d.tz()', () => {
+  expect(() => dayjs.tz('invalid', 'Europe/Skopje')).not.toThrow()
+  expect(dayjs.tz('invalid', 'Europe/Skopje').isValid()).toBe(false)
+})


### PR DESCRIPTION
…lues (#3180)

Add early-return guards in proto.tz and d.tz so that invalid dates return an invalid Day.js instance instead of throwing when Intl.DateTimeFormat.formatToParts receives an invalid Date.

Regression introduced in 1.11.22 by e27ee80.